### PR TITLE
batch of minor bugfixes

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -79477,6 +79477,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/chicken)
 "xxW" = (

--- a/code/game/objects/items/stacks/sheets/medical_stack/gauze.dm
+++ b/code/game/objects/items/stacks/sheets/medical_stack/gauze.dm
@@ -104,6 +104,8 @@
 		return
 	if(!helper.can_perform_action(owner, NEED_HANDS|FORBID_TELEKINESIS_REACH)) // telekinetic removal can be added later
 		return
+	if(!helper.CanReach(owner))
+		return
 
 	var/whose = helper == owner ? "your" : "[owner]'s"
 	var/theirs = helper == owner ? helper.p_their() : "[owner]'s"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -996,6 +996,10 @@
 	command = TRUE
 	freerange = TRUE
 
+/obj/item/radio/headset/chameleon/advanced/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
+
 /obj/item/modular_computer/pda/chameleon
 	name = "tablet"
 	var/datum/action/item_action/chameleon/change/tablet/chameleon_action

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -328,6 +328,10 @@ GLOBAL_LIST_INIT(pride_pin_reskins, list(
 		return
 	if(DOING_INTERACTION_WITH_TARGET(remover, wearer) || (wearer.w_uniform != uniform) || src.loc != uniform)
 		return
+	if(!remover.can_perform_action(wearer, NEED_DEXTERITY | NEED_HANDS | FORBID_TELEKINESIS_REACH | ALLOW_RESTING))
+		return
+	if(!remover.CanReach(wearer))
+		return
 	remover.visible_message(
 		span_warning("[remover] begins removing [src] from [wearer]."),
 		span_notice("You start removing [src] from [wearer]."))

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -1939,7 +1939,7 @@
 	name = "\improper New Osaka Sunrise soup"
 	icon = 'icons/obj/food/martian.dmi'
 	icon_state = "new_osaka_sunrise"
-	drink_type = MEAT | GRAIN | DAIRY | VEGETABLES
+	drink_type = GRAIN | DAIRY | VEGETABLES
 
 /datum/chemical_reaction/food/soup/new_osaka_sunrise
 	required_reagents = list(

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -77,8 +77,9 @@
 
 	toggle_open(user)
 
-
 /obj/item/modular_computer/laptop/click_alt(mob/user)
+	if(remove_id(user))
+		return CLICK_ACTION_SUCCESS
 	if(!screen_on)
 		return CLICK_ACTION_BLOCKING
 	try_toggle_open(user) // Close it.

--- a/monkestation/code/modules/assault_ops/code/pouch.dm
+++ b/monkestation/code/modules/assault_ops/code/pouch.dm
@@ -22,13 +22,9 @@
 	custom_price = PAYCHECK_CREW * 4
 	item_flags = INFINITE_RESKIN
 	unique_reskin = list(
-		"Ammo Pouch" = list(
-			RESKIN_ICON_STATE = "ammopouch"
-		),
-		"Casing Pouch" = list(
-			RESKIN_ICON_STATE = "casingpouch"
-		),
-	)
+		"Ammo Pouch" = "ammopouch",
+		"Casing Pouch" = "casingpouch"
+		)
 
 /obj/item/storage/pouch/ammo/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/modules/assault_ops/code/pouch.dm
+++ b/monkestation/code/modules/assault_ops/code/pouch.dm
@@ -24,7 +24,7 @@
 	unique_reskin = list(
 		"Ammo Pouch" = "ammopouch",
 		"Casing Pouch" = "casingpouch"
-		)
+	)
 
 /obj/item/storage/pouch/ammo/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/modules/factory_type_beat/designs.dm
+++ b/monkestation/code/modules/factory_type_beat/designs.dm
@@ -60,7 +60,7 @@
 	name = "Big Manipulator Board"
 	desc = "The circuit board for a big manipulator."
 	id = "big_manipulator"
-	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE | COLONY_FABRICATOR
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE | COLONY_FABRICATOR | IMPRINTER
 	build_path = /obj/item/circuitboard/machine/big_manipulator
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING


### PR DESCRIPTION
## About The Pull Request

big manipulator board is now avaiable in the circuit impriter
fixes #11483

advanced chameleon headset now actually gives you flashbang protection
fixes #11434

fixes missing wire on tramstation ranching
fixes #11413

You can now get your id back from laptops by alt clicking them
fixes #10085

new osaka sunrise soup no longer has meat flag because it literally doesnt have meat
fixes #11432

You can no longer remove gauzes and scryers from far away, and bypass dexterity checks needed for stripping scryers
fixes #10992

fixes ammo pouch reskins being invisible
fixes #8999

## Why It's Good For The Game

bug fix

## Testing

all of these are very minor
have the ammo pouch screenshot i guess 
<img width="151" height="263" alt="image" src="https://github.com/user-attachments/assets/fde212b6-7bf0-4bf4-b362-3f4ccd871201" />


## Changelog

:cl:
fix: fixed being able to stip gauzes and scryers from afar
fix: fixed ammo pouch reskins being invisible
fix: new osaka sunrise soup is no longer meat type (because it doesnt have meat)
fix: alt click now works as a way to get your ID out of a laptop
map: fixed missing wire on tramstation ranching
fix: advanced chameleon headset now actually gives you ear protection like it says it does
add: big manipulator circuit can be printed using circuit impriter
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
