### PR TITLE
prevent crew transfer votes from blocking map votes due to vote cooldown

### DIFF
--- a/monkestation/code/datums/votes/transfer_vote.dm
+++ b/monkestation/code/datums/votes/transfer_vote.dm
@@ -41,6 +41,7 @@
 	)
 
 /datum/vote/shuttle_call/finalize_vote(winning_option)
+	SSvote.last_vote_time = -INFINITY // prevent crew transfer vote from blocking map votes
 	switch(winning_option)
 		if(CHOICE_CALL)
 			SSautotransfer.crew_transfer_passed()


### PR DESCRIPTION

## About The Pull Request

this makes it so crew transfer votes won't trigger the vote cooldown - and as such, map votes can be started right after

## Why It's Good For The Game

kinda annoying not being able to start a map vote bc the crew transfer vote triggered a 5 minute vote cooldown

## Testing

same exact code that the "reset cooldown" admin button for votes uses, and that button has worked for me, so... yeah

## Changelog
:cl:
qol: Crew Transfer votes no longer trigger the vote cooldown - as such, you can start a map vote immediately after if you wish.
/:cl: