### PR TITLE
An actual, major change to Deep storage. PR nightmare not included. 

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -603,7 +603,6 @@
 	name = "Showers"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cw" = (
@@ -653,7 +652,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cG" = (
@@ -689,7 +687,6 @@
 /obj/item/soap/syndie,
 /obj/structure/curtain,
 /obj/machinery/shower/directional/south,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cO" = (
@@ -697,14 +694,12 @@
 /obj/structure/curtain,
 /obj/item/soap/syndie,
 /obj/machinery/shower/directional/south,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cR" = (
@@ -747,7 +742,6 @@
 	},
 /obj/structure/mirror/directional/east,
 /obj/machinery/light/directional/west,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cZ" = (
@@ -759,7 +753,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "da" = (
@@ -803,7 +796,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/sink/directional/west,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "ds" = (
@@ -948,13 +940,11 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dS" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dV" = (
@@ -976,7 +966,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "eb" = (
@@ -1035,7 +1024,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "en" = (
@@ -1052,14 +1040,12 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "ep" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "eq" = (
@@ -1070,7 +1056,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "es" = (
@@ -1079,7 +1064,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
@@ -1089,7 +1073,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "ev" = (
@@ -1153,7 +1136,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "eD" = (
@@ -1203,7 +1185,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "eR" = (
@@ -1330,12 +1311,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"eY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
 "eZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -1364,7 +1339,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "ff" = (
@@ -1405,9 +1379,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/plumbing/synthesizer{
-	reagent_id = /datum/reagent/water
-	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fm" = (
@@ -1436,13 +1407,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"fs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/pharmacy)
 "fu" = (
 /obj/structure/chair/office/tactical{
 	dir = 8
@@ -1507,7 +1471,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "fF" = (
@@ -1568,7 +1531,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "fP" = (
@@ -1608,7 +1570,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gb" = (
@@ -1627,7 +1588,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "gh" = (
@@ -1660,7 +1620,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gk" = (
@@ -1679,7 +1638,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "gm" = (
@@ -1746,7 +1704,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "gy" = (
@@ -1765,12 +1722,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
-"gA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/power)
 "gB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	dir = 5
@@ -1930,7 +1881,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "hi" = (
@@ -1943,7 +1893,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "hk" = (
@@ -1958,7 +1907,6 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "hm" = (
@@ -2188,7 +2136,6 @@
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "lf" = (
@@ -2208,7 +2155,6 @@
 	name = "Atmospherics and Power Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "lj" = (
@@ -2219,7 +2165,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "lB" = (
@@ -2485,7 +2430,6 @@
 /obj/machinery/coffeemaker/impressa,
 /obj/item/storage/box/coffeepack,
 /obj/item/storage/box/coffeepack/robusta,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "pS" = (
@@ -2599,7 +2543,6 @@
 "rv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "rx" = (
@@ -2748,7 +2691,6 @@
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "ud" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "ug" = (
@@ -2957,7 +2899,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "xp" = (
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "xw" = (
@@ -3053,7 +2994,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sink/directional/west,
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "yQ" = (
@@ -3315,7 +3255,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "Ee" = (
@@ -3627,7 +3566,6 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/machinery/duct,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
@@ -3684,7 +3622,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "LB" = (
@@ -3950,7 +3887,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "Qt" = (
@@ -4025,7 +3961,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "Rw" = (
-/obj/machinery/duct,
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
@@ -5105,7 +5040,7 @@ ge
 NA
 NX
 dc
-fs
+Qi
 Rw
 xp
 AR
@@ -5157,7 +5092,7 @@ ge
 ge
 Jn
 dc
-fs
+Qi
 rB
 lf
 tk
@@ -5877,14 +5812,14 @@ kP
 kP
 et
 cP
-eY
+kP
 lg
-gA
+gT
 hl
 fZ
 gj
 ud
-gA
+gT
 fl
 gT
 so

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -20,14 +20,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/obj/item/storage/medkit/combat/surgery{
-	pixel_x = 0;
-	pixel_y = -6
-	},
-/obj/item/storage/medkit/combat{
-	pixel_x = 0;
-	pixel_y = 6
-	},
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "ah" = (
@@ -182,17 +175,48 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "aR" = (
-/obj/structure/closet/cardboard,
 /obj/effect/turf_decal/delivery,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
+/obj/structure/closet/crate/medical,
+/obj/item/storage/medkit/regular{
+	pixel_x = -10;
+	pixel_y = -3
+	},
+/obj/item/storage/medkit/regular{
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/obj/item/storage/medkit/regular{
+	pixel_x = -10;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/ancient{
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/obj/item/storage/medkit/ancient{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/storage/medkit/ancient{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/storage/medkit/robotic_repair{
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/obj/item/storage/medkit/robotic_repair{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aS" = (
 /obj/machinery/airalarm/directional/north{
 	req_one_access = list("syndicate")
 	},
+/obj/structure/cargo_shelf,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aT" = (
@@ -298,10 +322,6 @@
 /obj/structure/sink/kitchen/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
-"bd" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/deepstorage/kitchen)
 "be" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/highsecurity{
@@ -396,7 +416,7 @@
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bx" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/griddle,
+/obj/machinery/deepfryer,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "by" = (
@@ -462,11 +482,14 @@
 /obj/structure/cable,
 /obj/structure/closet/cardboard,
 /obj/item/knife/kitchen,
-/obj/item/knife/kitchen,
-/obj/item/kitchen/rollingpin,
 /obj/item/hatchet,
 /obj/item/cultivator,
 /obj/effect/turf_decal/delivery,
+/obj/item/kitchen/rollingpin/illegal,
+/obj/item/kitchen/rollingpin/illegal,
+/obj/item/knife/kitchen,
+/obj/item/knife/kitchen,
+/obj/item/knife/butcher,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "bI" = (
@@ -525,7 +548,7 @@
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bO" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/table,
+/obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bP" = (
@@ -575,6 +598,14 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"cb" = (
+/obj/structure/cable,
+/obj/machinery/power/rtg/portable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/power)
 "cd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -846,8 +877,8 @@
 "dv" = (
 /obj/structure/closet/crate/secure/gear{
 	req_access = list("syndicate");
-	name = "GPS crate";
-	desc = "highly sensitive"
+	name = "Secured Gear Crate";
+	desc = "Special Equipment Bud."
 	},
 /obj/item/clothing/gloves/combat,
 /obj/item/clothing/gloves/combat,
@@ -1089,9 +1120,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
-"eq" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/airlock)
 "er" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
@@ -1151,19 +1179,24 @@
 /area/ruin/space/has_grav/deepstorage/armory)
 "ey" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = 0;
+	pixel_y = 11
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "ez" = (
-/obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "eA" = (
@@ -1382,7 +1415,6 @@
 /area/ruin/space/has_grav/deepstorage/armory)
 "fc" = (
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "fd" = (
@@ -1643,6 +1675,11 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"fW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/power)
 "fZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/firealarm/directional/west,
@@ -1865,6 +1902,7 @@
 "gJ" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gK" = (
@@ -2018,7 +2056,7 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "hE" = (
-/obj/machinery/porta_turret/syndicate/energy/raven{
+/obj/machinery/porta_turret/syndicate/energy{
 	dir = 4
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -2154,36 +2192,44 @@
 "jx" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/structure/table,
-/obj/item/storage/medkit/regular{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/medkit/regular{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/item/storage/medkit/brute{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/storage/medkit/brute{
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "jy" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/storage/medkit/brute{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/medkit/brute{
-	pixel_x = 1;
+/obj/item/storage/medkit/robotic_repair{
+	pixel_x = 0;
 	pixel_y = 2
+	},
+/obj/item/storage/medkit/robotic_repair{
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "jA" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/table/reinforced,
+/obj/item/storage/medkit/combat{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/item/storage/medkit/combat/surgery{
+	pixel_x = 0;
+	pixel_y = -6
+	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "jD" = (
@@ -2280,11 +2326,15 @@
 /obj/item/clothing/accessory/armband/medblue,
 /obj/item/clothing/gloves/latex/nitrile,
 /obj/item/clothing/gloves/latex/surgical,
+/obj/item/clothing/glasses/hud/health/night/science,
+/obj/item/clothing/glasses/hud/health/night/science,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "md" = (
-/obj/machinery/computer/diseasesplicer,
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/end{
+	dir = 4
+	},
+/obj/structure/chair/office/tactical,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "mt" = (
@@ -2298,15 +2348,15 @@
 	name = "Ammo crate"
 	},
 /obj/item/ammo_box/magazine/c40sol_rifle{
-	pixel_x = 3;
+	pixel_x = 6;
 	pixel_y = 1
 	},
 /obj/item/ammo_box/magazine/c40sol_rifle{
-	pixel_x = 3;
+	pixel_x = 6;
 	pixel_y = -2
 	},
 /obj/item/ammo_box/magazine/c40sol_rifle{
-	pixel_x = 3;
+	pixel_x = 6;
 	pixel_y = -5
 	},
 /obj/item/ammo_box/c40sol{
@@ -2325,6 +2375,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
+"mA" = (
+/obj/item/storage/box/petridish,
+/obj/machinery/disease2/diseaseanalyser,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "mE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2363,14 +2418,7 @@
 "nk" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/east,
-/obj/item/storage/medkit/robotic_repair{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/storage/medkit/robotic_repair{
-	pixel_x = 0;
-	pixel_y = 2
-	},
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "nv" = (
@@ -2396,14 +2444,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
-"nG" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers/bluespace{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/pharmacy)
 "nY" = (
 /obj/machinery/airalarm/directional/east{
 	req_one_access = list("syndicate")
@@ -2450,6 +2490,11 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"os" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers/bluespace,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "oC" = (
 /obj/machinery/power/rtg/portable,
 /obj/structure/cable,
@@ -2613,10 +2658,7 @@
 	name = "Equipment"
 	},
 /obj/item/storage/box/syringes,
-/obj/item/storage/box/syringes,
 /obj/item/storage/box/beakers,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/tube,
 /obj/item/storage/box/tube,
 /obj/item/storage/box/petridish,
 /turf/open/floor/iron/white,
@@ -2696,6 +2738,12 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"rU" = (
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "sd" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s4"
@@ -2763,9 +2811,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "sV" = (
-/obj/machinery/disease2/centrifuge,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/item/storage/box/tube,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "tk" = (
@@ -2808,6 +2856,8 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/item/clothing/suit/bio_suit/interdyne,
 /obj/item/clothing/head/bio_hood/interdyne,
+/obj/item/clothing/suit/bio_suit/interdyne,
+/obj/item/clothing/head/bio_hood/interdyne,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "ud" = (
@@ -2815,9 +2865,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "ug" = (
-/obj/machinery/disease2/diseaseanalyser,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/item/storage/box/petridish,
+/obj/effect/turf_decal/trimline/green/end{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "un" = (
@@ -2839,6 +2889,14 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"uy" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
+/obj/item/weapon/virusdish/random,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "uB" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2848,7 +2906,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "uG" = (
 /obj/machinery/door/airlock/medical/glass{
-	name = "Pharmacy"
+	name = "Chemistry"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -2932,16 +2990,32 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"wk" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "wu" = (
 /obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "wy" = (
-/obj/machinery/airalarm/directional/south{
-	req_one_access = list("syndicate")
+/obj/item/storage/box/beakers/variety{
+	pixel_x = 6;
+	pixel_y = 0
 	},
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/effect/turf_decal/trimline/orange/line,
+/obj/item/storage/box/beakers/variety{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers/variety{
+	pixel_x = 0;
+	pixel_y = 7
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "wF" = (
@@ -3054,7 +3128,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/machinery/iv_drip/saline,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "xN" = (
@@ -3094,6 +3168,15 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
+"xX" = (
+/obj/machinery/airalarm/directional/south{
+	req_one_access = list("syndicate")
+	},
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/machinery/vending/syndichem,
+/obj/effect/turf_decal/trimline/orange/line,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "yf" = (
 /obj/machinery/chem_master,
 /turf/open/floor/engine,
@@ -3329,6 +3412,14 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"BM" = (
+/obj/machinery/disease2/centrifuge,
+/obj/item/storage/box/tube,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "BW" = (
 /obj/structure/table,
 /obj/item/cultivator,
@@ -3350,6 +3441,20 @@
 /obj/effect/turf_decal/trimline/orange/line,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"Ct" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/internals,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
 "CL" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/secure/gear{
@@ -3401,9 +3506,6 @@
 /obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/armory)
-"Dp" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage)
 "Dq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -3414,6 +3516,32 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"DT" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/toy/plush/shark,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
+"Ea" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/toy/plush/beeplushie{
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
 "Ee" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3422,6 +3550,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/item/toy/plush/moth,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "Eg" = (
@@ -3488,6 +3617,12 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
+"EG" = (
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "EH" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -3523,9 +3658,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"EX" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
 "Fv" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s3"
@@ -3579,6 +3717,16 @@
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/kitchen)
+"Gn" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "Surgery";
+	req_one_access = list("syndicate")
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "Gw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3756,6 +3904,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "KO" = (
@@ -3955,7 +4104,10 @@
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "Og" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/infections,
+/obj/item/book/manual/wiki/infections{
+	pixel_x = 7;
+	pixel_y = 6
+	},
 /obj/machinery/reagentgrinder{
 	pixel_y = 14;
 	pixel_x = -11
@@ -3966,6 +4118,10 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
+	},
+/obj/item/stack/sheet/mineral/uranium/five{
+	pixel_x = 0;
+	pixel_y = -2
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
@@ -4059,6 +4215,10 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"Qk" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "Ql" = (
 /obj/structure/closet/cardboard,
 /obj/item/stack/sheet/cardboard,
@@ -4081,6 +4241,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Pharmacy"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "Qt" = (
@@ -4116,19 +4280,11 @@
 	pixel_x = 9;
 	pixel_y = 0
 	},
-/obj/item/storage/box/monkeycubes/mousecubes{
-	pixel_x = 9;
-	pixel_y = 0
-	},
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /obj/item/storage/box/monkeycubes{
 	pixel_x = -8;
-	pixel_y = 0
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -9;
 	pixel_y = 0
 	},
 /turf/open/floor/iron/white,
@@ -4260,6 +4416,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
+"Tn" = (
+/obj/machinery/computer/diseasesplicer,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "Tq" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cargo_shelf,
@@ -4315,16 +4475,16 @@
 	pixel_y = 5
 	},
 /obj/item/folder/red{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = -7;
-	pixel_y = 2
+	pixel_x = 5;
+	pixel_y = 0
 	},
 /obj/item/pen{
 	pixel_x = -6;
 	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4696,9 +4856,9 @@ aa
 aa
 aa
 aa
-wQ
-Iy
-Iy
+ab
+ab
+ab
 aa
 aa
 aa
@@ -4805,7 +4965,7 @@ ab
 ab
 ab
 ab
-aa
+ab
 aa
 aa
 aa
@@ -4818,7 +4978,7 @@ ab
 Iy
 Iy
 Iy
-Iy
+ab
 ab
 ab
 ab
@@ -4857,8 +5017,8 @@ OR
 OR
 OR
 ab
-wQ
-aa
+ab
+Iy
 aa
 aa
 "}
@@ -4908,10 +5068,10 @@ OR
 Og
 vH
 OR
+OR
 ab
-ab
+wQ
 Iy
-aa
 aa
 "}
 (8,1,1) = {"
@@ -4959,12 +5119,12 @@ yg
 OR
 QW
 sV
+BM
 OR
 ab
-ab
 Iy
+wQ
 ab
-aa
 "}
 (9,1,1) = {"
 aa
@@ -5011,8 +5171,8 @@ QA
 OR
 Oc
 ug
+mA
 OR
-ab
 ab
 Iy
 ab
@@ -5063,8 +5223,8 @@ Ay
 OR
 qS
 md
+Tn
 OR
-ab
 ab
 Iy
 ab
@@ -5088,7 +5248,7 @@ xf
 uU
 Tf
 Bk
-tn
+EX
 Oe
 zl
 zl
@@ -5114,12 +5274,12 @@ tS
 rT
 Zn
 qR
+uy
 Op
 OR
 ab
-ab
 Iy
-ab
+Iy
 ab
 "}
 (12,1,1) = {"
@@ -5144,12 +5304,12 @@ Vu
 Oe
 zl
 zl
-Jm
-Jm
+vn
+Ct
 vn
 vn
 ge
-ey
+Ea
 zu
 ge
 ey
@@ -5158,7 +5318,7 @@ ge
 ey
 zu
 dc
-Qi
+Gn
 jA
 PN
 OR
@@ -5168,7 +5328,7 @@ OR
 OR
 OR
 OR
-ab
+OR
 ab
 Iy
 Iy
@@ -5204,7 +5364,7 @@ ge
 UK
 ez
 ge
-Ee
+DT
 ez
 ge
 Ee
@@ -5216,11 +5376,11 @@ kV
 RT
 OR
 FS
-nG
+Qk
+os
 wu
 yf
 OR
-ab
 ab
 Iy
 Iy
@@ -5269,12 +5429,12 @@ AR
 OR
 OB
 Uj
+rU
 PH
 AI
 OR
 ab
 ab
-Iy
 Iy
 ab
 "}
@@ -5321,12 +5481,12 @@ tk
 OR
 kk
 EW
+Qk
 Cp
 ae
 OR
 ab
 ab
-Iy
 Iy
 ab
 "}
@@ -5374,11 +5534,11 @@ uG
 mW
 Il
 wy
+xX
 gF
 OR
 ab
 ab
-Iy
 Iy
 ab
 "}
@@ -5425,12 +5585,12 @@ rx
 OR
 EL
 Az
+EG
 JV
 ZN
 OR
 ab
 ab
-Iy
 Iy
 ab
 "}
@@ -5480,9 +5640,9 @@ OR
 OR
 OR
 OR
+OR
 ab
 ab
-Iy
 Iy
 ab
 "}
@@ -5508,7 +5668,7 @@ bH
 hH
 TC
 cH
-cI
+wk
 cI
 dD
 Nl
@@ -5535,7 +5695,7 @@ ab
 ab
 ab
 Iy
-aa
+Iy
 aa
 "}
 (20,1,1) = {"
@@ -5570,7 +5730,7 @@ ds
 ds
 ds
 ds
-Dp
+ds
 fT
 ne
 It
@@ -5639,8 +5799,8 @@ aa
 aa
 aa
 aa
-ab
-ab
+aa
+aa
 "}
 (22,1,1) = {"
 aa
@@ -5691,8 +5851,8 @@ Iy
 aa
 aa
 aa
-ab
-ab
+aa
+aa
 "}
 (23,1,1) = {"
 aa
@@ -5726,7 +5886,7 @@ ho
 eT
 EP
 ho
-eq
+ho
 nv
 ne
 PT
@@ -5736,14 +5896,14 @@ ds
 ab
 ab
 ab
-ab
-ab
 Iy
 Iy
-aa
-aa
 ab
 ab
+aa
+aa
+aa
+aa
 aa
 "}
 (24,1,1) = {"
@@ -5804,7 +5964,7 @@ aa
 aa
 Iy
 Iy
-Iy
+ab
 ab
 ab
 ab
@@ -5889,7 +6049,7 @@ gq
 QI
 gJ
 gR
-gZ
+cb
 gZ
 oC
 oC
@@ -5909,16 +6069,16 @@ aa
 ab
 aa
 aa
-Iy
 ab
 ab
+ab
 Ob
 Ob
 Ob
 Ob
 Ob
 Ob
-bd
+OX
 bx
 bO
 LC
@@ -5939,9 +6099,9 @@ JR
 gh
 gr
 QI
-gK
+fW
 gR
-gZ
+cb
 ZP
 oC
 oC
@@ -6003,8 +6163,8 @@ ab
 Iy
 aa
 aa
-ab
 aa
+ab
 "}
 (29,1,1) = {"
 aa
@@ -6054,9 +6214,9 @@ ab
 Iy
 Iy
 aa
-ab
-ab
 aa
+ab
+ab
 "}
 (30,1,1) = {"
 aa
@@ -6103,11 +6263,11 @@ QI
 ab
 ab
 ab
-Iy
+ab
+aa
 aa
 aa
 ab
-aa
 aa
 "}
 (31,1,1) = {"
@@ -6522,7 +6682,7 @@ aa
 aa
 aa
 aa
-aa
+ab
 aa
 aa
 "}
@@ -6573,9 +6733,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+ab
+ab
+ab
 aa
 "}
 (40,1,1) = {"
@@ -6622,12 +6782,12 @@ ab
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 ab
-aa
-aa
-aa
 ab
-aa
 aa
 "}
 (41,1,1) = {"
@@ -6674,7 +6834,7 @@ Iy
 aa
 aa
 aa
-ab
+aa
 aa
 aa
 aa
@@ -6881,8 +7041,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+ab
+ab
 ab
 ab
 ab
@@ -6933,13 +7093,13 @@ aa
 aa
 aa
 aa
-aa
-aa
 ab
 ab
 ab
-aa
-aa
+ab
+ab
+ab
+ab
 aa
 "}
 (47,1,1) = {"
@@ -6979,18 +7139,18 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 "}
@@ -7031,19 +7191,19 @@ aa
 aa
 aa
 ab
-aa
-aa
-aa
 ab
-aa
-aa
 ab
 aa
 aa
 aa
 aa
 aa
-ab
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 "}
 (49,1,1) = {"
@@ -7084,7 +7244,7 @@ aa
 aa
 aa
 aa
-aa
+ab
 aa
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -17,18 +17,21 @@
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "ag" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
+	},
+/obj/item/storage/medkit/combat/surgery{
+	pixel_x = 0;
+	pixel_y = -6
+	},
+/obj/item/storage/medkit/combat{
+	pixel_x = 0;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "ah" = (
 /obj/structure/kitchenspike,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"ai" = (
-/obj/structure/closet/secure_closet/freezer/meat/open,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "ak" = (
@@ -50,6 +53,9 @@
 /obj/item/clothing/under/syndicate/combat,
 /obj/item/storage/backpack/satchel,
 /obj/item/storage/box/survival/syndie,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "ao" = (
@@ -86,7 +92,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/structure/sign/poster/contraband/fun_police/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "at" = (
 /obj/effect/turf_decal/stripes/red/corner,
@@ -106,12 +112,13 @@
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "ax" = (
-/obj/machinery/processor{
-	name = "processor"
+/obj/structure/closet/secure_closet/freezer/meat/open{
+	req_access = list("syndicate")
 	},
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"ay" = (
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/pig,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "az" = (
@@ -129,7 +136,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aC" = (
 /obj/structure/cable,
@@ -183,7 +190,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aS" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/airalarm/directional/north{
+	req_one_access = list("syndicate")
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aT" = (
@@ -197,6 +206,7 @@
 "aU" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/trash/mopbucket,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aV" = (
@@ -247,9 +257,15 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/shoes/combat,
 /obj/effect/turf_decal/delivery,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aX" = (
@@ -345,9 +361,10 @@
 /area/ruin/space/has_grav/deepstorage/storage)
 "bq" = (
 /obj/structure/closet/cardboard,
-/obj/item/defibrillator,
 /obj/item/storage/box/medipens,
 /obj/effect/turf_decal/delivery,
+/obj/item/storage/box/medipens,
+/obj/item/defibrillator/loaded,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "br" = (
@@ -355,7 +372,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/exotic/languagebook,
 /obj/effect/spawner/random/exotic/languagebook,
-/obj/item/mop/advanced,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "bs" = (
@@ -460,7 +478,9 @@
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/flour,
 /obj/item/reagent_containers/condiment/flour,
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = list("syndicate")
+	},
 /obj/item/reagent_containers/condiment/sugar,
 /obj/item/reagent_containers/condiment/sugar,
 /obj/item/reagent_containers/condiment/rice,
@@ -520,7 +540,9 @@
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "bU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/airalarm/directional/east{
+	req_one_access = list("syndicate")
+	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
@@ -636,6 +658,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "cD" = (
@@ -684,16 +707,9 @@
 /area/ruin/space/has_grav/deepstorage)
 "cM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/item/soap/syndie,
 /obj/structure/curtain,
 /obj/machinery/shower/directional/south,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage)
-"cO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/curtain,
-/obj/item/soap/syndie,
-/obj/machinery/shower/directional/south,
+/obj/item/soap/deluxe,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cP" = (
@@ -747,7 +763,9 @@
 "cZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/mirror/directional/east,
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	req_one_access = list("syndicate")
+	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/toilet{
 	dir = 4
@@ -780,6 +798,9 @@
 	},
 /obj/item/storage/medkit/emergency,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "dg" = (
@@ -803,6 +824,19 @@
 /area/ruin/space/has_grav/deepstorage)
 "dt" = (
 /obj/machinery/light/directional/north,
+/obj/item/gps{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/gps{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate");
+	name = "GPS crate";
+	desc = "highly sensitive"
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "du" = (
@@ -811,7 +845,9 @@
 /area/ruin/space/has_grav/deepstorage/armory)
 "dv" = (
 /obj/structure/closet/crate/secure/gear{
-	req_access = list("syndicate")
+	req_access = list("syndicate");
+	name = "GPS crate";
+	desc = "highly sensitive"
 	},
 /obj/item/clothing/gloves/combat,
 /obj/item/clothing/gloves/combat,
@@ -943,7 +979,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dS" = (
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/airalarm/directional/south{
+	req_one_access = list("syndicate")
+	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
@@ -1009,6 +1047,9 @@
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "ei" = (
 /obj/structure/dresser,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "em" = (
@@ -1103,11 +1144,17 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "ey" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "ez" = (
@@ -1116,6 +1163,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "eA" = (
@@ -1127,6 +1175,9 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "eC" = (
@@ -1145,6 +1196,9 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "eF" = (
@@ -1170,6 +1224,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "eK" = (
@@ -1190,6 +1245,9 @@
 "eR" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "eS" = (
@@ -1279,8 +1337,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "eW" = (
@@ -1344,6 +1404,9 @@
 "ff" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "fg" = (
@@ -1353,17 +1416,19 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/syndicateemblem/top/left,
-/obj/effect/turf_decal/syndicateemblem/top/middle,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/syndicateemblem/top/middle,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fk" = (
@@ -1372,6 +1437,9 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/syndicateemblem/top/right,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fl" = (
@@ -1399,6 +1467,9 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "fr" = (
@@ -1412,13 +1483,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/syndicateemblem/middle/left,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/syndicateemblem/middle/middle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fw" = (
@@ -1427,6 +1499,9 @@
 	},
 /obj/structure/sign/poster/contraband/gorlex_recruitment/directional/east,
 /obj/effect/turf_decal/syndicateemblem/middle/right,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fy" = (
@@ -1438,7 +1513,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/airalarm/directional/north{
+	req_one_access = list("syndicate")
+	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
@@ -1557,7 +1634,7 @@
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 2
 	},
-/obj/effect/turf_decal/bot_red/right,
+/obj/effect/turf_decal/bot_red/left,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "fV" = (
@@ -1643,7 +1720,9 @@
 "gm" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light/directional/east,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/airalarm/directional/east{
+	req_one_access = list("syndicate")
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -1674,7 +1753,9 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/airalarm/directional/east{
+	req_one_access = list("syndicate")
+	},
 /obj/machinery/light/directional/east,
 /obj/structure/closet/l3closet/scientist,
 /obj/item/construction/plumbing/research,
@@ -1937,14 +2018,10 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "hE" = (
-/obj/machinery/porta_turret/syndicate/energy{
-	dir = 8
+/obj/machinery/porta_turret/syndicate/energy/raven{
+	dir = 4
 	},
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
-/obj/structure/window/reinforced/plasma/spawner/directional/south,
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/armory)
 "hH" = (
 /obj/structure/reagent_dispensers/watertank/high,
@@ -2017,11 +2094,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	req_one_access = list("syndicate")
+	},
 /obj/machinery/computer/message_monitor{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "ic" = (
@@ -2039,10 +2121,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden{
 	dir = 5
 	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "iw" = (
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/airalarm/directional/south{
+	req_one_access = list("syndicate")
+	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
@@ -2050,6 +2137,12 @@
 "iK" = (
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"iT" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/power)
 "jv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -2070,6 +2163,9 @@
 	pixel_y = 2
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "jy" = (
@@ -2088,14 +2184,6 @@
 "jA" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/surgery_syndie{
-	pixel_x = 0;
-	pixel_y = -3
-	},
-/obj/item/storage/medkit/hypospray/syndicate{
-	pixel_x = 0;
-	pixel_y = 8
-	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "jD" = (
@@ -2109,6 +2197,9 @@
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "kk" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "kE" = (
@@ -2228,6 +2319,10 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/ammo_box/c40sol/pierce{
+	pixel_x = -5;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "mE" = (
@@ -2257,6 +2352,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "ne" = (
@@ -2295,15 +2393,21 @@
 /obj/structure/table,
 /obj/effect/spawner/random/exotic/antag_gear_weak,
 /obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "nG" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/beakers/bluespace,
+/obj/item/storage/box/beakers/bluespace{
+	pixel_x = -5;
+	pixel_y = 1
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "nY" = (
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/airalarm/directional/east{
+	req_one_access = list("syndicate")
+	},
 /obj/structure/table,
 /obj/item/stack/cable_coil,
 /obj/item/stack/rods/fifty,
@@ -2319,11 +2423,17 @@
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = 4;
-	pixel_y = 4
+	pixel_x = 8;
+	pixel_y = -2
 	},
-/obj/item/reagent_containers/condiment/peppermill,
-/obj/item/knife/kitchen,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/knife/kitchen{
+	pixel_x = -7;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "on" = (
@@ -2452,6 +2562,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "qg" = (
@@ -2526,7 +2637,8 @@
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot_red/left,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "ra" = (
 /obj/structure/bed{
@@ -2549,7 +2661,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/vending/wardrobe/medi_wardrobe{
+	desc = "A vending machine rumoured to be capable of dispensing clothing for syndicate medical personnel."
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "rz" = (
@@ -2677,6 +2791,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"tE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "tS" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 5
@@ -2701,9 +2822,18 @@
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "un" = (
 /obj/structure/table/reinforced,
-/obj/item/disk/surgery/sleeper_protocol,
-/obj/item/disk/surgery/forgottenship,
-/obj/item/disk/surgery/brainwashing,
+/obj/item/disk/surgery/sleeper_protocol{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/disk/surgery/forgottenship{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/disk/surgery/brainwashing{
+	pixel_x = -8;
+	pixel_y = -5
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -2742,6 +2872,7 @@
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/syndicateemblem/bottom/left,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "uU" = (
@@ -2779,6 +2910,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "vH" = (
@@ -2803,15 +2937,16 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "wy" = (
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/airalarm/directional/south{
+	req_one_access = list("syndicate")
+	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/effect/turf_decal/trimline/orange/line,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "wF" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/table/glass,
-/obj/item/vacuum_pack,
-/obj/item/vacuum_pack,
 /obj/item/storage/box/monkeycubes{
 	pixel_x = -5;
 	pixel_y = 1
@@ -2844,8 +2979,6 @@
 /obj/item/stack/sheet/mineral/plasma/twenty,
 /obj/item/stack/sheet/mineral/plasma/twenty,
 /obj/item/stack/sheet/mineral/plasma/twenty,
-/obj/item/disk/vacuum_upgrade/biomass,
-/obj/item/disk/vacuum_upgrade/biomass,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "wH" = (
@@ -2952,7 +3085,9 @@
 /obj/item/storage/box/ingredients/italian,
 /obj/item/storage/box/ingredients/seafood,
 /obj/item/storage/box/ingredients/seafood,
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = list("syndicate")
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "yf" = (
@@ -2984,6 +3119,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "yA" = (
@@ -3012,6 +3150,7 @@
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/syndicateemblem/bottom/middle,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "zl" = (
@@ -3042,6 +3181,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "zu" = (
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "zI" = (
@@ -3068,6 +3208,9 @@
 /obj/item/binoculars,
 /obj/item/choice_beacon/pet,
 /obj/item/storage/box/survival/syndie,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "An" = (
@@ -3103,6 +3246,9 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "AI" = (
@@ -3197,11 +3343,14 @@
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "Cp" = (
 /obj/machinery/chem_heater/withbuffer,
+/obj/effect/turf_decal/trimline/orange/line,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "CL" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate/secure/gear,
+/obj/structure/closet/crate/secure/gear{
+	name = "T4 Parts"
+	},
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/part_replacer,
@@ -3225,7 +3374,9 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "Db" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/airalarm/directional/north{
+	req_one_access = list("syndicate")
+	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/machinery/stove,
 /turf/open/floor/iron/cafeteria,
@@ -3242,6 +3393,7 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /obj/effect/spawner/structure/electrified_grille,
+/obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/armory)
 "Dp" = (
@@ -3262,17 +3414,27 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "Eg" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate/secure/science,
+/obj/structure/closet/crate/secure/science{
+	name = "Cleaning Supplies"
+	},
 /obj/item/mop/advanced,
 /obj/item/mop/advanced,
 /obj/item/reagent_containers/cup/bucket,
 /obj/item/reagent_containers/cup/bucket,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/soap/syndie,
+/obj/item/soap/syndie,
 /obj/item/soap/syndie,
 /obj/item/soap/syndie,
 /turf/open/floor/iron,
@@ -3311,6 +3473,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
 	dir = 6
 	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "Ey" = (
@@ -3329,6 +3494,9 @@
 /obj/machinery/firealarm/directional/north,
 /obj/structure/closet/secure_closet/chemical{
 	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 5
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
@@ -3363,7 +3531,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/airalarm/directional/north{
+	req_one_access = list("syndicate")
+	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/light,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
@@ -3379,6 +3549,9 @@
 /area/ruin/space/has_grav/deepstorage)
 "FS" = (
 /obj/structure/sign/warning/biohazard/directional/north,
+/obj/effect/turf_decal/trimline/orange/end{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "FZ" = (
@@ -3542,6 +3715,9 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "JV" = (
 /obj/item/reagent_containers/cup/beaker/large,
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 6
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "Kh" = (
@@ -3603,12 +3779,12 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "KT" = (
-/obj/structure/table/glass,
 /obj/machinery/light/small/directional/north,
 /obj/item/restraints/handcuffs,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "KZ" = (
@@ -3722,6 +3898,9 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "NE" = (
@@ -3737,6 +3916,9 @@
 	},
 /obj/structure/sign/poster/contraband/free_key/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/wood,
@@ -3797,6 +3979,9 @@
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "OB" = (
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "OL" = (
@@ -3837,6 +4022,9 @@
 /area/ruin/space/has_grav/deepstorage)
 "PH" = (
 /obj/structure/chair/office/light,
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "PN" = (
@@ -4018,7 +4206,6 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "Tc" = (
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -4090,6 +4277,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/orange/line{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "Uw" = (
@@ -4129,6 +4319,9 @@
 /obj/item/pen{
 	pixel_x = -6;
 	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
@@ -4176,6 +4369,9 @@
 	},
 /obj/item/flatpacked_machine,
 /obj/item/flatpacked_machine/ore_silo,
+/obj/item/flatpacked_machine/sustenance_machine,
+/obj/item/flatpacked_machine/organics_printer,
+/obj/item/flatpacked_machine/gps_beacon,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "VU" = (
@@ -4210,6 +4406,9 @@
 	},
 /obj/item/wrench,
 /obj/effect/turf_decal/syndicateemblem/bottom/right,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "WL" = (
@@ -4239,6 +4438,7 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /obj/effect/spawner/structure/electrified_grille,
+/obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/armory)
 "Ya" = (
@@ -4250,6 +4450,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "Yv" = (
@@ -4262,6 +4464,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"YP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/table/glass,
+/obj/item/vacuum_pack,
+/obj/item/vacuum_pack,
+/obj/item/disk/vacuum_upgrade/biomass,
+/obj/item/disk/vacuum_upgrade/biomass,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
 "Zb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -4290,7 +4504,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "ZF" = (
-/obj/structure/closet/cardboard,
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
@@ -4305,6 +4518,9 @@
 /obj/item/pickaxe/drill,
 /obj/item/pickaxe/drill,
 /obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/secure/science{
+	name = "Mining Tools"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "ZL" = (
@@ -5064,7 +5280,7 @@ Ad
 sy
 LI
 LI
-LI
+YP
 sG
 VU
 BA
@@ -5536,9 +5752,9 @@ ab
 ab
 OX
 OX
-ai
+ax
 ap
-ay
+ax
 Ag
 ba
 bv
@@ -5549,7 +5765,7 @@ fP
 fP
 fP
 dI
-dV
+tE
 lk
 ho
 eU
@@ -5588,7 +5804,7 @@ ab
 ab
 OX
 OX
-ai
+ax
 aq
 az
 aN
@@ -5662,7 +5878,7 @@ fv
 zb
 ho
 gK
-gh
+iT
 gq
 QI
 gJ
@@ -5701,7 +5917,7 @@ bx
 bO
 LC
 Ag
-cO
+cM
 cZ
 dq
 cu

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -815,7 +815,6 @@
 /area/ruin/space/has_grav/deepstorage/armory)
 "du" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/structure/grille,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "dv" = (
@@ -870,13 +869,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
-"dz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
 "dA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -902,15 +894,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
-"dF" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
 "dG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -926,7 +909,6 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/deepstorage)
 "dM" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Classified Storage"
 	},
@@ -1359,10 +1341,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "fa" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/armory)
 "fc" = (
@@ -2933,6 +2913,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"wK" = (
+/obj/machinery/door/firedoor,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/armory)
 "wM" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -5160,7 +5145,7 @@ PF
 cD
 qg
 dg
-dz
+dA
 fN
 ge
 ge
@@ -5420,7 +5405,7 @@ cl
 uB
 cT
 oJ
-dF
+xw
 dV
 Kh
 ds
@@ -5991,7 +5976,7 @@ mN
 bA
 bA
 Ya
-fa
+wK
 dM
 ee
 hL

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -215,7 +215,6 @@
 /obj/machinery/airalarm/directional/north{
 	req_one_access = list("syndicate")
 	},
-/obj/structure/cargo_shelf,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
@@ -229,8 +228,8 @@
 /area/ruin/space/has_grav/deepstorage/storage)
 "aU" = (
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/trash/mopbucket,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aV" = (
@@ -261,6 +260,7 @@
 	amount = 5
 	},
 /obj/machinery/light/directional/north,
+/obj/item/stack/rods/fifty,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aW" = (
@@ -282,6 +282,10 @@
 	amount = 10
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
 /obj/item/stack/sheet/iron/fifty{
 	pixel_x = 2;
 	pixel_y = 2
@@ -737,7 +741,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/curtain,
 /obj/machinery/shower/directional/south,
 /obj/item/soap/deluxe,
@@ -783,25 +786,21 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/toilet{
 	dir = 4
 	},
 /obj/structure/mirror/directional/east,
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/mirror/directional/east,
-/obj/machinery/airalarm/directional/west{
-	req_one_access = list("syndicate")
-	},
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/toilet{
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "da" = (
@@ -823,14 +822,17 @@
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "de" = (
 /obj/structure/table,
-/obj/item/storage/medkit/emergency{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/storage/medkit/emergency,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/item/storage/medkit/combat_surgeon/stocked{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/storage/medkit/combat_surgeon/stocked{
+	pixel_x = -3;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
@@ -902,6 +904,8 @@
 /obj/item/clothing/suit/armor/vest/alt,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/storage/backpack/duffelbag/syndie,
+/obj/item/storage/backpack/duffelbag/syndie,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "dx" = (
@@ -1072,7 +1076,9 @@
 	pixel_x = 8;
 	pixel_y = -3
 	},
-/obj/structure/closet/crate/freezer,
+/obj/structure/closet/crate/freezer{
+	name = "Bean Freezer"
+	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
@@ -1415,6 +1421,15 @@
 /area/ruin/space/has_grav/deepstorage/armory)
 "fc" = (
 /obj/structure/table,
+/obj/effect/spawner/random/exotic/tool,
+/obj/item/clothing/gloves/combat{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_x = 3;
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "fd" = (
@@ -1434,11 +1449,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "ff" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "fg" = (
@@ -1552,7 +1567,16 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fA" = (
-/obj/structure/closet/firecloset/full,
+/obj/structure/closet/firecloset/full{
+	name = "Advanced Fire Safety Closet";
+	desc = "It a storage unit that contains addictional fire fighting supplies!"
+	},
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/extinguisher/advanced,
+/obj/item/extinguisher/advanced,
+/obj/structure/sign/warning/fire/directional/east,
+/obj/item/watertank/atmos,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fB" = (
@@ -1742,6 +1766,9 @@
 	},
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/belt/utility/syndicate,
+/obj/item/storage/belt/utility/syndicate,
+/obj/item/storage/toolbox/syndicate,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gl" = (
@@ -1852,6 +1879,9 @@
 	},
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/belt/utility/syndicate,
+/obj/item/storage/belt/utility/syndicate,
+/obj/item/storage/toolbox/syndicate,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gD" = (
@@ -1869,7 +1899,10 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "gG" = (
-/obj/structure/closet/crate/freezer,
+/obj/structure/closet/crate/freezer{
+	name = "Blood Crate";
+	desc = "A crate containing lifesaving blood supplies in the case that someone bleeds."
+	},
 /obj/item/reagent_containers/blood/o_minus,
 /obj/item/reagent_containers/blood/o_minus,
 /obj/item/reagent_containers/blood/o_minus,
@@ -2169,7 +2202,6 @@
 	req_one_access = list("syndicate")
 	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "iK" = (
@@ -2197,25 +2229,45 @@
 	dir = 1
 	},
 /obj/item/storage/medkit/brute{
-	pixel_x = 1;
-	pixel_y = 2
+	pixel_x = -12;
+	pixel_y = 1
 	},
 /obj/item/storage/medkit/brute{
-	pixel_x = 4;
+	pixel_x = -9;
 	pixel_y = 4
+	},
+/obj/item/storage/medkit/civil_defense/stocked{
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/item/storage/medkit/civil_defense/stocked{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/civil_defense/stocked{
+	pixel_x = 10;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "jy" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/storage/medkit/robotic_repair{
-	pixel_x = 0;
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = -6;
 	pixel_y = 2
 	},
-/obj/item/storage/medkit/robotic_repair{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/item/storage/medkit/civil_defense/comfort/stocked{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/storage/medkit/robotic_repair/preemo/stocked{
+	pixel_x = 3;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
@@ -2347,18 +2399,6 @@
 	req_access = list("syndicate");
 	name = "Ammo crate"
 	},
-/obj/item/ammo_box/magazine/c40sol_rifle{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/item/ammo_box/magazine/c40sol_rifle{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/ammo_box/magazine/c40sol_rifle{
-	pixel_x = 6;
-	pixel_y = -5
-	},
 /obj/item/ammo_box/c40sol{
 	pixel_x = -7;
 	pixel_y = 0
@@ -2370,8 +2410,20 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/item/ammo_box/c40sol/pierce{
-	pixel_x = -5;
+	pixel_x = -1;
 	pixel_y = 0
+	},
+/obj/item/ammo_box/c40sol/pierce{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/c40sol_rifle/standard{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/ammo_box/magazine/c40sol_rifle/standard{
+	pixel_x = 6;
+	pixel_y = -2
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
@@ -2439,9 +2491,15 @@
 /area/ruin/space/has_grav/deepstorage)
 "nA" = (
 /obj/structure/table,
-/obj/effect/spawner/random/exotic/antag_gear_weak,
-/obj/effect/spawner/random/exotic/antag_gear_weak,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/storage/box/nri_flares{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/storage/box/nri_flares{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "nY" = (
@@ -2449,13 +2507,6 @@
 	req_one_access = list("syndicate")
 	},
 /obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/cable_coil,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
@@ -2492,6 +2543,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "os" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/box/beakers/bluespace,
 /obj/item/storage/box/beakers/bluespace,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
@@ -2814,6 +2866,12 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/gloves{
+	pixel_x = 0;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "tk" = (
@@ -2931,6 +2989,12 @@
 	},
 /obj/effect/turf_decal/syndicateemblem/bottom/left,
 /obj/effect/turf_decal/siding/dark,
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Syndicate Radio Intercom";
+	pixel_y = -39;
+	pixel_x = 0
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "uU" = (
@@ -2946,7 +3010,10 @@
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "vj" = (
-/obj/structure/guncase,
+/obj/structure/guncase{
+	name = "Sol Rifle";
+	desc = "A note says that you shouldn't lose this."
+	},
 /obj/machinery/door/window/brigdoor/right/directional/south{
 	name = "Emergency Defense Gun";
 	desc = "Open incase of intruders or something.";
@@ -3003,18 +3070,22 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "wy" = (
-/obj/item/storage/box/beakers/variety{
-	pixel_x = 6;
-	pixel_y = 0
-	},
+/obj/structure/table/reinforced,
 /obj/item/storage/box/beakers/variety{
 	pixel_x = -5;
 	pixel_y = 0
 	},
-/obj/structure/table/reinforced,
 /obj/item/storage/box/beakers/variety{
-	pixel_x = 0;
-	pixel_y = 7
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/item/storage/box/beakers/variety{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/obj/item/storage/box/beakers/variety{
+	pixel_x = 4;
+	pixel_y = 0
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
@@ -3264,7 +3335,9 @@
 	pixel_x = 8;
 	pixel_y = -3
 	},
-/obj/structure/closet/crate/freezer,
+/obj/structure/closet/crate/freezer{
+	name = "Bean Freezer"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "zu" = (
@@ -3463,7 +3536,8 @@
 	},
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
-/obj/item/storage/part_replacer,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/part_replacer/bluespace/tier4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "CQ" = (
@@ -3504,6 +3578,7 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /obj/effect/spawner/structure/electrified_grille,
 /obj/structure/sign/warning/secure_area/directional/west,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/armory)
 "Dq" = (
@@ -3572,6 +3647,9 @@
 /obj/item/soap/syndie,
 /obj/item/soap/syndie,
 /obj/item/soap/syndie,
+/obj/item/lightreplacer/blue,
+/obj/item/lightreplacer,
+/obj/item/lightreplacer,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "Em" = (
@@ -3808,6 +3886,7 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /obj/effect/spawner/structure/electrified_grille,
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/armory)
 "Jm" = (
@@ -3913,26 +3992,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"KP" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare{
-	pixel_y = 6
-	},
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare{
-	pixel_y = 6
-	},
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare{
-	pixel_y = 6
-	},
-/obj/item/flashlight,
-/obj/item/flashlight,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
 "KT" = (
 /obj/machinery/light/small/directional/north,
 /obj/item/restraints/handcuffs,
@@ -3969,8 +4028,9 @@
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "LE" = (
 /obj/structure/table,
-/obj/effect/spawner/random/exotic/tool,
 /obj/machinery/light/directional/south,
+/obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/effect/spawner/random/exotic/antag_gear_weak,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "LH" = (
@@ -3991,18 +4051,7 @@
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "LO" = (
-/obj/structure/table,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/gloves/combat{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/clothing/gloves/combat{
-	pixel_x = 3;
-	pixel_y = -2
-	},
+/obj/machinery/recharge_station/fullupgrade,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "Mv" = (
@@ -4152,12 +4201,6 @@
 /obj/item/paper/fluff/ruins/deepstorage/hydro_notice,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
-"OM" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/engine/o2,
-/area/ruin/space/has_grav/deepstorage/armory)
 "OR" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
@@ -4221,8 +4264,6 @@
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "Ql" = (
 /obj/structure/closet/cardboard,
-/obj/item/stack/sheet/cardboard,
-/obj/item/stack/cable_coil,
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/stack/package_wrap,
@@ -4230,8 +4271,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
+"Qm" = (
+/turf/closed/wall/r_wall/syndicate/hull,
+/area/ruin/space)
 "Qr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -4254,6 +4302,11 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
+"Qu" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/trash/mopbucket,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
 "QA" = (
 /obj/machinery/door/airlock/virology/glass,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -4295,6 +4348,15 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
+"Rg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west{
+	req_one_access = list("syndicate")
+	},
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "Rj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 6
@@ -4314,6 +4376,46 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"RF" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/food/canned/chap{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/structure/closet/crate/freezer{
+	name = "Chap Freezer";
+	desc = "Smells like meat."
+	},
+/obj/item/food/canned/chap{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/obj/item/food/canned/chap{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/food/canned/chap{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/food/canned/chap{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/food/canned/chap{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/food/canned/chap{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/food/canned/chap{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
 "RH" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s3"
@@ -4361,6 +4463,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"SS" = (
+/obj/structure/sign/warning/secure_area/directional/west,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
 "Ta" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s2"
@@ -4471,23 +4577,20 @@
 	dir = 4
 	},
 /obj/item/folder/red{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/folder/red{
-	pixel_x = 5;
+	pixel_x = -7;
 	pixel_y = 0
 	},
 /obj/item/pen{
 	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 8
+	pixel_y = -2
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/item/folder/syndicate/red{
+	pixel_x = 8;
+	pixel_y = 0;
+	name = "folder- 'TOP SECRET COMMUNICATION LINKS'"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
@@ -4538,6 +4641,7 @@
 /obj/item/flatpacked_machine/sustenance_machine,
 /obj/item/flatpacked_machine/organics_printer,
 /obj/item/flatpacked_machine/gps_beacon,
+/obj/item/flatpacked_machine/organics_ration_printer,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "VU" = (
@@ -4605,6 +4709,7 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /obj/effect/spawner/structure/electrified_grille,
 /obj/structure/sign/warning/secure_area/directional/west,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/armory)
 "Ya" = (
@@ -4670,23 +4775,22 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "ZF" = (
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/shovel,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/secure/science{
 	name = "Mining Tools"
 	},
+/obj/item/pickaxe/drill/compact,
+/obj/item/pickaxe/drill/compact,
+/obj/item/pickaxe/drill/compact,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/storage/box/nri_flares,
+/obj/item/storage/box/nri_flares,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "ZL" = (
@@ -5070,8 +5174,8 @@ vH
 OR
 OR
 ab
-wQ
 Iy
+wQ
 aa
 "}
 (8,1,1) = {"
@@ -5123,7 +5227,7 @@ BM
 OR
 ab
 Iy
-wQ
+Iy
 ab
 "}
 (9,1,1) = {"
@@ -5302,12 +5406,12 @@ ZF
 kE
 Vu
 Oe
+RF
 zl
-zl
+Qu
+vn
 vn
 Ct
-vn
-vn
 ge
 Ea
 zu
@@ -5737,10 +5841,10 @@ It
 ds
 ds
 ds
-ab
-ab
 Iy
 Iy
+ab
+Qm
 ab
 ab
 ab
@@ -5792,7 +5896,7 @@ gQ
 Iy
 Iy
 Iy
-Iy
+SS
 Iy
 Iy
 aa
@@ -6189,7 +6293,7 @@ ca
 ct
 oE
 kP
-kP
+Rg
 kP
 kP
 et
@@ -6402,7 +6506,7 @@ dO
 hL
 OY
 Ht
-KP
+LO
 fo
 QI
 fB
@@ -6525,7 +6629,7 @@ ab
 ab
 ab
 Iy
-wQ
+Iy
 aa
 aa
 aa
@@ -6711,7 +6815,7 @@ Ya
 Ya
 XK
 Bv
-OM
+Bv
 Bv
 Jc
 Dh

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -16,8 +16,13 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "ag" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "ah" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/iron/freezer,
@@ -27,8 +32,9 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "ak" = (
-/obj/effect/turf_decal/stripes/red/corner,
-/obj/structure/sign/poster/contraband/fun_police/directional/north,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/obj/effect/spawner/structure/electrified_grille,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "al" = (
@@ -36,15 +42,15 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
-"am" = (
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/crusher)
 "an" = (
-/turf/closed/wall,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/hats/hos/beret/syndicate,
+/obj/item/clothing/neck/large_scarf/syndie,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/storage/backpack/satchel,
+/obj/item/storage/box/survival/syndie,
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "ao" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -57,34 +63,34 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "aq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "ar" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "as" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/obj/structure/sign/warning/explosives/alt/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/storage/toolbox/emergency,
+/obj/structure/sign/poster/contraband/fun_police/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "at" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "au" = (
@@ -92,9 +98,13 @@
 /turf/open/floor/circuit/red,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aw" = (
-/obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/storage)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
 "ax" = (
 /obj/machinery/processor{
 	name = "processor"
@@ -102,11 +112,11 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "ay" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "az" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "aA" = (
@@ -138,155 +148,42 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
-"aG" = (
-/obj/structure/closet/cardboard,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/gold,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/exotic/antag_gear_weak,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"aH" = (
-/obj/structure/closet/cardboard,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/toolbox/drone,
-/obj/item/storage/toolbox/drone,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"aJ" = (
-/obj/structure/closet/cardboard,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/zipties,
-/obj/item/switchblade,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/exotic/antag_gear_weak,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"aK" = (
-/obj/structure/closet/cardboard,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"aL" = (
-/obj/structure/closet/cardboard,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/shoes/combat,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"aM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/kitchen)
 "aN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Freezer"
 	},
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage/kitchen)
-"aO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Self-Destruct"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/crusher)
 "aP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aQ" = (
-/turf/closed/wall/r_wall,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/bucket,
+/obj/machinery/splicer,
+/obj/item/reagent_containers/cup/watering_can/advanced,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "aR" = (
 /obj/structure/closet/cardboard,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/shovel,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aS" = (
-/obj/structure/closet/cardboard,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/tape/random,
-/obj/item/tape/random,
-/obj/item/tape/random,
-/obj/item/storage/box/rxglasses,
-/obj/item/extinguisher,
-/obj/item/extinguisher,
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aT" = (
@@ -298,31 +195,61 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aU" = (
-/obj/structure/closet/cardboard,
-/obj/item/knife/kitchen,
-/obj/item/knife/kitchen,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/kitchen/rollingpin,
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mopbucket,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aV" = (
 /obj/structure/closet/cardboard,
-/obj/item/defibrillator,
-/obj/item/storage/box/medipens,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/gold/five,
+/obj/item/stack/sheet/mineral/silver{
+	amount = 5
+	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aW" = (
 /obj/structure/closet/cardboard,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/exotic/languagebook,
-/obj/effect/spawner/random/exotic/languagebook,
-/obj/item/mop/advanced,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aX" = (
@@ -338,22 +265,17 @@
 /obj/item/reagent_containers/condiment/soysauce{
 	pixel_x = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "ba" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/oven/range,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bc" = (
@@ -365,37 +287,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "be" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Self-Destruct"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"bf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/turretid{
-	control_area = "/area/ruin/space/has_grav/deepstorage/crusher";
-	dir = 1;
-	icon_state = "control_kill";
-	lethal = 1;
-	name = "self-destruct turret controls";
-	pixel_y = 30;
-	req_access = list("syndicate")
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"bg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/hydroponics)
+/area/ruin/space/has_grav/deepstorage/crusher)
 "bh" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -424,93 +322,49 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "bm" = (
-/obj/structure/closet/cardboard,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/matches,
-/obj/item/storage/box/bodybags,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/item/mod/module/jetpack,
-/obj/item/flatpacked_machine,
-/obj/item/flatpacked_machine/ore_silo,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "bn" = (
-/obj/structure/closet/cardboard,
-/obj/item/stack/sheet/cardboard,
-/obj/item/stack/cable_coil,
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/stack/package_wrap,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"bo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "bp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "bq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/structure/closet/cardboard,
+/obj/item/defibrillator,
+/obj/item/storage/box/medipens,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "br" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/mopbucket,
+/obj/structure/closet/cardboard,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/exotic/languagebook,
+/obj/effect/spawner/random/exotic/languagebook,
+/obj/item/mop/advanced,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "bs" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/item/storage/box/drinkingglasses,
+/obj/machinery/light/directional/west,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bu" = (
@@ -522,41 +376,30 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
-"bw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/deepstorage/kitchen)
 "bx" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/east,
+/obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "by" = (
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "bz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "bA" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/hydroponics)
-"bB" = (
-/obj/structure/table,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants/portaseeder,
-/turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "bC" = (
 /turf/open/floor/iron,
@@ -568,203 +411,154 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
-"bE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
 "bF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"bG" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"bH" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/storage)
-"bI" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"bJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"bK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"bL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"bG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/vending/dinnerware,
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/item/switchblade,
+/obj/item/storage/box/zipties,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/mousetraps,
+/obj/item/storage/box/mousetraps,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"bH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/structure/cable,
+/obj/structure/closet/cardboard,
+/obj/item/knife/kitchen,
+/obj/item/knife/kitchen,
+/obj/item/kitchen/rollingpin,
+/obj/item/hatchet,
+/obj/item/cultivator,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"bI" = (
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/rice,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"bJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"bK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"bL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/reagent_containers/condiment/peppermill,
-/obj/item/knife/kitchen,
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"bN" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/effect/mapping_helpers/apc/syndicate_access,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bO" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/griddle,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/table,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bP" = (
-/obj/machinery/firealarm/directional/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
-"bQ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/hydroponics)
 "bR" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
-"bT" = (
-/obj/effect/turf_decal/delivery,
-/obj/item/food/canned/beans{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = -2
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 5
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
 "bU" = (
-/obj/effect/turf_decal/delivery,
-/obj/item/food/canned/beans{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = -2
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 5
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"bV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
-"bW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/storage)
 "bX" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "General Storage"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "bY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen"
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/smartfridge,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/processor{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "ca" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cd" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/seed_rare,
-/obj/effect/spawner/random/food_or_drink/seed_rare,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "cf" = (
@@ -779,30 +573,10 @@
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
-"cj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/barsign/all_access/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"ck" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
 "cl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/kitchen)
 "cn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -813,58 +587,32 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "co" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"cq" = (
-/obj/machinery/shower/directional/east,
-/obj/item/soap,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage)
-"cr" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage)
+/obj/machinery/smartfridge,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/kitchen)
 "ct" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Showers"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
-"cv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/hydroponics)
 "cw" = (
 /obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/seed_rare,
+/obj/effect/spawner/random/food_or_drink/seed_rare,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/obj/item/reagent_containers/cup/bucket{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/bucket,
-/obj/machinery/splicer,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "cx" = (
@@ -885,83 +633,42 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "cB" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"cC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "cD" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Provisions Storage"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
+/area/ruin/space/has_grav/deepstorage)
 "cE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"cH" = (
+/obj/machinery/barsign/all_access/directional/north,
 /obj/structure/chair{
 	dir = 4
 	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"cH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cI" = (
@@ -969,503 +676,384 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
-"cK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
 "cL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/vending/coffee,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/vending/boozeomat/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cM" = (
-/obj/machinery/shower/directional/east,
-/obj/structure/window/reinforced/plasma/spawner/directional/south,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage)
-"cN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/soap/syndie,
+/obj/structure/curtain,
+/obj/machinery/shower/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sink/directional/west,
-/obj/structure/mirror/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/curtain,
+/obj/item/soap/syndie,
+/obj/machinery/shower/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
-"cQ" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/apc/syndicate_access,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"cS" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
+"cR" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/dorm)
 "cT" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cU" = (
-/obj/structure/chair{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/vending/cigarette,
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "cX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/structure/curtain,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage)
-"cY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/mirror/directional/east,
+/obj/machinery/light/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/mirror/directional/east,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "da" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/armory)
-"db" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/gauze,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
-"dc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Storage"
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"de" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/armory)
-"df" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"dg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"dh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"di" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/chair/stool/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"dj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"dk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"dp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage)
-"dq" = (
-/obj/machinery/door/airlock{
-	name = "Showers"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage)
-"dt" = (
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
-"du" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
-"dv" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/rods/fifty,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
-"dw" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 5
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/machinery/light/directional/west,
-/obj/item/vending_refill/cigarette{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/vending_refill/cigarette,
-/obj/item/vending_refill/coffee{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"dx" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 5
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/vending_refill/cigarette{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/vending_refill/cigarette,
-/obj/item/vending_refill/coffee{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"dy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"dz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"dA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/armory)
+"dc" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"de" = (
+/obj/structure/table,
+/obj/item/storage/medkit/emergency{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/storage/medkit/emergency,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"dg" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"dj" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"dq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/sink/directional/west,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/has_grav/deepstorage)
+"ds" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage)
+"dt" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"du" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"dv" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/item/radio/headset/syndicate/alt,
+/obj/item/radio/headset/syndicate/alt,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Restricted Gear";
+	req_one_access = list("syndicate")
+	},
+/obj/item/clothing/suit/armor/vest/alt,
+/obj/item/clothing/suit/armor/vest/alt,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"dx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
+"dy" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Provisions Storage"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
+"dz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"dA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "dC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
+	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"dH" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"dI" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage)
+"dM" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Classified Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"dH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"dI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"dK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"dM" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Storage"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/armory)
 "dN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "dO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Classified Storage"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "dR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/area/ruin/space/has_grav/deepstorage)
 "dS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Dorms"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"dU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/structure/table,
-/obj/item/reagent_containers/cup/glass/mug/britcup{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/cup/glass/mug{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/cup/glass/mug{
-	pixel_x = -8;
-	pixel_y = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "eb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "ee" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Storage"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/armory)
-"ef" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+"eg" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/food/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
-"eh" = (
-/obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/apc/away_general_access,
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
+/obj/item/food/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/food/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/food/canned/beans{
+	pixel_x = 5
+	},
+/obj/item/food/canned/beans{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/food/canned/beans{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/freezer,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
 "ei" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
-"ej" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"ek" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/deepstorage{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"el" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/dorm)
 "em" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Dorms"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "en" = (
@@ -1476,50 +1064,60 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "eo" = (
-/obj/machinery/door/poddoor{
-	id = "bunkerinterior"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
+/area/ruin/space/has_grav/deepstorage)
 "ep" = (
-/obj/machinery/door/poddoor{
-	id = "bunkerinterior"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
+/area/ruin/space/has_grav/deepstorage)
 "eq" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "er" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Airlock Control"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/duct,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
+/area/ruin/space/has_grav/deepstorage)
 "es" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"et" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"et" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "ev" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Restricted Gear";
+	req_one_access = list("syndicate")
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "ew" = (
@@ -1529,16 +1127,22 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "ex" = (
+/obj/structure/cable,
 /obj/structure/table,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/obj/effect/spawner/random/exotic/tool,
-/obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/item/storage/medkit/toxin{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/medkit/toxin,
+/obj/item/storage/pill_bottle/multiver,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/syndicate_access,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "ey" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/head/hats/hos/beret/syndicate,
-/obj/item/clothing/neck/large_scarf/syndie,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "ez" = (
@@ -1550,28 +1154,24 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "eA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"eB" = (
-/obj/machinery/door/airlock{
-	name = "Personal Dorm"
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/deepstorage/comms{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "eC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "eD" = (
@@ -1584,31 +1184,75 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "eF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "eG" = (
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"eJ" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Airlock Control"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"eK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"eQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/dorm)
+"eR" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage)
+"eS" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "General Storage"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"eT" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter";
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"eH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"eI" = (
+"eU" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
 	dir = 4
@@ -1620,7 +1264,6 @@
 	pixel_y = 28;
 	pixel_x = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door/directional/west{
 	id = "bunkerexterior";
 	name = "exterior blast door access";
@@ -1647,9 +1290,14 @@
 	pixel_y = 30;
 	req_access = list("syndicate")
 	},
-/obj/item/pen,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/pen{
+	pixel_x = -7;
+	pixel_y = -1
+	},
 /obj/item/stamp/denied{
 	pixel_x = 11;
 	pixel_y = 16
@@ -1662,179 +1310,66 @@
 	pixel_x = -9;
 	pixel_y = 16
 	},
-/turf/open/floor/iron,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"eJ" = (
+"eV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"eK" = (
+"eW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/structure/filingcabinet/security,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/turf/open/floor/iron,
+/obj/structure/filingcabinet/security{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/structure/filingcabinet/medical{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"eL" = (
+"eX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
 	dir = 10
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/apc/cell_5k,
-/obj/structure/filingcabinet/medical,
 /obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"eO" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/combat{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/clothing/gloves/combat{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
-"eP" = (
-/obj/structure/table,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare{
-	pixel_y = 6
-	},
-/obj/item/flashlight/flare{
-	pixel_y = 6
-	},
-/obj/item/flashlight/flare{
-	pixel_y = 6
-	},
-/obj/item/storage/toolbox/syndicate,
-/obj/item/storage/toolbox/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
-"eQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"eR" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage)
-"eT" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bunkershutter"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"eU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/paper/monitorkey,
-/obj/machinery/fax{
-	syndicate_network = 1;
-	name = "Syndicate Research Bunker";
-	fax_name = "Syndicate Research Outpost"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"eV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"eW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"eX" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	name = "Hall Siphon to Port"
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/structure/filingcabinet,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "eY" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Atmospherics and Power Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/duct,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/power)
+/area/ruin/space/has_grav/deepstorage)
 "eZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Atmospherics and Power Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/power)
+/area/ruin/space/has_grav/deepstorage)
 "fa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/armory)
 "fc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/power)
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
 "fd" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
@@ -1844,9 +1379,12 @@
 /area/ruin/space)
 "fe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "ff" = (
@@ -1855,48 +1393,57 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "fg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/tactical{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/effect/turf_decal/syndicateemblem/top/left,
+/obj/effect/turf_decal/syndicateemblem/top/middle,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/syndicateemblem/top/middle,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/valve{
+	name = "Hall Siphon to Port"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/gorlex_recruitment/directional/east,
-/turf/open/floor/iron,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/syndicateemblem/top/right,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 8
+	},
 /obj/structure/cable,
+/obj/machinery/plumbing/synthesizer{
+	reagent_id = /datum/reagent/water
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Atmospherics and Power Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/interdyne,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/power)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/armory)
 "fq" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/light/small/directional/east,
@@ -1904,73 +1451,55 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "fr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden{
-	dir = 5
-	},
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"fu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom";
-	pixel_y = -26
-	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"fv" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "Port To Hall"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"fw" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"fx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/effect/mapping_helpers/apc/syndicate_access,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/power)
-"fy" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
+"fs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"fu" = (
+/obj/structure/chair/office/tactical{
+	dir = 8
+	},
+/obj/effect/turf_decal/syndicateemblem/middle/left,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"fv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/syndicateemblem/middle/middle,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"fw" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/gorlex_recruitment/directional/east,
+/obj/effect/turf_decal/syndicateemblem/middle/right,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"fy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fB" = (
@@ -1991,46 +1520,43 @@
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/deepstorage/power)
 "fE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "fF" = (
-/obj/machinery/door/poddoor{
-	id = "bunkerexterior"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fG" = (
-/obj/machinery/door/poddoor{
-	id = "bunkerexterior"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "fH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "fJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("deepo2"="Oxygen Supply");
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
@@ -2050,38 +1576,34 @@
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/power)
 "fN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/obj/machinery/vending/imported/yangyu,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "fO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "fP" = (
-/obj/structure/closet/wardrobe/pjs,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"fQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/porta_turret/syndicate/energy{
-	dir = 6
-	},
-/obj/effect/turf_decal/bot_red/right,
-/turf/open/floor/iron,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/deepstorage)
-"fR" = (
+"fS" = (
+/obj/machinery/door/poddoor{
+	id = "bunkerexterior"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"fT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -2090,107 +1612,42 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"fS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"fT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"fU" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Bunker entrance";
-	network = list("bunker1")
-	},
-/obj/structure/sign/warning/secure_area/directional/north,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_red/right,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "fV" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
-"fW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/power)
-"fX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/sign/warning/electric_shock/directional/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/power)
-"fY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/power)
 "fZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/power)
-"ga" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
-	dir = 4
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("deepn2"="Nitrogen Supply");
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "ge" = (
-/obj/machinery/door/airlock{
-	name = "Personal Dorm"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/wood,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "gf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "gh" = (
@@ -2219,44 +1676,42 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gk" = (
-/obj/machinery/light/directional/east,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "gm" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate/bin{
-	name = "laundry bin"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/washing_machine,
+/obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
-"gn" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
 "gp" = (
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/white/textured,
@@ -2277,21 +1732,20 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gs" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/light/directional/east,
 /obj/structure/closet/l3closet/scientist,
-/obj/item/clothing/suit/bio_suit/interdyne,
-/obj/item/clothing/suit/bio_suit/interdyne,
-/obj/item/clothing/suit/bio_suit/interdyne,
-/obj/item/clothing/head/bio_hood/interdyne,
-/obj/item/clothing/head/bio_hood/interdyne,
-/obj/item/clothing/head/bio_hood/interdyne,
 /obj/item/construction/plumbing/research,
+/obj/item/clothing/head/bio_hood/interdyne,
+/obj/item/clothing/suit/bio_suit/interdyne,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "gu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gv" = (
@@ -2301,12 +1755,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/deepstorage/power)
-"gw" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
 "gx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -2315,26 +1763,19 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "gy" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "gz" = (
 /obj/machinery/door/airlock/highsecurity{
 	desc = "Nothing to see here, folks, just an inconspicuous airlock. Now go away!";
@@ -2345,26 +1786,23 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "gA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("deepn2"="Nitrogen Supply");
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
+	dir = 4
 	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gD" = (
@@ -2382,9 +1820,28 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "gG" = (
-/obj/machinery/iv_drip,
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/item/reagent_containers/chem_pack/saline,
+/obj/item/reagent_containers/chem_pack/saline,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "gH" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -2411,14 +1868,13 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gO" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gP" = (
@@ -2445,42 +1901,23 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 5
-	},
-/obj/structure/sign/warning/radiation/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/hacked,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/electrical,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gW" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gY" = (
@@ -2491,12 +1928,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gZ" = (
-/obj/structure/cable,
-/obj/machinery/power/rtg/portable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/power)
-"ha" = (
-/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/machinery/power/rtg/portable,
 /turf/open/floor/plating,
@@ -2514,77 +1945,56 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "hg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Showers"
 	},
-/obj/machinery/firealarm/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"hh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
 "hi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "hj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "hk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/c20r/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "hl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/firealarm/directional/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "hm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/poddoor{
+	id = "bunkerexterior"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
+/area/ruin/space/has_grav/deepstorage/airlock)
 "hn" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/airlock)
 "ho" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/power)
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/airlock)
 "hq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 4
@@ -2598,67 +2008,168 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"hv" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
+"hE" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 8
 	},
-/obj/machinery/duct,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
-"hA" = (
-/obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"hB" = (
-/obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/hydroponics)
-"hT" = (
-/obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage)
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/armory)
+"hH" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"hL" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/armory)
+"hO" = (
+/obj/item/storage/toolbox/drone,
+/obj/item/storage/toolbox/drone,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/engineering,
+/obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/effect/spawner/random/exotic/antag_gear_weak,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
 "hU" = (
-/turf/closed/wall,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "hV" = (
-/obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 5
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/vending_refill/cigarette{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/vending_refill/cigarette,
+/obj/item/vending_refill/coffee{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
 "hW" = (
-/obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "hX" = (
-/obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/airlock)
-"hY" = (
-/obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/power)
-"ie" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/message_monitor{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/iron,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"iA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
+"ic" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"ie" = (
+/obj/machinery/computer/camera_advanced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"iw" = (
+/obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/deepstorage)
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
 "iK" = (
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"jv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"jx" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/obj/structure/table,
+/obj/item/storage/medkit/regular{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/medkit/regular{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"jy" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/item/storage/medkit/brute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/medkit/brute{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"jA" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/surgery_syndie{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/storage/medkit/hypospray/syndicate{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "jD" = (
 /obj/machinery/plumbing/ooze_compressor{
 	dir = 1
@@ -2668,32 +2179,69 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"kB" = (
+"kk" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"kE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/south,
-/obj/machinery/duct,
-/turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
-"kE" = (
-/obj/machinery/camera/autoname/directional/south{
-	network = list("bunker1")
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"kF" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Bio Testing Chamber";
+	desc = "I am afraid of whatever your testing in there."
 	},
-/obj/machinery/corral_corner{
-	mapping_id = "s3"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
-"lf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/chemical,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"kP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"kV" = (
+/obj/machinery/shower/directional/east,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/end{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"lf" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/item/storage/medkit,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"lg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Atmospherics and Power Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/power)
 "lj" = (
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/power)
+"lk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "lB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -2706,31 +2254,76 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "lG" = (
-/turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"mg" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
-"ml" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Xenobiology"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+/obj/structure/closet/secure_closet/medical1{
+	req_access = list("syndicate")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/storage)
-"mD" = (
-/obj/effect/turf_decal/stripes{
+/obj/item/emergency_bed,
+/obj/item/clothing/accessory/armband/medblue,
+/obj/item/clothing/gloves/latex/nitrile,
+/obj/item/clothing/gloves/latex/surgical,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"md" = (
+/obj/machinery/computer/diseasesplicer,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"mt" = (
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Emergency Defense Gun";
+	desc = "Open incase of intruders or something";
+	req_one_access = list("syndicate")
+	},
+/obj/structure/closet/crate/secure/weapon{
+	req_access = list("syndicate");
+	name = "Ammo crate"
+	},
+/obj/item/ammo_box/magazine/c40sol_rifle{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/ammo_box/magazine/c40sol_rifle{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/ammo_box/magazine/c40sol_rifle{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/c40sol{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/item/ammo_box/c40sol{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"mE" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/duct,
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"mN" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/hydroponics)
 "mW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -2741,6 +2334,73 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"ne" = (
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"nk" = (
+/obj/structure/table,
+/obj/machinery/firealarm/directional/east,
+/obj/item/storage/medkit/robotic_repair{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/robotic_repair{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"nv" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Bunker entrance";
+	network = list("bunker1")
+	},
+/obj/structure/sign/warning/secure_area/directional/north,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 2
+	},
+/obj/effect/turf_decal/bot_red/right,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"nA" = (
+/obj/structure/table,
+/obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/effect/spawner/random/exotic/antag_gear_weak,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"nG" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers/bluespace,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"nY" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"ob" = (
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/peppermill,
+/obj/item/knife/kitchen,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/kitchen)
 "on" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s2"
@@ -2750,32 +2410,131 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"oA" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
+"or" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"oC" = (
+/obj/machinery/power/rtg/portable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/power)
+"oE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "oI" = (
-/obj/machinery/vending/medical/syndicate_access/cybersun,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/white,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/dorm)
+"oJ" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/light/floor/has_bulb,
+/obj/structure/table/wood,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "oV" = (
 /obj/machinery/composters,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
+"pn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "po" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
+"pu" = (
+/obj/structure/closet/crate/secure/weapon{
+	req_access = list("syndicate");
+	name = "Ammo crate"
+	},
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/c9mm{
+	pixel_y = 6
+	},
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/machinery/door/window/brigdoor/right/directional/south{
+	name = "Restricted Gear";
+	req_one_access = list("syndicate")
+	},
+/obj/item/ammo_box/c9mm{
+	pixel_y = 6
+	},
+/obj/item/ammo_box/c9mm,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
 "pP" = (
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/coffeemaker/impressa,
+/obj/item/storage/box/coffeepack,
+/obj/item/storage/box/coffeepack/robusta,
+/obj/machinery/duct,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"pS" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/power)
+"pX" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"qc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
 "qg" = (
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
+/obj/machinery/vending/cigarette/syndicate,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "qm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	chamber_id = "deepo2";
@@ -2783,25 +2542,93 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/power)
+"qt" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/armory)
+"qB" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/crusher)
 "qM" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/machinery/corral_corner{
-	mapping_id = "s3"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "s3";
-	dir = 2
-	},
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
-"qN" = (
-/obj/machinery/computer/operating{
-	dir = 1
+/obj/machinery/duct,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("bunker1")
 	},
 /turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"qN" = (
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"qQ" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/hydroponics)
+"qR" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/wall/directional/east{
+	name = "Equipment"
+	},
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/tube,
+/obj/item/storage/box/tube,
+/obj/item/storage/box/petridish,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"qS" = (
+/obj/structure/reagent_dispensers/wall/virusfood/directional/north,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"qT" = (
+/obj/structure/sign/warning/explosives/alt/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/crusher)
+"ra" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"rv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"rx" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "rz" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 8
@@ -2809,21 +2636,60 @@
 /obj/effect/turf_decal/bot_red/left,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
+"rB" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/machinery/sleeper/syndie/fullupgrade{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "rD" = (
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
-/obj/structure/table/reinforced,
-/obj/item/disk/surgery/brainwashing,
-/obj/item/disk/surgery/forgottenship,
-/obj/item/disk/surgery/sleeper_protocol,
-/turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"sa" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"rT" = (
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"sd" = (
+/obj/machinery/corral_corner{
+	mapping_id = "s4"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "s4"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"sj" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"so" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 5
+	},
+/obj/structure/sign/warning/radiation/directional/west,
+/obj/machinery/autolathe/hacked,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/power)
+"sw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/crusher)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "sx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -2836,23 +2702,51 @@
 "sy" = (
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"sG" = (
+/obj/machinery/biomass_recycler,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
 "sL" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "sQ" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
-"tk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/engine,
+"sV" = (
+/obj/machinery/disease2/centrifuge,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/item/storage/box/tube,
+/turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"tk" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/machinery/vending/medical/syndicate_access/cybersun,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"tm" = (
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"tn" = (
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
 "tA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -2860,15 +2754,46 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"tH" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/kitchen)
+"tS" = (
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 8
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/item/clothing/suit/bio_suit/interdyne,
+/obj/item/clothing/head/bio_hood/interdyne,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"ud" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/power)
+"ug" = (
+/obj/machinery/disease2/diseaseanalyser,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/item/storage/box/petridish,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "un" = (
-/obj/structure/table/optable,
-/obj/machinery/light/small/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/disk/surgery/sleeper_protocol,
+/obj/item/disk/surgery/forgottenship,
+/obj/item/disk/surgery/brainwashing,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"uB" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "uG" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy"
@@ -2884,6 +2809,22 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"uM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Syndicate Radio Intercom";
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/syndicateemblem/bottom/left,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"uU" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
 "vc" = (
 /obj/machinery/plumbing/ooze_compressor{
 	dir = 1
@@ -2893,12 +2834,42 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"vs" = (
-/obj/effect/turf_decal/stripes/corner{
+"vj" = (
+/obj/structure/guncase,
+/obj/machinery/door/window/brigdoor/right/directional/south{
+	name = "Emergency Defense Gun";
+	desc = "Open incase of intruders or something.";
+	req_one_access = list("syndicate")
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/gun/ballistic/automatic/sol_rifle/evil/no_mag{
+	pin = /obj/item/firing_pin
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"vn" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
+"vo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"vH" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/obj/machinery/smartfridge/disks{
+	pixel_x = 8;
+	pixel_y = 14
+	},
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "vL" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -2907,6 +2878,11 @@
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "wu" = (
 /obj/machinery/chem_dispenser/fullupgrade,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"wy" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "wF" = (
@@ -2950,23 +2926,19 @@
 /obj/item/disk/vacuum_upgrade/biomass,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"wI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/d_day_promo/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
-"wJ" = (
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"wK" = (
-/obj/structure/table,
-/obj/item/storage/medkit/regular{
-	pixel_x = 4;
-	pixel_y = 4
+"wH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/item/storage/medkit/regular,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"wM" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/deepstorage/armory)
+/area/ruin/space/has_grav/deepstorage/crusher)
 "wQ" = (
 /mob/living/basic/carp,
 /turf/open/misc/asteroid/airless,
@@ -2993,56 +2965,214 @@
 /turf/open/floor/light,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "xn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
-	dir = 4
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("deepo2"="Oxygen Supply");
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
+"xp" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"xw" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"xx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
 "xI" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"xN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/green/corner,
+/obj/structure/sign/warning/biohazard/directional/west,
+/obj/machinery/shower/directional/east,
+/obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"xQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
 "xV" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/turf/closed/wall,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/seafood,
+/obj/item/storage/box/ingredients/seafood,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "yf" = (
 /obj/machinery/chem_master,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"yg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"yy" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/power)
+"yz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
 "yA" = (
 /mob/living/basic/slime,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"yQ" = (
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"zi" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"zv" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron,
+"yN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sink/directional/west,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/deepstorage)
+"yQ" = (
+/obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = -14;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"zb" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "Port To Hall"
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/syndicateemblem/bottom/middle,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"zl" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/food/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/food/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/food/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/food/canned/beans{
+	pixel_x = 5
+	},
+/obj/item/food/canned/beans{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/food/canned/beans{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/freezer,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
+"zu" = (
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
+"zI" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/storage)
 "Ad" = (
 /obj/machinery/slime_market_pad,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"Ag" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"Al" = (
+/obj/structure/closet/cabinet,
+/obj/item/flashlight/lantern/syndicate,
+/obj/item/clothing/under/syndicate/sniper,
+/obj/item/clothing/head/hats/hos/beret/syndicate,
+/obj/item/clothing/head/hats/hos/cap/syndicate,
+/obj/item/clothing/neck/large_scarf/syndie,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/megaphone,
+/obj/item/binoculars,
+/obj/item/choice_beacon/pet,
+/obj/item/storage/box/survival/syndie,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
 "An" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/duct,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"Ap" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"Ay" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/secure_area/directional/south,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "Az" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -3068,6 +3198,12 @@
 /obj/item/gun/syringe/syndicate,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"AR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/defibrillator_mount/loaded/directional/south,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "AZ" = (
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/deepstorage/crusher)
@@ -3081,18 +3217,52 @@
 /obj/effect/spawner/structure/electrified_grille,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
+"Bk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"Bv" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/effect/spawner/structure/electrified_grille,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/deepstorage/armory)
 "Bw" = (
 /mob/living/basic/carp/mega,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
 "BA" = (
-/obj/structure/closet,
-/obj/item/storage/box/beakers/bluespace,
-/obj/item/storage/box/beakers/bluespace,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/syringes,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"BH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"BW" = (
+/obj/structure/table,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/hydroponics)
 "Cf" = (
 /obj/machinery/growing/tray,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -3104,11 +3274,13 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
-"CA" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/crusher)
 "CL" = (
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/part_replacer,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
 "CQ" = (
 /obj/machinery/computer/slime_market,
@@ -3129,9 +3301,6 @@
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "Db" = (
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/machinery/stove,
 /turf/open/floor/iron/cafeteria,
@@ -3143,9 +3312,47 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
+"Dh" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/obj/effect/spawner/structure/electrified_grille,
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/deepstorage/armory)
 "Dp" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/deepstorage)
+"Dq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"Ee" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
+"Eg" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/secure/science,
+/obj/item/mop/advanced,
+/obj/item/mop/advanced,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/soap/syndie,
+/obj/item/soap/syndie,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
 "Em" = (
 /obj/machinery/growing/tray,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -3154,28 +3361,73 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/light,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
+"En" = (
+/obj/structure/chair{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/toy/balloon_animal/lizard{
+	name = "Syndi-Lizard";
+	desc = "Hah. Stupid goober";
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/turf/open/misc/asteroid/airless,
+/area/ruin/space)
 "Et" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/camera_advanced{
-	dir = 4
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/paper/monitorkey,
+/obj/machinery/fax{
+	syndicate_network = 1;
+	name = "Syndicate Research Bunker";
+	fax_name = "Syndicate Research Outpost"
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"EG" = (
-/obj/structure/closet/cabinet,
-/obj/item/flashlight/lantern/syndicate,
-/obj/item/clothing/under/syndicate/sniper,
-/obj/item/clothing/head/hats/hos/beret/syndicate,
-/obj/item/clothing/head/hats/hos/cap/syndicate,
-/obj/item/clothing/neck/large_scarf/syndie,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/deepstorage/dorm)
+"Ey" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/crusher)
+"EH" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/structure/table,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"EL" = (
+/obj/machinery/firealarm/directional/north,
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "EP" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden{
+	dir = 5
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"EW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/airlock)
+/obj/structure/table/reinforced,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "Fv" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s3"
@@ -3191,17 +3443,85 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/light,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
-"Ht" = (
-/obj/structure/table,
-/obj/item/storage/medkit/toxin{
-	pixel_x = 4;
-	pixel_y = 4
+"FR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/item/storage/medkit/toxin,
-/obj/item/storage/pill_bottle/multiver,
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"FS" = (
+/obj/structure/sign/warning/biohazard/directional/north,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"FZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/turretid{
+	control_area = "/area/ruin/space/has_grav/deepstorage/crusher";
+	dir = 1;
+	icon_state = "control_kill";
+	lethal = 1;
+	name = "self-destruct turret controls";
+	pixel_y = 30;
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"Ga" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"Gw" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/sleeper/syndie/fullupgrade{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Hp" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Xenobiology"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"Ht" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
+"Hx" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"HN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "Ik" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3219,30 +3539,119 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"It" = (
+/obj/structure/sign/poster/contraband/d_day_promo/directional/south,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "Iy" = (
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
-"Jp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
+"IS" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"Jc" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/effect/spawner/structure/electrified_grille,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/deepstorage/armory)
+"Jm" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate/internals{
+	desc = "A crate that holds bottles of water.";
+	name = "Water bottle crate"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
+"Jn" = (
+/obj/machinery/door/airlock{
+	name = "Personal Dorm"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
+"Jp" = (
+/obj/machinery/light/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
-"JC" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/corral_corner{
-	mapping_id = "s3"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
+"JG" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/power)
+"JR" = (
+/obj/structure/sign/warning/electric_shock/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/power)
 "JV" = (
 /obj/item/reagent_containers/cup/beaker/large,
 /turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Kh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/mug/britcup{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"Ks" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "KO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3250,13 +3659,49 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"KY" = (
-/mob/living/basic/carp,
-/turf/template_noop,
-/area/template_noop)
+"KP" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare{
+	pixel_y = 6
+	},
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare{
+	pixel_y = 6
+	},
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare{
+	pixel_y = 6
+	},
+/obj/item/flashlight,
+/obj/item/flashlight,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
+"KT" = (
+/obj/structure/table/glass,
+/obj/machinery/light/small/directional/north,
+/obj/item/restraints/handcuffs,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "KZ" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
+/obj/structure/cargo_shelf,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"Lm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "LB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -3264,6 +3709,17 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"LC" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"LE" = (
+/obj/structure/table,
+/obj/effect/spawner/random/exotic/tool,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
 "LH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -3274,20 +3730,26 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"LO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
-	dir = 4
+"LI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/armory)
-"Mp" = (
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"LO" = (
 /obj/structure/table,
-/obj/item/storage/medkit/brute{
-	pixel_x = 4;
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/gloves/combat{
+	pixel_x = -3;
 	pixel_y = 4
 	},
-/obj/item/storage/medkit/brute,
-/obj/machinery/light/directional/north,
+/obj/item/clothing/gloves/combat{
+	pixel_x = 3;
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "Mv" = (
@@ -3296,28 +3758,31 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"MB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/power)
 "MJ" = (
 /obj/machinery/growing/tray,
 /turf/open/floor/light,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
-"Nc" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
-"Nl" = (
+"ML" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/structure/table,
-/obj/machinery/coffeemaker/impressa,
-/obj/item/storage/box/coffeepack,
-/obj/item/storage/box/coffeepack/robusta,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Nl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "Nw" = (
@@ -3327,10 +3792,14 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "NA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband/free_key/directional/south,
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/deepstorage{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "NE" = (
@@ -3340,86 +3809,258 @@
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"NF" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "s3";
-	dir = 1
+"NX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
+/obj/structure/sign/poster/contraband/free_key/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
 "Ob" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/crusher)
-"OD" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/deepstorage/kitchen)
-"Pb" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/engine,
+"Oc" = (
+/obj/structure/closet/secure_closet/wall/directional/north,
+/obj/item/device/antibody_scanner,
+/obj/item/device/antibody_scanner,
+/obj/item/clothing/glasses/hud/health/night/science,
+/obj/item/clothing/glasses/hud/health/night/science,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/pathology,
+/obj/item/clothing/glasses/pathology,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Oe" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
+"Of" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
+"Og" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/infections,
+/obj/machinery/reagentgrinder{
+	pixel_y = 14;
+	pixel_x = -11
+	},
+/obj/item/stack/sheet/mineral/plasma/five{
+	pixel_x = -13;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Op" = (
+/obj/machinery/disease2/incubator,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Ot" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"OB" = (
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"OL" = (
+/obj/structure/noticeboard/directional/north,
+/obj/item/paper/fluff/ruins/deepstorage/water_concern,
+/obj/item/paper/fluff/ruins/deepstorage/hydro_notice,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"OM" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/effect/spawner/structure/electrified_grille,
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/deepstorage/armory)
+"OR" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"OX" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/kitchen)
+"OY" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/machinery/door/window/brigdoor/right/directional/south{
+	name = "Restricted Gear";
+	req_one_access = list("syndicate")
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/armory)
 "Ps" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"PM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+"PF" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"PH" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"PN" = (
+/obj/machinery/computer/operating{
+	dir = 1
 	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white/textured,
-/area/ruin/space/has_grav/deepstorage/xenobiology)
-"Qi" = (
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"PT" = (
 /obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted/spawner/directional/west,
-/obj/structure/chair/greyscale{
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"Qi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"Qt" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light/directional/east,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/decal/cleanable/dirt,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Qj" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"Ql" = (
+/obj/structure/closet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/cable_coil,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/package_wrap,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"Qr" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Qt" = (
+/obj/structure/closet/wardrobe/pjs,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
+"QA" = (
+/obj/machinery/door/airlock/virology/glass,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/turf_decal/trimline/green/filled,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"QI" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/power)
+"QM" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/cable,
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/deepstorage/armory)
+"QW" = (
+/obj/structure/closet/secure_closet/wall/directional/north{
+	name = "Monkey and Mouse Cube Locker"
+	},
+/obj/item/storage/box/monkeycubes/mousecubes{
+	pixel_x = 9;
+	pixel_y = 0
+	},
+/obj/item/storage/box/monkeycubes/mousecubes{
+	pixel_x = 9;
+	pixel_y = 0
+	},
+/obj/item/storage/box/monkeycubes/mousecubes{
+	pixel_x = 9;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "Re" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "Rj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 6
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/power)
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/armory)
 "Rs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
-"RT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/light,
+"Rw" = (
+/obj/machinery/duct,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"RH" = (
+/obj/machinery/corral_corner{
+	mapping_id = "s3"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "s3"
+	},
 /turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"RT" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/stasis{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "Sp" = (
 /obj/machinery/corral_corner{
@@ -3430,60 +4071,99 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"SJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
+"St" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"SR" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/deepstorage/pharmacy)
+/area/ruin/space/has_grav/deepstorage/power)
+"SB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "Ta" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s2"
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"Tp" = (
-/obj/structure/closet/crate/secure/gear{
-	req_access = list("syndicate")
-	},
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/under/syndicate/combat,
-/obj/item/clothing/under/syndicate/combat,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/delivery,
-/obj/item/radio/headset/syndicate/alt,
-/obj/item/radio/headset/syndicate/alt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage/aux_storage)
-"TC" = (
-/obj/structure/noticeboard/directional/north,
-/obj/item/paper/fluff/ruins/deepstorage/water_concern,
-/obj/item/paper/fluff/ruins/deepstorage/hydro_notice,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"Tc" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"Tf" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"Tm" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 5
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/machinery/light/directional/west,
+/obj/item/vending_refill/cigarette{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/vending_refill/cigarette,
+/obj/item/vending_refill/coffee{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/aux_storage)
+"Tq" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cargo_shelf,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
+"TC" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/storage)
 "TL" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"Ud" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/duct,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "Uj" = (
@@ -3492,12 +4172,46 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"Uw" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"Uy" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
 "UH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/c20r/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
+"UK" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/folder/red{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/folder/red{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/dorm)
 "UO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3505,97 +4219,174 @@
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "UX" = (
-/obj/machinery/sleeper/syndie{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/deepstorage/dorm)
-"Va" = (
-/obj/effect/turf_decal/box/white/corners{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/closet/crate/secure/weapon{
-	req_access = list("syndicate")
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"Va" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
 	},
-/obj/item/ammo_box/c9mm{
-	pixel_y = 6
-	},
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/magazine/m9mm{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/ammo_box/magazine/m9mm{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/ammo_box/magazine/m9mm{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/ammo_box/magazine/m9mm{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/aux_storage)
+"Ve" = (
+/obj/machinery/corral_corner{
+	mapping_id = "s4"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"Vu" = (
+/obj/structure/closet/cardboard,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/matches,
+/obj/item/storage/box/bodybags,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/flatpacked_machine,
+/obj/item/flatpacked_machine/ore_silo,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
 "VU" = (
-/obj/machinery/biomass_recycler,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
-/obj/item/stack/biomass,
+/obj/structure/closet,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers/bluespace,
+/obj/item/storage/box/beakers/bluespace,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "VY" = (
-/turf/closed/wall/r_wall,
+/obj/structure/closet/cardboard,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/storage/box/rxglasses,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
-"Wf" = (
+"Wd" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/item/wrench,
+/obj/effect/turf_decal/syndicateemblem/bottom/right,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/deepstorage/airlock)
+"WL" = (
+/obj/structure/closet/secure_closet/wall/directional/north{
+	name = "Equipment Lockup"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
+"XF" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"WR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/deepstorage/comms{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/deepstorage/dorm)
+"XK" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/effect/spawner/structure/electrified_grille,
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/deepstorage/armory)
 "Ya" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "Yo" = (
-/obj/structure/table,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/spawner/random/exotic/antag_gear_weak,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
-"YY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/porta_turret/syndicate/energy{
-	dir = 9
+"Yv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot_red/left,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/door/window/brigdoor/right/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"Zb" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
+"Zn" = (
+/obj/machinery/door/airlock/virology/glass,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/deepstorage/pharmacy)
 "Zx" = (
 /obj/machinery/duct,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"ZD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
+"ZF" = (
+/obj/structure/closet/cardboard,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/shovel,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/storage)
 "ZL" = (
 /obj/machinery/growing/tray,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -3611,27 +4402,16 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "ZP" = (
-/turf/closed/wall/r_wall,
+/obj/structure/cable,
+/obj/machinery/power/rtg/portable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 
 (1,1,1) = {"
 aa
 aa
 aa
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 ab
 aa
@@ -3648,6 +4428,7 @@ aa
 aa
 aa
 aa
+ab
 aa
 aa
 aa
@@ -3656,21 +4437,35 @@ aa
 aa
 aa
 aa
-KY
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+aa
 aa
 aa
 ab
 ab
 ab
 ab
-aa
 aa
 "}
 (2,1,1) = {"
 aa
+aa
 ab
-aa
-aa
+ab
+ab
 aa
 aa
 aa
@@ -3700,34 +4495,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
 ab
 aa
 aa
 aa
-Iy
-Iy
-Iy
-ab
-ab
 aa
+aa
+aa
+aa
+aa
+Bw
+Iy
+wQ
+ab
 aa
 "}
 (3,1,1) = {"
 aa
 aa
-ab
+aa
 ab
 ab
 ab
 aa
 aa
 aa
+Iy
 aa
 aa
 aa
@@ -3738,48 +4533,48 @@ ab
 ab
 ab
 Iy
-Bw
-ab
-aa
-aa
-aa
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-aa
-aa
-aa
-ab
-aa
-aa
-aa
-ab
-ab
-ab
-Bw
 Iy
 ab
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+Iy
+aa
+aa
+aa
+aa
+ab
 ab
 aa
+aa
+aa
+aa
+aa
+wQ
+Iy
+Iy
+aa
+aa
+aa
+Iy
+ab
 aa
 "}
 (4,1,1) = {"
 aa
 aa
-ab
-ab
-ab
-ab
 aa
 aa
 aa
+aa
+aa
+aa
+wQ
+Iy
 ab
 aa
 aa
@@ -3790,25 +4585,21 @@ aa
 aa
 ab
 Iy
+Bw
 Iy
+aa
+aa
+aa
+ab
+ab
+ab
 Iy
 aa
 aa
 aa
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
 ab
 ab
-ab
-aa
-aa
 aa
 aa
 aa
@@ -3816,38 +4607,25 @@ ab
 ab
 ab
 ab
-KY
+ab
+ab
+ab
+aa
 aa
 aa
 aa
 aa
 "}
 (5,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
 ab
 aa
 aa
-aa
 ab
-aa
-aa
 ab
 wQ
 Iy
+Bw
 Iy
-KY
-ab
-ab
-ab
 ab
 ab
 ab
@@ -3856,9 +4634,18 @@ aa
 aa
 ab
 aa
+aa
+aa
+wQ
+Iy
+aa
+aa
+aa
 ab
 ab
 ab
+ab
+Iy
 aa
 aa
 aa
@@ -3866,9 +4653,16 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -3878,60 +4672,56 @@ aa
 aa
 aa
 ab
+ab
+Iy
+Iy
+Iy
+Iy
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
 aa
+ab
+ab
+ab
 ab
 ab
 Iy
 Iy
 Iy
 aa
+aa
+aa
 Iy
 Iy
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
+OR
+OR
+OR
+OR
+OR
+OR
+OR
 ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-aa
-aa
-ab
-aa
-aa
-ab
+wQ
 aa
 aa
 aa
 "}
 (7,1,1) = {"
 aa
-aa
-ab
-aa
-aa
 ab
 ab
 ab
@@ -3946,8 +4736,11 @@ ab
 ab
 ab
 ab
-aa
-aa
+ab
+ab
+ab
+ab
+ab
 Iy
 Iy
 ab
@@ -3956,50 +4749,49 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
+Iy
+Bw
+Iy
+wQ
+Iy
+wQ
 ab
 ab
 ab
-aa
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OR
+KT
+ra
+OR
+Og
+vH
+OR
+ab
+ab
+Iy
 aa
 aa
 "}
 (8,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
+wQ
 ab
-KZ
-KZ
-KZ
-KZ
-KZ
-KZ
-KZ
-KZ
-KZ
-KZ
-KZ
-ab
-ab
-ab
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+zI
+zI
+zI
+zI
 ab
 ab
 ab
@@ -4010,6 +4802,8 @@ ab
 ab
 ab
 ab
+Iy
+Iy
 ab
 ab
 ab
@@ -4017,38 +4811,46 @@ ab
 ab
 ab
 ab
+OR
+WL
+yg
+OR
+QW
+sV
+OR
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+Iy
+ab
 aa
 "}
 (9,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
+Iy
 ab
-KZ
+uU
+Fv
+iK
+iK
+Fv
+ic
 Ta
 iK
 iK
 Ta
 wV
-JC
-iK
-iK
-Fv
+uU
 KZ
+tn
+KZ
+Of
+Of
+Of
+Of
+Of
+Of
+Of
+Of
 ab
 ab
 ab
@@ -4057,367 +4859,359 @@ ab
 ab
 ab
 ab
+OR
+OR
+OR
+OR
+OR
+OR
+QA
+OR
+Oc
+ug
+OR
 ab
 ab
+Iy
 ab
 ab
-ab
-ab
-ag
-ag
-ag
-ag
-ag
-ag
-ab
-ab
-aa
-aa
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
 "}
 (10,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
+Bw
 ab
-KZ
+uU
 Ps
 yA
 hr
 Zx
-xf
-oA
+Uw
 iK
 yA
-Pb
-KZ
+hr
+Zx
+xf
+uU
+Tq
+tn
+Tq
+Oe
+eg
+zl
+Jm
+Jm
 CL
-CL
-CL
-CL
-CL
-CL
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
+Tm
 oI
-dc
+oI
+oI
+oI
+oI
+oI
+oI
+oI
+oI
+OR
 lG
 un
 ag
+OR
+xN
+Ay
+OR
+qS
+md
+OR
 ab
 ab
-aa
+Iy
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
 "}
 (11,1,1) = {"
-aa
-aa
-aa
+Iy
 ab
 ab
-ab
-ab
-KZ
+uU
+iK
+iK
+iK
+iK
+Uw
 iK
 iK
 iK
 iK
 xf
-mD
-NF
-iK
-iK
-CL
-CL
-CL
-CL
-CL
-CL
-CL
+uU
+Tf
+Bk
+tn
+Oe
+zl
+zl
+Jm
+Jm
+Eg
 hV
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
+cR
+ei
+Al
+ge
+ei
+an
+ge
+ei
 an
 dc
 rD
 qN
-ag
+Hx
+OR
+tS
+rT
+Zn
+qR
+Op
+OR
 ab
 ab
+Iy
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-ab
-aa
-aa
 "}
 (12,1,1) = {"
-aa
-aa
-aa
-aa
+wQ
 ab
-ab
-KZ
-KZ
+uU
+uU
+Fv
+iK
+iK
+RH
+Uw
 Ta
 iK
 iK
 on
-xf
 qM
-iK
-iK
+uU
+ZF
 kE
-CL
-bT
-bU
-cB
-cB
-Tp
-dw
-an
-ei
-EG
-an
-ei
+Vu
+Oe
+zl
+zl
+Jm
+Jm
+vn
+vn
+ge
 ey
-an
-ei
+zu
+ge
 ey
-an
-vs
+zu
+ge
+ey
+zu
+dc
 Qi
-gF
-gF
-gF
-gF
-gF
+jA
+PN
+OR
+OR
+kF
+OR
+OR
+OR
+OR
 ab
 ab
+Iy
+Iy
 ab
-aa
-ab
-aa
-ab
-aa
-aa
 "}
 (13,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+Iy
 ab
-KZ
+uU
 LH
 TL
 TL
 TL
 jD
-Wf
+XF
+TL
+TL
+TL
+jD
 aw
+Uy
 VY
-VY
-VY
-CL
+kE
+Ql
+Oe
 bU
-bU
-cB
+xQ
 cB
 Va
 dx
-an
-ej
+xx
+ge
+UK
 ez
-an
-ej
+ge
+Ee
 ez
-an
-ej
+ge
+Ee
 ez
-an
-wJ
+dc
 UX
-gF
-wu
+Gw
+kV
 RT
+OR
+FS
+nG
+wu
 yf
-gF
+OR
 ab
 ab
-aa
-aa
-aa
-aa
-ab
-ab
+Iy
+Iy
 ab
 "}
 (14,1,1) = {"
-aa
-aa
-ab
-aa
-aa
-ab
-KZ
-CQ
-sy
-sy
-gp
-KO
-An
-VY
-aG
-aR
-bm
-hU
-bV
-SJ
-cC
-cQ
-df
-dy
-an
-WR
-eA
-an
-ek
-eA
-an
-ek
-NA
-an
-wJ
-UX
-gF
-Cp
-Uj
-AI
-gF
-ab
-ab
-aa
-aa
-ab
-wQ
 Iy
 ab
+uU
+CQ
+sy
+KO
+gp
+sy
+IS
+IS
+Ud
+IS
+BH
+An
+uU
+aR
+bm
+hO
+Oe
+Oe
+Oe
+Oe
+Oe
+dy
+Oe
+ge
+eA
+yz
+ge
+NA
+yz
+ge
+NA
+NX
+dc
+fs
+Rw
+xp
+AR
+OR
+OB
+Uj
+PH
+AI
+OR
+ab
+ab
+Iy
+Iy
 ab
 "}
 (15,1,1) = {"
-aa
+wQ
 ab
-ab
-ab
-ab
-ab
-KZ
+uU
 Ad
 sy
+LI
+LI
+LI
+sG
 VU
 BA
+LI
 tA
-kB
-VY
-aH
+jv
+uU
 aS
 bn
-hU
-qg
-qg
+iw
+TC
+PF
 cD
 qg
 dg
 dz
 fN
-el
-eB
-fN
-el
-eB
-fN
-fN
 ge
-an
-gw
-zi
-gF
+ge
+Jn
+ge
+ge
+Jn
+ge
+ge
+Jn
+dc
+fs
+rB
 lf
 tk
+OR
+kk
+EW
+Cp
 ae
-gF
+OR
 ab
 ab
-aa
-aa
-ab
-Iy
 Iy
 Iy
 ab
 "}
 (16,1,1) = {"
-aa
-ab
 Iy
 ab
-ab
-ab
-KZ
+uU
 NE
 sy
-sy
-gp
 UO
+gp
+sy
+IS
+IS
+Ud
+IS
+wH
 sx
-ml
+Hp
 aT
 aT
-bo
-bE
-bW
+aT
 TC
-cE
-dh
-dh
+TC
+OL
+ne
+ne
 dA
 dR
 em
@@ -4429,163 +5223,164 @@ fE
 fO
 gf
 gl
+Qr
 gx
-gx
+pn
+sw
+ML
 uG
 mW
 Il
-SR
+wy
 gF
-gF
+OR
 ab
-aa
-aa
+ab
 Iy
 Iy
-Iy
-aa
-aa
+ab
 "}
 (17,1,1) = {"
-ab
-ab
-ab
-wQ
 Iy
 ab
-KZ
+uU
 wF
 vL
 vL
 vL
 vc
-PM
-VY
-aJ
+pX
+vL
+vL
+vL
+vc
+Zb
+uU
 aU
 bp
 bF
 bX
-cF
-cF
-cS
-di
-an
+eS
+dG
+dG
+dG
+FR
 dS
-pP
-pP
-pP
-pP
-pP
-pP
+fP
+fP
+fP
+fP
+fP
+fP
 fP
 Qt
 gm
 gy
 gG
-gF
+Ks
 xI
+rx
+OR
+EL
 Az
 JV
 ZN
-gF
+OR
 ab
-aa
-aa
-Bw
+ab
 Iy
 Iy
-ab
 ab
 "}
 (18,1,1) = {"
-aa
-ab
-Iy
-Iy
 ab
 ab
-KZ
-KZ
+uU
+uU
+Ve
+iK
+iK
+sd
+Uw
 Nw
 iK
 iK
 Sp
 xf
-VY
-aK
+uU
 aV
 bq
 bG
 hU
-cj
+TC
 cG
-cF
+dj
 dj
 dC
-cF
+rv
+rv
 en
 eD
 eD
 eD
 eD
-Dp
-ag
-ag
-ag
-ag
-ag
-gF
-gF
-gF
-gF
-gF
-gF
+ds
+oI
+oI
+OR
+OR
+OR
+OR
+OR
+OR
+OR
+OR
+OR
+OR
+OR
 ab
-aa
-aa
+ab
 Iy
 Iy
-wQ
-ab
 ab
 "}
 (19,1,1) = {"
-aa
-Iy
-Iy
-Bw
 ab
 ab
 ab
-KZ
+uU
+iK
+yA
+hr
+Zx
+Uw
 iK
 yA
 CZ
 Zx
-hv
-VY
-aL
+xf
+uU
 aW
 br
 bH
-hU
-ck
+hH
+TC
 cH
-cT
-dk
+cI
+cI
 dD
 Nl
 pP
+ds
 eE
 eR
 ff
 fq
-Dp
-fQ
+ds
 fV
-fV
-Dp
+ne
+or
+ds
 ab
 ab
 ab
@@ -4595,91 +5390,90 @@ ab
 ab
 ab
 ab
+ab
+ab
+Iy
 aa
 aa
-ab
-ab
-ab
-ab
 "}
 (20,1,1) = {"
-aa
 ab
 ab
-aa
-aa
-aa
 ab
-KZ
+uU
 Ps
 iK
 iK
 iK
+tm
+iK
+iK
+iK
+iK
 Mv
-VY
-hA
-yQ
-yQ
-yQ
-tH
+uU
+sj
+Ag
+Ag
+Ag
 cl
-cI
-zv
-fT
+uB
+cT
+oJ
 dF
 dV
-pP
-pP
-pP
-pP
-pP
+Kh
+ds
+ds
+ds
+ds
+ds
 Dp
-fR
 fT
-wI
-Dp
-Dp
-Dp
+ne
+It
+ds
+ds
+ds
+ab
 ab
 Iy
 Iy
-Iy
 ab
 ab
 ab
-aa
-aa
+ab
 aa
 aa
 aa
 aa
 "}
 (21,1,1) = {"
+ab
 aa
 ab
-ab
-KY
-aa
-Iy
-ab
-KZ
+uU
+Ve
+iK
+iK
+Ve
+Ot
 Nw
 iK
-mg
+iK
 Nw
-Nc
 gs
-OD
+uU
 aX
 bs
 bI
 xV
+Ga
 LB
-cI
 cU
-fT
-dF
-hh
+Qj
+xw
+dV
 eo
 eF
 Rs
@@ -4687,8 +5481,9 @@ UH
 hk
 fF
 fS
-fT
-fT
+HN
+ne
+ne
 gz
 gH
 gQ
@@ -4696,40 +5491,39 @@ Iy
 Iy
 Iy
 Iy
+Iy
+Iy
+aa
+aa
+aa
+aa
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
 "}
 (22,1,1) = {"
 aa
 aa
-aa
-aa
-aa
-Iy
 ab
-KZ
-KZ
-KZ
-OD
-OD
-OD
-OD
-OD
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
+uU
 aY
 bt
 bJ
 bY
+Ap
 cn
-cK
 cV
-cF
+Yv
 dG
 dW
 ep
@@ -4739,8 +5533,9 @@ fg
 fr
 fG
 hm
-fT
-fT
+mE
+ne
+ne
 gz
 gI
 gQ
@@ -4749,31 +5544,30 @@ Iy
 Iy
 Iy
 Iy
+Iy
+Iy
+aa
+aa
+aa
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
 "}
 (23,1,1) = {"
 aa
 aa
-aa
-aa
-aa
-Iy
 ab
 ab
-CA
-Bg
-OD
+ab
+ab
+ab
+ab
+ab
+OX
+OX
 ah
 ao
 ax
-yQ
+Ag
 Db
 bu
 bK
@@ -4781,79 +5575,79 @@ bZ
 co
 cL
 cW
-dH
+Tc
 dH
 hi
-eq
-eH
-eT
+Dq
+ho
+ho
 eT
 EP
+ho
 eq
-fU
-fT
-gn
-Dp
-Dp
-Dp
+nv
+ne
+PT
+ds
+ds
+ds
+ab
+ab
+ab
 ab
 ab
 Iy
 Iy
-Iy
-Iy
+aa
+aa
 ab
 ab
-aa
-aa
-aa
-aa
 aa
 "}
 (24,1,1) = {"
+ab
 aa
-aa
-aa
-aa
-aa
-aa
+Iy
 ab
 ab
-CA
-Bg
-OD
+ab
+ab
+ab
+ab
+OX
+OX
 ai
 ap
 ay
-aM
+Ag
 ba
 bv
 bL
 yQ
-pP
-pP
-pP
-hT
+Ag
+fP
+fP
+fP
 dI
-dU
-eq
-eI
+dV
+lk
+ho
 eU
 Et
 ie
 hX
 hn
-fV
-YY
-Dp
+ZD
+ne
+or
+ds
 ab
 ab
 ab
 ab
 ab
 ab
-Iy
-Iy
+ab
 ab
 ab
 aa
@@ -4866,26 +5660,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Iy
+Iy
+Iy
 ab
 ab
-CA
-Bg
-OD
+ab
+OX
+OX
 ai
 aq
 az
 aN
 bb
-bw
 bM
-yQ
-cq
+bM
+ob
+Ag
 cM
 cX
-pP
+yN
 hg
 dY
 er
@@ -4893,22 +5687,22 @@ eJ
 eV
 fi
 fu
-eq
+uM
 ho
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
 ab
-Iy
-Iy
 ab
 ab
-aa
 aa
 aa
 aa
@@ -4920,48 +5714,48 @@ aa
 aa
 aa
 aa
+Iy
 ab
 ab
 ab
-CA
-Bg
-OD
+OX
+OX
 ah
 ar
 aA
-yQ
+Ag
 bc
 bu
-bN
-yQ
-cr
-cN
-cY
-dp
-dH
+bu
+EH
+Ag
+fP
+fP
+fP
+fP
 cE
 es
 eK
 eW
 fj
 fv
-eq
-fW
+zb
+ho
+gK
 gh
 gq
-ZP
+QI
 gJ
 gR
 gZ
 gZ
-ZP
+oC
+oC
+QI
 ab
-Iy
-Iy
 ab
 ab
-aa
-aa
+ab
 aa
 aa
 aa
@@ -4969,14 +5763,14 @@ aa
 (27,1,1) = {"
 aa
 aa
+aa
 ab
 aa
 aa
+Iy
 ab
 ab
-ab
-CA
-Bg
+Ob
 Ob
 Ob
 Ob
@@ -4985,35 +5779,35 @@ Ob
 bd
 bx
 bO
-yQ
-iA
+LC
+Ag
 cO
 cZ
 dq
 cu
 cF
-eq
-eL
+rv
+ho
 eX
 fk
 fw
-eq
-fX
+Wd
+ho
+JR
 gh
 gr
-ZP
+QI
 gK
 gR
 gZ
-ha
 ZP
+oC
+oC
+QI
 ab
-Iy
-Iy
-Iy
 ab
-aa
-aa
+ab
+ab
 aa
 aa
 aa
@@ -5024,53 +5818,54 @@ aa
 aa
 aa
 aa
+aa
+Iy
 ab
 ab
-ab
-CA
+Ob
 Bg
 Ob
-sa
 as
+qT
 aB
-Ob
-yQ
-yQ
-yQ
-yQ
-pP
-pP
-pP
-pP
-dK
+OX
+Ag
+Ag
+Ag
+Ag
+fP
+fP
+fP
+fP
 eb
-eq
-eq
-eq
-eq
-eq
-eq
-fY
+Lm
+ho
+ho
+ho
+ho
+ho
+ho
+Ik
 gi
 Ik
-ZP
+QI
 gL
-ZP
-ZP
-ZP
-ZP
+QI
+QI
+QI
+QI
+QI
+QI
 ab
 ab
 Iy
-Iy
+aa
+aa
 ab
-aa
-aa
-aa
-aa
 aa
 "}
 (29,1,1) = {"
+aa
 aa
 ab
 wQ
@@ -5079,148 +5874,147 @@ aa
 aa
 ab
 ab
-CA
-Bg
 Ob
+Bg
 ak
 at
+qB
 aC
-aO
 be
 by
 bP
 ca
 ct
-cP
-cP
-cP
-cP
-cE
+oE
+kP
+kP
+kP
+kP
 et
 cP
 eY
-fl
-fx
+lg
+gA
 hl
 fZ
 gj
-fl
+ud
 gA
 fl
 gT
-ZP
+so
+QI
 hb
-ZP
+QI
 ab
 ab
 ab
 Iy
+Iy
 aa
-aa
-aa
-aa
-aa
+ab
+ab
 aa
 "}
 (30,1,1) = {"
+aa
 ab
 ab
 Iy
 Bw
 Iy
 aa
-aa
 ab
-CA
+ab
+Ob
 Bg
 Ob
 al
 au
 De
 aP
-bf
-bz
-cF
-bz
-cu
-bz
-bz
-bz
-cu
-cF
-bz
+FZ
+eZ
+SB
+eZ
+eZ
+eZ
+eZ
+dC
+eZ
+eZ
 bz
 eZ
 fm
 fy
 fH
-fH
-fH
+gu
+gu
 gu
 gB
 gN
 gU
+MB
 gY
 hc
-ZP
+QI
 ab
 ab
 ab
 Iy
 aa
 aa
-aa
-aa
+ab
 aa
 aa
 "}
 (31,1,1) = {"
 aa
+aa
 ab
 ab
 Iy
 Iy
 aa
-aa
 ab
-CA
+ab
+Ob
 Bg
 CY
-am
 sQ
+wM
 aE
 Ya
-bg
 bA
-bQ
 bA
-cv
-aQ
-da
-da
+mN
+bA
+bA
+Ya
+fa
 dM
 ee
-da
+hL
 da
 fa
 Rj
 fz
 fI
-ga
-fI
-fz
+gO
+pS
+gO
 fI
 gO
 gV
-ZP
+St
+QI
 hd
-ZP
+QI
 ab
 ab
 ab
-Iy
 ab
-aa
+ab
 aa
 aa
 aa
@@ -5228,6 +6022,7 @@ aa
 "}
 (32,1,1) = {"
 aa
+aa
 ab
 ab
 Iy
@@ -5235,23 +6030,22 @@ wQ
 aa
 ab
 ab
-CA
+Ob
 Bg
 Ob
-AZ
+Ey
 rz
 Bb
 Ya
 bh
-bB
-sL
+BW
 cd
 cw
 aQ
-db
+Ya
 dt
 dN
-ef
+hL
 ev
 Ht
 LO
@@ -5264,13 +6058,13 @@ Jp
 gC
 gb
 gW
-ZP
-ZP
-ZP
+yy
+QI
+QI
+QI
 ab
 ab
 ab
-Iy
 Iy
 ab
 aa
@@ -5281,15 +6075,16 @@ aa
 (33,1,1) = {"
 aa
 aa
+aa
 ab
 ab
 aa
 aa
 ab
 ab
-CA
+Ob
 Bg
-Bg
+AZ
 Ob
 Ob
 Ob
@@ -5299,32 +6094,31 @@ bC
 sL
 sL
 cx
-aQ
-wK
+Ya
 du
 dO
-po
-ew
-eO
-LO
-ZP
+hL
+OY
+Ht
+KP
+fo
+QI
 fB
 fK
 hq
-ZP
+QI
 fB
 fK
 hq
-ZP
-ZP
+QI
+QI
 ab
 ab
 ab
 ab
 ab
 Iy
-Iy
-ab
+wQ
 aa
 aa
 aa
@@ -5333,42 +6127,43 @@ aa
 (34,1,1) = {"
 aa
 aa
-ab
-ab
-aa
 aa
 ab
 ab
-CA
-CA
+aa
+ab
+ab
+ab
+Ob
 Bg
 Bg
 Bg
 Bg
-aQ
+Bg
+Ya
 bj
 bC
 bR
 sL
 cy
-aQ
-Mp
+Ya
 dv
 Yo
-eh
+hL
 ex
-eP
-LO
-ZP
+Ht
+nA
+fo
+QI
 fC
 fL
 qm
-ZP
+QI
 gv
 gD
 gP
-ZP
-ZP
+QI
+QI
 ab
 ab
 ab
@@ -5376,7 +6171,6 @@ ab
 ab
 Iy
 Iy
-ab
 aa
 aa
 aa
@@ -5392,44 +6186,44 @@ aa
 ab
 ab
 ab
-CA
-CA
-CA
-CA
-CA
-aQ
+Ob
+Ob
+Ob
+Ob
+Ob
+Ob
+Ya
 FI
 bC
 MJ
 sL
 xg
-aQ
-de
-de
-de
-de
+Ya
+pu
+qc
+hE
 de
 hW
-LO
-ZP
+LE
+fo
+QI
 lj
 fM
 lj
-ZP
+QI
 fD
 gE
 fD
-hY
-ZP
+JG
+QI
+ab
 ab
 ab
 ab
 ab
 ab
 Iy
-Iy
-Iy
-aa
+wQ
 aa
 aa
 aa
@@ -5441,6 +6235,7 @@ aa
 aa
 aa
 aa
+aa
 ab
 ab
 ab
@@ -5449,38 +6244,37 @@ ab
 ab
 ab
 ab
-aQ
+Ya
 Cf
 bC
 MJ
 cf
 ZL
-aQ
-ab
-ab
-ab
-ab
-ab
-ab
+Ya
+mt
+vo
+hL
+jx
+ew
 fc
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
+fo
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
 ab
 ab
 aa
 ab
 ab
 ab
-Iy
-Iy
+Bw
 aa
 aa
 aa
@@ -5493,6 +6287,8 @@ aa
 aa
 aa
 aa
+aa
+aa
 ab
 ab
 ab
@@ -5500,38 +6296,36 @@ ab
 ab
 ab
 ab
-ab
-aQ
+Ya
 Em
 bC
 MJ
 sL
 MJ
-aQ
-ab
-ab
-ab
-ab
-Iy
-Iy
-fd
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
+Ya
+vj
+po
+hL
+jy
+nY
+nk
+fo
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
+QI
 ab
 ab
 ab
 aa
 aa
-aa
-aa
-aa
+ab
+ab
 aa
 aa
 aa
@@ -5541,11 +6335,12 @@ aa
 (38,1,1) = {"
 aa
 aa
-aa
-aa
 ab
 aa
 aa
+ab
+aa
+aa
 aa
 ab
 ab
@@ -5553,31 +6348,30 @@ ab
 ab
 ab
 ab
-aQ
+Ya
 lB
 bD
 bC
 cg
 oV
-aQ
+Ya
+hL
+QM
+hL
+QM
+hL
+qt
+fo
+QI
 ab
 ab
 ab
 ab
-Iy
 ab
 ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
 aa
 aa
 aa
@@ -5594,6 +6388,7 @@ aa
 aa
 aa
 aa
+aa
 ab
 ab
 aa
@@ -5605,22 +6400,20 @@ ab
 ab
 ab
 ab
-hB
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-ab
-Iy
-Iy
-Iy
-Iy
-ab
-ab
-ab
-ab
+qQ
+Ya
+Ya
+Ya
+Ya
+Ya
+Ya
+XK
+Bv
+OM
+Bv
+Jc
+Dh
+fo
 ab
 ab
 ab
@@ -5629,7 +6422,8 @@ ab
 ab
 ab
 ab
-aa
+ab
+ab
 aa
 aa
 aa
@@ -5646,6 +6440,7 @@ aa
 aa
 aa
 aa
+aa
 ab
 ab
 aa
@@ -5654,7 +6449,23 @@ aa
 aa
 aa
 aa
-aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+Ya
+hL
+hL
+hL
+hL
+hL
+hL
+fo
 ab
 ab
 ab
@@ -5665,32 +6476,15 @@ ab
 ab
 ab
 ab
-Iy
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
 ab
 aa
 aa
 aa
 ab
 aa
+aa
+aa
+ab
 aa
 aa
 "}
@@ -5698,6 +6492,7 @@ aa
 aa
 aa
 aa
+aa
 Iy
 ab
 aa
@@ -5708,40 +6503,39 @@ aa
 aa
 aa
 aa
-aa
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fo
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+En
 ab
 ab
 Iy
-ab
-Iy
-Iy
-ab
-Iy
-Iy
-Iy
-Iy
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-Iy
-wQ
-aa
-aa
-aa
-ab
 aa
 aa
 aa
-KY
+ab
+aa
+aa
+aa
 aa
 aa
 aa
@@ -5750,6 +6544,7 @@ aa
 aa
 aa
 aa
+aa
 wQ
 Iy
 Bw
@@ -5761,18 +6556,11 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-Iy
-Iy
-Iy
-Iy
 aa
-aa
-aa
-Bw
+ab
+ab
+ab
+ab
 Iy
 Iy
 ab
@@ -5781,11 +6569,18 @@ ab
 ab
 ab
 ab
+fd
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
 Iy
-Iy
 aa
 aa
 aa
@@ -5793,65 +6588,65 @@ aa
 aa
 aa
 Iy
-Iy
+wQ
 ab
-aa
 aa
 "}
 (43,1,1) = {"
 aa
+aa
+ab
+ab
+Iy
+Iy
+Iy
+wQ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 Iy
 Iy
 Iy
 wQ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Iy
+ab
+ab
 ab
 ab
 Iy
-Iy
 ab
-aa
-aa
-aa
-aa
-Iy
-Iy
 Iy
 wQ
 Iy
+ab
+ab
+ab
+ab
+ab
 Iy
-ab
-ab
-ab
+Iy
+aa
 aa
 ab
-ab
+Iy
 Iy
 Bw
-aa
-aa
-ab
-wQ
 Iy
-Iy
-Bw
 Iy
 ab
-aa
 aa
 "}
 (44,1,1) = {"
 aa
+aa
 ab
 ab
 ab
@@ -5867,17 +6662,17 @@ aa
 ab
 aa
 aa
-ab
-ab
-Iy
-Iy
 aa
-aa
-KY
+ab
+wQ
+Iy
 aa
 aa
 aa
 aa
+aa
+wQ
+Iy
 Iy
 Iy
 Iy
@@ -5886,25 +6681,25 @@ Iy
 Iy
 ab
 aa
-ab
-ab
-ab
-ab
+Iy
+Iy
+Iy
 aa
-KY
-ab
-ab
-Iy
-Iy
-Iy
-ab
-ab
 aa
+aa
+ab
+ab
+wQ
+Iy
+Iy
+ab
+ab
 aa
 "}
 (45,1,1) = {"
 aa
 aa
+aa
 ab
 ab
 Iy
@@ -5925,18 +6720,18 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
+aa
+aa
 aa
 aa
 Iy
+Bw
 Iy
 Iy
 Iy
+wQ
 Iy
-Iy
-Iy
+aa
 aa
 aa
 aa
@@ -5951,7 +6746,6 @@ ab
 ab
 ab
 ab
-aa
 aa
 "}
 (46,1,1) = {"
@@ -5959,6 +6753,7 @@ aa
 aa
 aa
 aa
+aa
 Iy
 Iy
 ab
@@ -5975,33 +6770,32 @@ aa
 aa
 aa
 aa
+aa
+Iy
+Bw
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-aa
 aa
 aa
 aa
@@ -6017,14 +6811,6 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
 aa
 ab
 ab
@@ -6033,11 +6819,19 @@ ab
 aa
 aa
 aa
-ab
+aa
+aa
+Iy
+wQ
 ab
 ab
 ab
 aa
+aa
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -6069,17 +6863,10 @@ aa
 aa
 aa
 aa
+aa
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -6093,6 +6880,10 @@ aa
 aa
 aa
 aa
+aa
+ab
+ab
+ab
 ab
 aa
 aa
@@ -6100,6 +6891,10 @@ aa
 ab
 aa
 aa
+aa
+ab
+aa
+aa
 ab
 aa
 aa
@@ -6107,7 +6902,6 @@ aa
 aa
 aa
 ab
-aa
 aa
 "}
 (49,1,1) = {"
@@ -6119,6 +6913,7 @@ aa
 aa
 aa
 aa
+aa
 ab
 aa
 aa
@@ -6140,8 +6935,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+ab
 ab
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -3008,6 +3008,10 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/closet/l3closet/scientist,
+/obj/item/clothing/suit/bio_suit/interdyne,
+/obj/item/clothing/head/bio_hood/interdyne,
+/obj/item/construction/plumbing/research,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "xf" = (
@@ -3349,7 +3353,8 @@
 "CL" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/secure/gear{
-	name = "T4 Parts"
+	name = "T4 Parts";
+	req_access = list("syndicate")
 	},
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
@@ -3422,7 +3427,8 @@
 "Eg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/secure/science{
-	name = "Cleaning Supplies"
+	name = "Cleaning Supplies";
+	req_access = list("syndicate")
 	},
 /obj/item/mop/advanced,
 /obj/item/mop/advanced,


### PR DESCRIPTION
## About The Pull Request
Right, after my previous PR disaster on the last two, this PR basically makes a crapload of new changes to the Syndicate Deep Storage facility. Mainly in 3-4 massive changes added that completely remodel the entire base. That is the Secured Storage, Xenobio, medbay, and detonation room. I have focused a majority of my effort improving those 4 areas but mainly in the first 3 areas because frankly, despite being considered a bioweapons facility it... Didnt really have much going for it.

So with what I mapped out I furthered the Deep storage medbay by expanding the medbay itself which came with a huge assortment of upgrades. Then comes the Secured Storage which is... Extremely different now. I'll just begin to show photos of everything to give an example of what has changed in the map because It is an extremely large change and improvement to basically the entire base and I think its easier to explain the changes that way.

The first I'll talk about that the least changed one and its the self destruct base.
<img width="511" height="445" alt="image" src="https://github.com/user-attachments/assets/d0279cfe-9de8-4ce4-86ad-468b5a107096" />
The area simply just has a extra window and turret for added defense, however I did have to cut off the long grille defense due to the fact that another turret was in the way. Regardless that still a fairly important change.

Next is Xenobio and it been given some new changes mainly to its chamber.
<img width="873" height="748" alt="image" src="https://github.com/user-attachments/assets/c8643a6e-7a02-4f87-803d-23f96c5fb3ab" />
Thats right. It has FOUR rooms now and is completely squared off, no weird awkward room in the corner it completely square... Mostly. That and well the chambers are properly set up and ducts are linked to the vents to suck out ooze. Hopefully there isnt any issues with it. This is a fairly big change as it required an extra cell and required that Xenobio itself needed to be extended upwards for it to fit in the base.

Now to talk about relatively minor-moderate changes involved in the main area and storage facilities. 
<img width="933" height="690" alt="image" src="https://github.com/user-attachments/assets/d4c65b44-043e-4811-86a8-6da68d23d4d2" />
Both the storage areas have been improved and expanded allowing its true namesake as "Deep storage" to literally be, actually good at storing stuff. Some equipment has been shuffled around but in general things that didnt make sense or clogged up storage like the music players were removed. The lobby bar also has been given improvements in that, the cigar vendor is now a syndicate one and there an actual alcoholic vendor for beer and such. Along with imported food vendor for... Sushi or something.

<img width="753" height="439" alt="image" src="https://github.com/user-attachments/assets/3e4b0b5f-0337-445b-a5b1-e5f317e3b42d" />
This is the second most important thing I've added to the Deep storage facility. The medbay itself? Completely changed so that it actually a functional and proper medbay that isnt extremely cramped. IT has extra medical kits, vendors, surplus limbs, generally everything needed for a functional decent medbay. Saline drips were added, a clothing medidrobe for style because well, its a cool and neat medbay.

<img width="501" height="501" alt="image" src="https://github.com/user-attachments/assets/0b22052d-fa95-4571-a91a-030acdac0e50" />

On top of that Chems has been upgraded fairly heavily and that a recent issue with it, being that the locker that comes in with the base was actually set to on station chemist access instead of the syndicates, requiring the comms agent with an Esword to break it. Now that has been fixed on top of having mutliple beakers, bluespace beakers, and generally things to make bombs or chemical weapons with because its a bioweapon facility.

<img width="209" height="215" alt="image" src="https://github.com/user-attachments/assets/ec73a83a-47f5-49ae-b135-34441689a823" />
It is this locker to be precise which has been moved by the way.

<img width="518" height="595" alt="image" src="https://github.com/user-attachments/assets/d0416e3e-7475-4f5b-ab0e-599eabbb1062" />
Next up is virology and I tried making it as equal as I could to the station virology and gave it every tool needed. Im not good with Virology and never have worked on it but I believe that it contains every tool needed, petri dishes, virus foods, scanners, ETC, monkey cubes. And with this I believe players would actually start making bioweapons on it. Plus its an extremely major addiction to it and I think its neat that people can mess around with this if they'd like.

<img width="800" height="577" alt="image" src="https://github.com/user-attachments/assets/40bd53a7-938a-4e90-84d6-eba007fcb50c" />
This is possibly the most extensive and probably controversial thing that will come of this. The tech storage of the entire base has been heavily remapped. A turret is in the center inside a wall so it can shoot around with pepperspray mount on but it there just for security reasons incase yall get pepperspray. Otherwise yes, there is now TWO syndicate modsuits and the previous interdyne modsuit was removed due to the fact that interdyne modsuits... are not shockproof, which in a station that has a kit to set up solars is a bad idea and was frankly quite stupid. On top of that yes. They are given a Syndicate sol rifle, however it is unloaded and the mags given are two 30 rounders which combined with the fact that the walls are... a pain in the ass to breach I think makes it not as ideal to try to get especially with how defended the base is. This is also where the headsets, armor, and ammo of the previous deep storage crates are now placed because previously, explorer have broken into that base before to steal comms and now that it in a secured area makes it really safe and troublesome to get. Along with that a GPS crate has  been added so people can explore their local sector as they are technically authorized for it. Along with that their secured storage has alot more medical supplies and items incase you want to mess around with it! 

Some other changes I have to bring up.
<img width="399" height="394" alt="image" src="https://github.com/user-attachments/assets/0da1514f-bcad-4eeb-9a12-2f8ca0159c0a" />
This is just a small change to the command room, making it more snazzy to be in and making it fit the theme of syndicate outposts. The two cabinets to the left are medical and sec records while the one on the right is empty for whatever purpose a player might have. Shutters also have been changed so it faces eastwards instead of downwards which looked strange when shutters closed.

<img width="326" height="322" alt="image" src="https://github.com/user-attachments/assets/15a0d504-c13d-47d0-8818-28d514b3401b" />
Toilets were given a small change and now have syndicate soap bars. On top of being split into two other rooms. Not really a major change honestly.

<img width="628" height="681" alt="image" src="https://github.com/user-attachments/assets/b9ce92dc-5ea5-4dda-a0fe-bb0957bdbdd0" />

The engineering bay has been given considerably more RTG so it stays powered up longer due to now extra power draw it requires. On top of that it has been given more equipment in the lockers such as syndicate toolbelts, toolboxes, and a fire locker that has ADVANCED fire repellant supplies because why not? Its an advanced station that works with explosives and fire.

<img width="457" height="554" alt="image" src="https://github.com/user-attachments/assets/4a5ac53f-ba92-4abd-a1b0-69e3647bb29c" />
Kitchen has been given more stuff to cook with and the lockers inside have more crap to them so its an actual kitchen players can use to cook with. Like to mention it has it now has ingredient boxes and eggs and everything else required for a kitchen. 

<img width="334" height="556" alt="image" src="https://github.com/user-attachments/assets/8447a8a6-3943-42b0-87d0-62c6f6111991" />
Dorm rooms have been improved. Frankly because it just felt small and... Uncozy to be in. Thus a bed was added under the sleep along with bedsheets and some other equipment that the researchers would need in their closets. 

All in all that basically everything mentioned and there might be further map refinements as problems are brought on. Otherwise there isnt exactly much else to explain other than the fact that this map is pretty different now.


## Why It's Good For The Game
The Syndicate ghost roles have taken a fairly severe hit even now because of some removal due to... Bad actors abusing the equipment given to them in the game. With this major mapping change I feel like its fair to both, improve on many aspects of the map as well as to give more chances for players to mess around. My additional reasoning is that. In my opinion of playing Ghost roles for so long that Deep Storage is practically the 2nd most played ghost role ever, it has everything you'd need to fool around but not enough to actually want to go further, it was a little bland and with the loss of its techfab it pretty much began to die out and was never really worth playing it.

With this new mapping change I think it makes it way more viable to mess around with and to play as now it has both, modsuits to fly around with and do work in, self defense guns and protection that make it easy to boot off wanders from touching your loot, and just general quality of life improvements that wouldn't be seen in a while. Thus with these stated out I believe that on why its good for the game is in summary:

Syndicate roles were given a slight beating, They began to become slightly unpopular in recent weeks and months, I added many major changes and quality of life improvements to the map which I believe is beneficial in making ghost roles fun again. 

## Testing
I ran it through local test and got a few issues solved. No runtimes were spotted and considering that its a map there shouldnt be any groundbreaking issues. Actually managed to finally work the PR now so that it won't give me a headache.

## Changelog
:cl:
add: Added more Medical supplies in Deep Storage such as a syndicate combat medical kit and a combat surgical kit!
add: Added more items in Deep Storage closet such as operation kits because for some reason the ghost roles lack them.
del: Removed generally crap items out of the base.
del: Removed a syndicate surgical duffle bag kit.
qol: Removed some generally unneeded items like cassette players out of the boxes in Deep Storage.
map: fixed a huge majority of the previously old Deep Storage pipe system which had more than 30-40 percent of all pipes inside a wall. Most are fixed now with only one system of pipes still being in a wall that links to outputting waste gas.
map: added a new Virology and containment unit for Deep Storage, features all the tools needed to operate it.
map: modified the old secured storage into two new chambers in Deep Storage. Classified storage, and Secured Storage each containing their own equipment.
map: modified Medbay by adding upgraded vendors, expanding the space inside deep storage medbay center, and adding additional equipment inside for use.
map: added two syndicate modsuit storage units in Secured Storage of Deep Storage, also moved pretty much everything else that was old into that area.
map: added a small emergency defense armory in Deep storage Classified storage containing a empty syndicate Sol rifle with 2 mags of 30 round sol mags with ammo to boot. Also moved the other sensitive equipment like headsets and ammo inside which is walled off with reinforced walls and reinforced plasma windows.
map: added extra Deep storage RTG to balance the extra use of power.
map: expanded Deep Storage Xenobio by giving it an extra pen as well as smoothing out the place.
add: more food in the kitchen to cook with.
map: modified Deep Storage dorms to feature beds and bedsheets incase players need to SSD or do whatever. 
qol: Changed much of the access in Deep Storage to feature syndicate access such as air alarms and certain lockers and storages. No more will you have your shit stolen or be locked out of.
del: Deleted alot of flares and flashlights that weren't needed and replaced much of the flares with boxed ones instead.
map: Deep storage engineering now has a plethora of actual tools and advanced firefighting supplies!
add: More frontier items to build and use it with! 
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
