### PR TITLE
Ghosts can no longer open PDAs and laptops

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -315,8 +315,9 @@
 	return TRUE
 
 /obj/item/modular_computer/mouse_drop_dragged(atom/over_object, mob/user)
-	if(!istype(over_object, /atom/movable/screen))
-		return attack_self(user)
+	if(!isobserver(user))
+		if(!istype(over_object, /atom/movable/screen))
+			return attack_self(user)
 
 /obj/item/modular_computer/attack_ai(mob/user)
 	return attack_self(user)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -315,9 +315,10 @@
 	return TRUE
 
 /obj/item/modular_computer/mouse_drop_dragged(atom/over_object, mob/user)
-	if(!isobserver(user))
-		if(!istype(over_object, /atom/movable/screen))
-			return attack_self(user)
+	if(isobserver(user))
+		return
+	if(!istype(over_object, /atom/movable/screen))
+		return attack_self(user)
 
 /obj/item/modular_computer/attack_ai(mob/user)
 	return attack_self(user)


### PR DESCRIPTION

## About The Pull Request
ghosts are no longer able to open PDA's and laptops on the floor
adds a check to see if you are an observer before opening PDA's or laptops

https://github.com/user-attachments/assets/a8ad068a-2760-4234-858e-b1e1a2a15d55
## Why It's Good For The Game
it's funny but, not intended. nor very useful as they still cannot interact with them beyond turning it on.
## Testing

https://github.com/user-attachments/assets/7de5f9d0-588b-43f7-a7f8-ebcc9c3c626a
## Changelog
:cl: Cujo
fix: Ghosts are no longer able to turn on PDAs and laptops
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
