### PR TITLE
fixes cyborgs omni-toolset unable to pull out organs

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -194,7 +194,12 @@
 			if(isnull(chosen_organ))
 				return SURGERY_STEP_FAIL
 			target_organ = chosen_organ
-			if(user && target && user.Adjacent(target) && user.get_active_held_item() == tool)
+			if(user && target && user.Adjacent(target))
+				var/obj/item/held_tool = user.get_active_held_item()
+				if(held_tool)
+					held_tool = held_tool.get_proxy_attacker_for(target, user)
+				if(held_tool != tool)
+					return SURGERY_STEP_FAIL
 				target_organ = organs[target_organ]
 				if(!target_organ)
 					return SURGERY_STEP_FAIL

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -194,7 +194,7 @@
 			if(isnull(chosen_organ))
 				return SURGERY_STEP_FAIL
 			target_organ = chosen_organ
-			if(user && target && user.Adjacent(target))
+			if(target && user?.Adjacent(target))
 				var/obj/item/held_tool = user.get_active_held_item()
 				if(held_tool)
 					held_tool = held_tool.get_proxy_attacker_for(target, user)


### PR DESCRIPTION

## About The Pull Request
Cyborg omnitools correctly can pull out organs via organ manipulation.

Closes #11446

## Why It's Good For The Game
Bugfix.

## Testing
Completed organ manipulation.

<img width="455" height="67" alt="image" src="https://github.com/user-attachments/assets/b3212fa0-ecba-4308-9781-78891fc4c4e4" />

<img width="153" height="149" alt="image" src="https://github.com/user-attachments/assets/a64e0820-b524-4d83-967a-d6647b2ac1fd" />

## Changelog
:cl:
fix: Cyborg surgery omni-toolset now can pull organs via organ manipulation as intended.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
