### PR TITLE
medical cyborg crew monitor button icon no longer becomes invisible

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -534,13 +534,11 @@
 		return .
 	crew_monitor = new /datum/action/item_action/crew_monitor(src)
 	crew_monitor.Grant(borg)
-	icon_state = "scanner"
 
 /obj/item/borg/upgrade/pinpointer/deactivate(mob/living/silicon/robot/borg, mob/living/user = usr)
 	. = ..()
 	if(!.)
 		return .
-	icon_state = "pinpointer_crew"
 	crew_monitor.Remove(borg)
 	QDEL_NULL(crew_monitor)
 
@@ -552,6 +550,8 @@
 
 /datum/action/item_action/crew_monitor
 	name = "Interface With Crew Monitor"
+	button_icon = 'icons/obj/device.dmi'
+	button_icon_state = "scanner_med"
 
 /obj/item/borg/upgrade/transform
 	name = "borg model picker (Standard)"


### PR DESCRIPTION

## About The Pull Request
The crew monitor action that is granted to Medical Cyborgs when the pinpointer upgrade is applied no longer will have its button icon disappear / become invisible whenever a new action is given (e.g. self-repair action).

In addition, the same action now uses the medical crew monitor icon.

## Why It's Good For The Game
Bugfix and a better icon that more accurately depicts its function.

## Testing
Applied pinpointer upgrade and then self-repair upgrade in that order:
<img width="188" height="120" alt="top_left_crewmonitor_fix" src="https://github.com/user-attachments/assets/f48e5ac3-edee-4dd9-8640-12e84b94f4cb" />
## Changelog
:cl:
add: Medical Cyborg's crew monitor button icon now looks like a medical crew monitor.
fix: Medical Cyborg's crew monitor button icon no longer becomes invisible when getting an another action (e.g. self-repair).
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
