### PR TITLE
Cyborg eye lights now use lamp color

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -313,6 +313,7 @@
 			eye_lights = new()
 		if(lamp_enabled || lamp_doom)
 			eye_lights.icon_state = "[model.special_light_key ? "[model.special_light_key]" : "[model.cyborg_base_icon]"]_l"
+			eye_lights.color = lamp_doom ? COLOR_RED : lamp_color
 			set_light_range(max(MINIMUM_USEFUL_LIGHT_RANGE, lamp_intensity))
 			set_light_color(lamp_doom ? COLOR_RED : lamp_color) //Red for doomsday killborgs, borg's choice otherwise
 			SET_PLANE_EXPLICIT(eye_lights, ABOVE_LIGHTING_PLANE, src) //glowy eyes


### PR DESCRIPTION

## About The Pull Request
The color of a cyborg's eye lights now uses their lamp color instead of always being the default white.

## Why It's Good For The Game
This makes it less jarring to see a cyborg's light emit one color (around them), but appear as if they are emitting the default color (on their sprite).
## Testing
Spawned a cyborg. Set lamp color. Turned on lamp.
(default)
<img width="460" height="227" alt="image" src="https://github.com/user-attachments/assets/5d734ad0-1487-48fc-a8cd-ae1bfcee3cb6" />

(green)
<img width="461" height="228" alt="image" src="https://github.com/user-attachments/assets/cdc1b362-5c9b-4942-87e0-ff0bbce0bc06" />

(red)
<img width="461" height="229" alt="image" src="https://github.com/user-attachments/assets/c792712b-079c-4fb6-8a7f-467ce6518baa" />

## Changelog
:cl:
add: The color of a cyborg's eye lights now uses their lamp color instead of being the usual white-yellow.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
