### PR TITLE
Darkspawn can now use their wand again

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_objects/warlock_staff.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_objects/warlock_staff.dm
@@ -23,6 +23,11 @@
 	/// Flags used for different effects that apply when a projectile hits something
 	var/effect_flags
 
+/obj/item/gun/magic/darkspawn/can_trigger_gun(mob/living/user, akimbo_usage)
+	if(IS_DARKSPAWN_OR_THRALL(user))
+		return TRUE
+	return ..()
+
 /obj/item/gun/magic/darkspawn/examine(mob/user)
 	. = ..()
 	if(isobserver(user) || IS_DARKSPAWN(user))


### PR DESCRIPTION
## About The Pull Request

Fix

## Why It's Good For The Game

For the fix.

## Testing

<img width="1255" height="983" alt="image" src="https://github.com/user-attachments/assets/91fed3fd-00c2-46c6-8fa2-bcedcdf2b39d" />


## Changelog

:cl:
fix: Darkspawns can use their staff again.
/:cl: