### PR TITLE
[TM ONLY] Potentially fixes storyteller spawning extra antags on blood brothers without paying for them

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
@@ -42,11 +42,11 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_BRIG_PHYSICIAN,
 	)
-	extra_spawned_events = list(
-		/datum/round_event_control/antagonist/traitor/roundstart = 9, //Traitors are always fun
-		VAMPIRE_ROUNDSTART_EVENT = 1, //Vampires can vassalize people making very big teams.
-		/datum/round_event_control/antagonist/heretic/roundstart = 2, //Heretics cant convert crew to their side. So it gets a higher weight then Vampires
-	)
+	// extra_spawned_events = list(
+	// 	/datum/round_event_control/antagonist/traitor/roundstart = 9, //Traitors are always fun
+	// 	VAMPIRE_ROUNDSTART_EVENT = 1, //Vampires can vassalize people making very big teams.
+	// 	/datum/round_event_control/antagonist/heretic/roundstart = 2, //Heretics cant convert crew to their side. So it gets a higher weight then Vampires
+	// )
 
 /datum/round_event_control/antagonist/brother/midround
 	name = "Sleeper Agents (Blood Brothers)"


### PR DESCRIPTION
## About The Pull Request
TM only
<img width="607" height="31" alt="image" src="https://github.com/user-attachments/assets/293760a3-ee93-4e95-819c-ad466470b226" />
<img width="1185" height="113" alt="image" src="https://github.com/user-attachments/assets/cfa89d60-551b-46c2-ab16-04f57dd0cd16" />

Preferred events for a ruleset, like that of blood cult, will only spawn those events if it has the points to spare. Bloodbrothers sets extra_spawned_events instead, which i think will always spawn the extra antags

## Why It's Good For The Game
storyteller spawning more antags than intended is bad

## Testing
## Changelog
:cl:
fix: blood brothers ruleset track should no longer always spawn traitors, heretics, or vampires, even without the right points
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
