### PR TITLE
[BOUNTY] Blind people can use health analyzers now

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -49,7 +49,7 @@
 	return BRUTELOSS
 
 /obj/item/healthanalyzer/attack_self(mob/user)
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src))
 		return
 
 	scanmode = (scanmode + 1) % SCANMODE_COUNT


### PR DESCRIPTION
## About The Pull Request
Blind already has a variety of downsides, being able to use health analyzers makes it slightly better

## Why It's Good For The Game
no longer bricked from doing doctor stuff as a blind person

## Testing
Tested in game, works fine
## Changelog

:cl:
balance: The blind can use health analyzers now
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
