### PR TITLE
Adds a player count + IC date/year to the statpanel

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -37,12 +37,18 @@ SUBSYSTEM_DEF(statpanels)
 		if(cached)
 			global_data += "Next Map: [cached.map_name]"
 
+		var/active_players = get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = FALSE) //This is a list of all active players, including players who are dead
+		var/observing_players = length(GLOB.current_observers_list) //This is a list of all players that started as an observer-- dead and lobby players are not included.
+		var/timeinworld = "[time2text(world.timeofday, "DD of Month,")] [CURRENT_STATION_YEAR]"
+
 		global_data += list(
 			"Storyteller: [!SSgamemode.secret_storyteller && SSgamemode.current_storyteller ? SSgamemode.current_storyteller.name : "Secret"]",
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
+			"Connected: [length(GLOB.clients)] | Active: [active_players] | Observing: [observing_players]",
+			" ",
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss", world.timezone)]",
 			"Round Time: [ROUND_TIME()]",
-			"Station Time: [station_time_timestamp()]",
+			"Station Time: [station_time_timestamp()], [timeinworld]",
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
 		)
 


### PR DESCRIPTION

## About The Pull Request

this just adds a player count + IC date/year to the statpanel

ported from iris/oculis

## Why It's Good For The Game

Is nice to know how many people are actually playing.

Also, not a lot of people know exactly what the IC year is, so this is helpful.

## Testing

<img width="288" height="179" alt="2026-05-02 (1777746967) ~ dreamseeker" src="https://github.com/user-attachments/assets/9976312f-e647-44b2-af56-f9de8d08e655" />

## Changelog
:cl:
add: Added a player count and the IC date/year to the statpanel.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
