### PR TITLE
fixed hyposprays deleting containers while in crit

### DIFF
--- a/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
+++ b/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 	if(vial)
 		if(!can_remove_vials)
 			return FALSE
-		if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH|ALLOW_RESTING))
+		if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH|ALLOW_RESTING|IGNORE_SOFTCRIT))
 			return FALSE
 		if(!silent)
 			to_chat(user, span_notice("You remove the [vial] from [src]."))


### PR DESCRIPTION

## About The Pull Request
fixes #11510

this was happening while in softcrit when swapping vials. vials now swap normally while in crit

## Why It's Good For The Game
bug fix

## Testing


https://github.com/user-attachments/assets/835233d0-4417-40ad-8fb2-d9e45d609f19


https://github.com/user-attachments/assets/24b7fbc6-fe31-4feb-9c74-0ac2f517ca95




## Changelog
:cl:
fix: fixed hyposprays deleting containers when in crit
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

