### PR TITLE
Fixes changeling plasmemes igniting in chitinous armour

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -543,6 +543,7 @@
 	icon_state = "lingarmor"
 	inhand_icon_state = null
 	item_flags = DROPDEL
+	clothing_flags = PLASMAMAN_PREVENT_IGNITION
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	armor_type = /datum/armor/armor_changeling
 	flags_inv = HIDEJUMPSUIT
@@ -572,6 +573,7 @@
 	icon_state = "lingarmorhelmet"
 	inhand_icon_state = null
 	item_flags = DROPDEL
+	clothing_flags = PLASMAMAN_PREVENT_IGNITION
 	armor_type = /datum/armor/helmet_changeling
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEEYES|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
 	flags_cover = PEPPERPROOF


### PR DESCRIPTION

## About The Pull Request
As title
Fixes issue #11441
## Why It's Good For The Game
Plasmemes not being able to use their antag abilities is sucky
## Testing

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing
. -->
Unrelated walkman code was runtiming, but all dandy otherwise.
First one is pre-fix, other one is post-fix

https://github.com/user-attachments/assets/1383f034-4768-48bc-8091-b383d53f0e4a

https://github.com/user-attachments/assets/3d5dd873-d870-4b82-9dd6-635cf6e12313
## Changelog
:cl:
fix: Changeling plasmamen igniting when using their chitinous armour.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
