### PR TITLE
cyborg surgical omnitool upgrade uses medical module sprite

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -708,7 +708,7 @@
 	name = "cyborg surgical omni-tool upgrade"
 	desc = "An upgrade to the Medical model, upgrading the built-in \
 		surgical omnitool, to be on par with advanced surgical tools, allowing for faster surgery."
-	icon_state = "cyborg_upgrade4"
+	icon_state = "module_medical"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/medical, /obj/item/robot_model/syndicate_medical)
 	model_flags = BORG_MODEL_MEDICAL


### PR DESCRIPTION

## About The Pull Request
Makes the cyborg surgical omni-tool upgrade use the medical module sprite.

## Why It's Good For The Game
Bugfix. It is suppose to use the new sprites from https://github.com/Monkestation/Monkestation2.0/pull/11279.

## Testing
Spawned in cyborg surgical omni-tool upgrade. It uses the correct sprite.
<img width="339" height="18" alt="image" src="https://github.com/user-attachments/assets/6bb04bff-cce9-42b0-8ca3-f13666609d2d" />

## Changelog
:cl:
fix: The cyborg surgical omni-tool upgrade now uses the medical module sprite just like other medical module upgrades.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
