### PR TITLE
Removes weight decay roundstart high threat antags

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/_event_control.dm
+++ b/monkestation/code/modules/storytellers/converted_events/_event_control.dm
@@ -70,7 +70,6 @@
 	checks_antag_cap = TRUE
 	track = EVENT_TRACK_ROLESET
 	dont_spawn_near_roundend = TRUE
-	repeated_mode_adjust = TRUE
 	earliest_start = BASE_MIDROUND_SPAWN_TIME //roundstarts need to set this to 0 anyway
 	///list of required roles, needed for this to form
 	var/list/required_roles

--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodcult.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodcult.dm
@@ -5,7 +5,6 @@
 	antag_datum = /datum/antagonist/cult
 	typepath = /datum/round_event/antagonist/bloodcult
 	shared_occurence_type = SHARED_HIGH_THREAT
-	repeated_mode_adjust = TRUE
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodling.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodling.dm
@@ -5,7 +5,6 @@
 	antag_datum = /datum/antagonist/bloodling
 	typepath = /datum/round_event/antagonist/bloodling
 	shared_occurence_type = SHARED_HIGH_THREAT
-	repeated_mode_adjust = TRUE
 	protected_roles = list(
 		JOB_CAPTAIN,
 		JOB_HEAD_OF_PERSONNEL,

--- a/monkestation/code/modules/storytellers/converted_events/solo/clockwork_cult.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/clockwork_cult.dm
@@ -5,7 +5,6 @@
 	antag_datum = /datum/antagonist/clock_cultist
 	typepath = /datum/round_event/antagonist/clockcult
 	shared_occurence_type = SHARED_HIGH_THREAT
-	repeated_mode_adjust = TRUE
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
@@ -5,7 +5,6 @@
 	antag_datum = /datum/antagonist/nukeop/commando
 	typepath = /datum/round_event/antagonist/commando_operative
 	shared_occurence_type = SHARED_HIGH_THREAT
-	repeated_mode_adjust = TRUE
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/darkspawn.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/darkspawn.dm
@@ -5,7 +5,6 @@
 	antag_datum = /datum/antagonist/darkspawn
 	typepath = /datum/round_event/antagonist/darkspawn
 	shared_occurence_type = SHARED_HIGH_THREAT
-	repeated_mode_adjust = TRUE
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
@@ -15,7 +15,6 @@
 		JOB_BRIG_PHYSICIAN,
 	)
 	shared_occurence_type = SHARED_HIGH_THREAT
-	repeated_mode_adjust = TRUE
 	maximum_antags = 1
 	required_roles = list(JOB_AI)
 	required_enemies = 4

--- a/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
@@ -5,7 +5,6 @@
 	antag_datum = /datum/antagonist/nukeop
 	typepath = /datum/round_event/antagonist/nuclear_operative
 	shared_occurence_type = SHARED_HIGH_THREAT
-	repeated_mode_adjust = TRUE
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/wizard.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/wizard.dm
@@ -5,7 +5,6 @@
 	antag_flag = ROLE_WIZARD
 	antag_datum = /datum/antagonist/wizard
 	shared_occurence_type = SHARED_HIGH_THREAT
-	repeated_mode_adjust = TRUE
 	restricted_roles = list(
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,

--- a/monkestation/code/modules/storytellers/storytellers/operative.dm
+++ b/monkestation/code/modules/storytellers/storytellers/operative.dm
@@ -1,7 +1,7 @@
 /datum/storyteller/operative
 	name = "The Operative"
 	desc = "The Operative has a lower capacity for threats but will rapidly replace those destroyed."
-	star_colour = STARCOLOUR_MIDNIGHTSUN
+	star_colour = STARCOLOUR_REDSTAR
 	welcome_text = "The eyes of multiple organizations have been set on the station."
 	starting_point_multipliers = list(
 		EVENT_TRACK_MUNDANE = 1,


### PR DESCRIPTION
## About The Pull Request

removes repeated_mode_adjust from all roundstart high threat antags
moves operative storyteller to red star instead of midnight sun

## Why It's Good For The Game

this change has made all of these high threat antags incredibly rare, making them almost never spawn. im sure people would like to actually play these instead of them spawning once per few days. 

operative moved to red star as it just doesn't fit midnight sun, it barely spawns any antags


## Testing


## Changelog

:cl:
remove: Roundstart high threat antags no longer have weight decay.
/:cl:

>

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
