### PR TITLE
fixes diagnostic hud implants not working

### DIFF
--- a/code/modules/mod/modules/modules_visor.dm
+++ b/code/modules/mod/modules/modules_visor.dm
@@ -53,7 +53,7 @@
 		from advanced machinery, exosuits, and other devices, allowing the user to visualize current power levels \
 		and integrity of such. They say these also let you see behind you."
 	icon_state = "diaghud_visor"
-	hud_type = DATA_HUD_DIAGNOSTIC_ADVANCED
+	hud_type = DATA_HUD_DIAGNOSTIC_BASIC
 	visor_traits = list(TRAIT_DIAGNOSTIC_HUD)
 
 //Security Visor - Gives you a security HUD.

--- a/monkestation/code/modules/cybernetics/augments/eye_implants.dm
+++ b/monkestation/code/modules/cybernetics/augments/eye_implants.dm
@@ -80,7 +80,7 @@
 	name = "diagnostic HUD implant"
 	desc = "These cybernetic eye implants will display a diagnostic HUD over everything you see."
 	icon_state = "eye_implant_diagnostic"
-	HUD_type = DATA_HUD_DIAGNOSTIC_ADVANCED
+	HUD_type = DATA_HUD_DIAGNOSTIC_BASIC
 
 /obj/item/organ/internal/cyberimp/eyes/hud/security/syndicate
 	name = "Contraband Security HUD Implant"


### PR DESCRIPTION

## About The Pull Request
this replaces the DATA_HUD_DIAGNOSTIC_ADVANCED in the cybernetic eye implants and diagnostic visor module with DATA_HUD_DIAGNOSTIC_BASIC. 
## Why It's Good For The Game
fixes 
#11422 
#11389 
#10291 
#10340 

DATA_HUD_DIAGNOSTIC_ADVANCED is broken right now in that it doesn't show the things the basic one does (like borg charge and HP) and this means they're at least functional until someone can merge https://github.com/tgstation/tgstation/pull/84984 to hopefully fix it
## Testing
## Changelog
:cl: suffering intensfies
fix: diagnostic hud implants and modsuit visors now let you see cyborg charge and HP properly
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
