### PR TITLE
AI Law change sound notification + AI Law State panel adjustment

### DIFF
--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -28,6 +28,7 @@
 	throw_alert(ALERT_NEW_LAW, /atom/movable/screen/alert/newlaw)
 	if(announce && last_lawchange_announce != world.time)
 		to_chat(src, span_boldannounce("Your laws have been changed."))
+		SEND_SOUND(src, sound('sound/machines/cryo_warning.ogg'))
 		// lawset modules cause this function to be executed multiple times in a tick, so we wait for the next tick in order to be able to see the entire lawset
 		addtimer(CALLBACK(src, PROC_REF(show_laws)), 0)
 		addtimer(CALLBACK(src, PROC_REF(deadchat_lawchange)), 0)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -359,7 +359,9 @@
 			number++
 	list += {"<br><br><A href='byond://?src=[REF(src)];laws=1'>State Laws</A>"}
 
-	usr << browse(list, "window=laws")
+	var/datum/browser/browser = new(usr, "laws")
+	browser.set_content(list)
+	browser.open()
 
 /mob/living/silicon/proc/ai_roster()
 	if(!client)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -329,7 +329,7 @@
 		if (length(law) > 0)
 			if (!(law in hackedcheck))
 				law_display = "No"
-			list += {"<A href='byond://?src=[REF(src)];lawh=[index]'>[law_display] [ion_num()]:</A> <font color='#660000'>[law]</font><BR>"}
+			list += {"<A href='byond://?src=[REF(src)];lawh=[index]'>[law_display] [ion_num()]:</A> <font color='#aa0000'>[law]</font><BR>"}
 
 	for (var/index in 1 to length(laws.ion))
 		law_display = "Yes"


### PR DESCRIPTION

## About The Pull Request

Ports a change from TG which adds a sound effect that plays for the AI whenever they get a law change.
Ports code that changes the Law panel the AI can access to be black and blue like the majority of the UI, instead of the old pure white. 
Also changed the colour of hacked laws from #660000 to #aa0000 to make it easier to see on the backgrounds while still being distinct from zeroth laws.

It does not play a sound for cyborgs, it can probably be done but i'm lazy. If it really needs to be added let me know. The AI should ideally be badgering their Cyborgs about the new law(s) anyways.
## Why It's Good For The Game

Silicons getting an audio notification of law changes is nice. The law panel looks nicer too.
## Testing

It's like 4 lines of codes it works.
<img width="414" height="442" alt="image" src="https://github.com/user-attachments/assets/10550c9c-892d-4df0-9417-f5f2729fe6e6" />
<img width="477" height="161" alt="image" src="https://github.com/user-attachments/assets/b2e1f5ed-295a-492c-a1fe-57f6c2c78e4e" />

https://github.com/user-attachments/assets/c4d91034-b616-425e-b363-c9449edc3a8d
## Changelog
:cl:
qol: Added an audio notification whenever you receive a law change as AI.
image: Change the AI's law panel to match the rest of the current UI.
image: Adjusted the colour of hacked laws to be easier to see on dark UI.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
