### PR TITLE
Tweaks darkspawn's crawling shadows to better fit it's original design

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_objects/crawling_shadows.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_objects/crawling_shadows.dm
@@ -63,7 +63,7 @@
 	var/lums = GET_SIMPLE_LUMCOUNT(T)
 	if(lums < SHADOW_SPECIES_BRIGHT_LIGHT)
 		speed = 0 //Faster, too
-		alpha = max(alpha - ((SHADOW_SPECIES_BRIGHT_LIGHT - lums) * 60), 10) //Rapidly becomes more invisible in the dark
+		alpha = max(alpha - ((SHADOW_SPECIES_BRIGHT_LIGHT - lums) * 60), 0) //Rapidly becomes more invisible in the dark
 	else
 		speed = 1
 		alpha = min(alpha + (lums * 30), 255) //Slowly becomes more visible in brighter light

--- a/code/modules/antagonists/darkspawn/darkspawn_objects/crawling_shadows.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_objects/crawling_shadows.dm
@@ -7,8 +7,8 @@
 	icon_living = "crawling_shadows"
 	initial_language_holder = /datum/language_holder/darkspawn
 	//survival variables
-	maxHealth = 20
-	health = 20
+	maxHealth = 5
+	health = 5
 	pressure_resistance = INFINITY
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	bodytemp_cold_damage_limit = 0
@@ -16,7 +16,7 @@
 
 	//movement variables
 	movement_type = FLYING
-	speed = 0
+	speed = 1
 	pass_flags = PASSTABLE | PASSMOB | PASSDOORS | PASSMACHINE
 
 	//combat variables
@@ -62,9 +62,9 @@
 	var/turf/T = get_turf(src)
 	var/lums = GET_SIMPLE_LUMCOUNT(T)
 	if(lums < SHADOW_SPECIES_BRIGHT_LIGHT)
-		speed = -1 //Faster, too
-		alpha = max(alpha - ((SHADOW_SPECIES_BRIGHT_LIGHT - lums) * 60), 0) //Rapidly becomes more invisible in the dark
+		speed = 0 //Faster, too
+		alpha = max(alpha - ((SHADOW_SPECIES_BRIGHT_LIGHT - lums) * 60), 10) //Rapidly becomes more invisible in the dark
 	else
-		speed = 0
+		speed = 1
 		alpha = min(alpha + (lums * 30), 255) //Slowly becomes more visible in brighter light
 	update_simplemob_varspeed()

--- a/code/modules/antagonists/darkspawn/darkspawn_upgrades/utility_upgrades.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_upgrades/utility_upgrades.dm
@@ -205,7 +205,7 @@
 	desc = "Assumes a shadowy form that can crawl through vents and squeeze through the cracks in doors."
 	lore_description = ""
 	icon_state = "crawling_shadows"
-	willpower_cost = 3
+	willpower_cost = 2
 	shadow_flags = ALL_DARKSPAWN_CLASSES
 	menu_tab = STORE_UTILITY
 	learned_abilities = list(/datum/action/cooldown/spell/shapeshift/crawling_shadows)


### PR DESCRIPTION
## About The Pull Request
Reduces health of crawling shadows shapeshift from 20 to 5
Reduces the speed of crawling shadows in darkness from -1 to 0
Reduces the speed of crawling shadows in light from 0 to 1
Reduces the lucidity cost of crawling shadows from 3 to 2

## Why It's Good For The Game

Crawling shadows was initially designed with being more of a stealth utility spell, useful for getting through locked doors, or around the map quickly using vents. 
With the port to monke (which has simple_animal instead of simple_mob) they seem to have become substantially faster.
This has enabled every single class to have mobility comparable to scout, reducing class identity.
3 cost also seems overcosted in hindsight.

## Testing
<img width="500" height="342" alt="image" src="https://github.com/user-attachments/assets/409bb164-efa0-45af-89f6-a4688466f170" />

It's slower and costs less, idk what more you expect, i can post a video if you really need


## Changelog

:cl:
balance: Darkspawns crawling shadows is now slower and squishier, but costs less to buy
/:cl:


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
