### PR TITLE
Fix the force_move component allowing for multiple move loops to be created at the same time

### DIFF
--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -129,10 +129,6 @@
 
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay)
 
-	if(result == MOVELOOP_FAILURE && ishuman(src.moving) && istype(src, /datum/move_loop/has_target/move_towards)) // Tell the mob we slipped and what happened
-		var/datum/move_loop/has_target/move_towards/collide_move = src
-		SEND_SIGNAL(src.moving, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay, collide_move.moving_towards, src)
-
 	if(QDELETED(src) || result != MOVELOOP_SUCCESS) //Can happen
 		return
 

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -80,12 +80,13 @@
 	SIGNAL_HANDLER
 
 
-	if(!result && slip_spin)
-		var/mob/mob_parent = parent
-		mob_parent.spin(1, 1)
+	if(!result)
+		if(slip_spin)
+			var/mob/mob_parent = parent
+			mob_parent.spin(1, 1)
 		return
 
-	if(!isliving(parent))
+	if(!slip_crash || !isliving(parent))
 		return
 
 	var/mob/living/living_parent = parent

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -54,7 +54,7 @@
 /// Create a new movement loop for us
 /datum/component/force_move/proc/create_loop(atom/target)
 	var/dist = get_dist(parent, target)
-	our_looper = SSmove_manager.move_towards(parent, target, delay = 1, timeout = min(dist, 6 SECONDS))
+	our_looper = SSmove_manager.move_towards(parent, target, delay = 1, timeout = dist)
 	if(spin)
 		RegisterSignal(our_looper, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_spin))
 	RegisterSignal(our_looper, COMSIG_QDELETING, PROC_REF(loop_ended))

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -22,6 +22,9 @@
 	if(!target || !ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 
+	var/mob/mob_parent = parent
+	mob_parent.face_atom(target)
+
 	src.slip_spin = slip_spin
 	src.slip_crash = slip_crash
 
@@ -74,8 +77,7 @@
 /datum/component/force_move/proc/post_process(datum/source, result, delay)
 	SIGNAL_HANDLER
 
-
-	if(!result)
+	if(result != MOVELOOP_FAILURE)
 		if(slip_spin)
 			var/mob/mob_parent = parent
 			mob_parent.spin(1, 1)

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -43,7 +43,6 @@
 	if(!i_am_original)
 		return
 
-	// Delete the old loop but don't delete us
 	clean_loop()
 
 	src.spin = spin
@@ -64,7 +63,7 @@
 	if(QDELETED(our_looper))
 		return
 	UnregisterSignal(our_looper, list(COMSIG_MOVELOOP_POSTPROCESS, COMSIG_QDELETING))
-	qdel(our_looper)
+	QDEL_NULL(our_looper)
 
 /// Signal proc to prevent client movement
 /datum/component/force_move/proc/stop_move(datum/source)

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -8,7 +8,7 @@
 	var/datum/move_loop/has_target/our_looper = null
 	// Making these vars for ease of inheritance
 	/// If TRUE the movement causes a spin every step
-	var/spin = FALSE
+	var/slip_spin = FALSE
 	/// If TRUE termination of movement causes a stun and can cause vendors to fall
 	var/slip_crash = FALSE
 
@@ -18,11 +18,11 @@
 	our_looper = null
 	return ..()
 
-/datum/component/force_move/Initialize(atom/target, spin = FALSE, slip_crash = FALSE)
+/datum/component/force_move/Initialize(atom/target, slip_spin = FALSE, slip_crash = FALSE)
 	if(!target || !ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	src.spin = spin
+	src.slip_spin = slip_spin
 	src.slip_crash = slip_crash
 
 	create_loop(target)
@@ -30,8 +30,6 @@
 /datum/component/force_move/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(stop_move))
 	RegisterSignal(parent, COMSIG_ATOM_PRE_PRESSURE_PUSH, PROC_REF(stop_pressure))
-	if(slip_crash)
-		RegisterSignal(parent, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_crash))
 
 /datum/component/force_move/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, COMSIG_ATOM_PRE_PRESSURE_PUSH, COMSIG_MOVELOOP_POSTPROCESS))
@@ -39,13 +37,13 @@
 // Slipping allows for two force_move components to be added, this breaks the movement loop signals and if slide distance is too high,
 // it causes people to get stuck until the loop expires.
 // We could just reduce the slide but really we should just make sure that two loops aren't created that conflict eachother.
-/datum/component/force_move/InheritComponent(datum/component/force_move/new_mover, i_am_original, atom/target, spin, slip_crash)
+/datum/component/force_move/InheritComponent(datum/component/force_move/new_mover, i_am_original, atom/target, slip_spin, slip_crash)
 	if(!i_am_original)
 		return
 
 	clean_loop()
 
-	src.spin = spin
+	src.slip_spin = slip_spin
 	src.slip_crash = slip_crash
 
 	create_loop(target)
@@ -54,8 +52,8 @@
 /datum/component/force_move/proc/create_loop(atom/target)
 	var/dist = get_dist(parent, target)
 	our_looper = SSmove_manager.move_towards(parent, target, delay = 1, timeout = dist)
-	if(spin)
-		RegisterSignal(our_looper, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_spin))
+	if(slip_spin || slip_crash)
+		RegisterSignal(our_looper, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(post_process))
 	RegisterSignal(our_looper, COMSIG_QDELETING, PROC_REF(loop_ended))
 
 /// Safely remove the old loop in case of inheritance
@@ -77,36 +75,34 @@
 
 	return COMSIG_ATOM_BLOCKS_PRESSURE
 
-/// Signal proc to spin the mob right around
-/datum/component/force_move/proc/slip_spin(datum/source)
+/// Signal proc for after the moveloop has processed
+/datum/component/force_move/proc/post_process(datum/source, result, delay)
 	SIGNAL_HANDLER
 
-	var/mob/mob_parent = parent
-	mob_parent.spin(1, 1)
 
-/// Signal proc that causes hitting dense atoms to stun the mob
-/datum/component/force_move/proc/slip_crash(datum/source, result, delay, turf/target_turf, datum/blocked)
-	SIGNAL_HANDLER
-
-	if(result)
+	if(!result && slip_spin)
+		var/mob/mob_parent = parent
+		mob_parent.spin(1, 1)
 		return
 
-	if(!iscarbon(parent))
+	if(!isliving(parent))
 		return
 
-	var/mob/living/carbon/carbon_parent = parent
+	var/mob/living/living_parent = parent
+	var/turf/target_turf = get_step(living_parent, living_parent.dir)
 
 	var/obj/machinery/heavy_weight = (locate(/obj/machinery/vending) in target_turf)
 	if(heavy_weight) // When a stoppable force hits immovable capitalism.
-		INVOKE_ASYNC(heavy_weight, TYPE_PROC_REF(/obj/machinery/vending, tilt), parent) // We hit the machine so let them hit back.
-		qdel(blocked)
+		INVOKE_ASYNC(heavy_weight, TYPE_PROC_REF(/obj/machinery/vending, tilt), living_parent) // We hit the machine so let them hit back.
 	else
-		// We hit a structure and we need to keep going.
-		carbon_parent.Immobilize(0.8 SECONDS) // Prevent them from throw bending around objects.
-		carbon_parent.apply_status_effect(/datum/status_effect/no_throw_back) // Stops the default knockback when tossed into walls
+		// We hit a dense atom and we need to stop.
+		living_parent.Immobilize(0.8 SECONDS) // Prevent them from throw bending around objects.
+		living_parent.apply_status_effect(/datum/status_effect/no_throw_back) // Stops the default knockback when tossed into walls
+
 		// We don't exactly know what stopped us. So throw us at the turf and let physics handle it.
-		INVOKE_ASYNC(carbon_parent, TYPE_PROC_REF(/atom/movable, throw_at), target_turf, 1, 1)
-		qdel(blocked)
+		INVOKE_ASYNC(living_parent, TYPE_PROC_REF(/atom/movable, throw_at), target_turf, 1, 1)
+
+	qdel(our_looper)
 
 /// Signal proc to cleanup once we're done moving
 /datum/component/force_move/proc/loop_ended(datum/source)

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -3,57 +3,117 @@
 ///Supports spinning on each move, for lube related reasons
 ///Supports slip and crashing interactions. Like slamming into a wall or slipping into disposals
 /datum/component/force_move
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	/// Current movement loop, so we can keep it if this component is added twice
+	var/datum/move_loop/has_target/our_looper = null
+	// Making these vars for ease of inheritance
+	/// If TRUE the movement causes a spin every step
+	var/spin = FALSE
+	/// If TRUE termination of movement causes a stun and can cause vendors to fall
+	var/slip_crash = FALSE
 
-/datum/component/force_move/Initialize(atom/target, spin, slip_crash)
+/datum/component/force_move/Destroy(force)
+	if(!QDELETED(our_looper))
+		qdel(our_looper)
+	our_looper = null
+	return ..()
+
+/datum/component/force_move/Initialize(atom/target, spin = FALSE, slip_crash = FALSE)
 	if(!target || !ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	var/mob/mob_parent = parent
-	var/dist = get_dist(mob_parent, target)
-	var/datum/move_loop/loop = SSmove_manager.move_towards(mob_parent, target, delay = 1, timeout = dist)
-	RegisterSignal(mob_parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(stop_move))
-	RegisterSignal(mob_parent, COMSIG_ATOM_PRE_PRESSURE_PUSH, PROC_REF(stop_pressure))
-	if(slip_crash)
-		RegisterSignal(mob_parent, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_crash))
-	if(spin)
-		RegisterSignal(loop, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_spin))
-	RegisterSignal(loop, COMSIG_QDELETING, PROC_REF(loop_ended))
+	src.spin = spin
+	src.slip_crash = slip_crash
 
+	create_loop(target)
+
+/datum/component/force_move/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(stop_move))
+	RegisterSignal(parent, COMSIG_ATOM_PRE_PRESSURE_PUSH, PROC_REF(stop_pressure))
+	if(slip_crash)
+		RegisterSignal(parent, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_crash))
+
+/datum/component/force_move/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, COMSIG_ATOM_PRE_PRESSURE_PUSH, COMSIG_MOVELOOP_POSTPROCESS))
+
+// Slipping allows for two force_move components to be added, this breaks the movement loop signals and if slide distance is too high,
+// it causes people to get stuck until the loop expires.
+// We could just reduce the slide but really we should just make sure that two loops aren't created that conflict eachother.
+/datum/component/force_move/InheritComponent(datum/component/force_move/new_mover, i_am_original, atom/target, spin, slip_crash)
+	if(!i_am_original)
+		return
+
+	// Delete the old loop but don't delete us
+	clean_loop()
+
+	src.spin = spin
+	src.slip_crash = slip_crash
+
+	create_loop(target)
+
+/// Create a new movement loop for us
+/datum/component/force_move/proc/create_loop(atom/target)
+	var/dist = get_dist(parent, target)
+	our_looper = SSmove_manager.move_towards(parent, target, delay = 1, timeout = min(dist, 6 SECONDS))
+	if(spin)
+		RegisterSignal(our_looper, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_spin))
+	RegisterSignal(our_looper, COMSIG_QDELETING, PROC_REF(loop_ended))
+
+/// Safely remove the old loop in case of inheritance
+/datum/component/force_move/proc/clean_loop()
+	if(QDELETED(our_looper))
+		return
+	UnregisterSignal(our_looper, list(COMSIG_MOVELOOP_POSTPROCESS, COMSIG_QDELETING))
+	qdel(our_looper)
+
+/// Signal proc to prevent client movement
 /datum/component/force_move/proc/stop_move(datum/source)
 	SIGNAL_HANDLER
+
 	return COMSIG_MOB_CLIENT_BLOCK_PRE_LIVING_MOVE
 
+/// Signal proc to prevent pressure movement
 /datum/component/force_move/proc/stop_pressure(datum/source)
 	SIGNAL_HANDLER
+
 	return COMSIG_ATOM_BLOCKS_PRESSURE
 
+/// Signal proc to spin the mob right around
 /datum/component/force_move/proc/slip_spin(datum/source)
 	SIGNAL_HANDLER
+
 	var/mob/mob_parent = parent
 	mob_parent.spin(1, 1)
 
+/// Signal proc that causes hitting dense atoms to stun the mob
 /datum/component/force_move/proc/slip_crash(datum/source, result, delay, turf/target_turf, datum/blocked)
 	SIGNAL_HANDLER
-	if(iscarbon(parent) && istype(blocked, /datum/move_loop/has_target/move_towards))
-		var/mob/living/carbon/mob_parent = parent
-		if(!result) // Something prevented us from moving into the space.
-			var/obj/machinery/heavy_weight = (locate(/obj/machinery/vending) in target_turf)
-			var/datum/move_loop/has_target/move_towards/blocked_move = blocked
-			if(heavy_weight) // When a stoppable force hits immovable capitalism.
-				blocked_move.lifetime = -1
-				INVOKE_ASYNC(heavy_weight, TYPE_PROC_REF(/obj/machinery/vending, tilt), parent) // We hit the machine so let them hit back.
-			else
-				// We hit a structure and we need to keep going.
-				mob_parent.Immobilize(0.8 SECONDS) // Prevent them from throw bending around objects.
-				mob_parent.apply_status_effect(/datum/status_effect/no_throw_back) // Stops the default knockback when tossed into walls
-			// We don't exactly know what stopped us. So throw us at the turf and let physics handle it.
-				blocked_move.lifetime = -1
-				INVOKE_ASYNC(mob_parent, TYPE_PROC_REF(/atom/movable, throw_at), target_turf, 1, 1)
 
+	if(result)
+		return
+
+	if(!iscarbon(parent))
+		return
+
+	var/mob/living/carbon/carbon_parent = parent
+
+	var/obj/machinery/heavy_weight = (locate(/obj/machinery/vending) in target_turf)
+	if(heavy_weight) // When a stoppable force hits immovable capitalism.
+		INVOKE_ASYNC(heavy_weight, TYPE_PROC_REF(/obj/machinery/vending, tilt), parent) // We hit the machine so let them hit back.
+		qdel(blocked)
+	else
+		// We hit a structure and we need to keep going.
+		carbon_parent.Immobilize(0.8 SECONDS) // Prevent them from throw bending around objects.
+		carbon_parent.apply_status_effect(/datum/status_effect/no_throw_back) // Stops the default knockback when tossed into walls
+		// We don't exactly know what stopped us. So throw us at the turf and let physics handle it.
+		INVOKE_ASYNC(carbon_parent, TYPE_PROC_REF(/atom/movable, throw_at), target_turf, 1, 1)
+		qdel(blocked)
+
+/// Signal proc to cleanup once we're done moving
 /datum/component/force_move/proc/loop_ended(datum/source)
 	SIGNAL_HANDLER
+
 	if(QDELETED(src))
 		return
+
 	qdel(src)
-
-

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -32,16 +32,18 @@
 	RegisterSignal(parent, COMSIG_ATOM_PRE_PRESSURE_PUSH, PROC_REF(stop_pressure))
 
 /datum/component/force_move/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, COMSIG_ATOM_PRE_PRESSURE_PUSH, COMSIG_MOVELOOP_POSTPROCESS))
+	UnregisterSignal(parent, list(COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, COMSIG_ATOM_PRE_PRESSURE_PUSH))
 
-// Slipping allows for two force_move components to be added, this breaks the movement loop signals and if slide distance is too high,
-// it causes people to get stuck until the loop expires.
-// We could just reduce the slide but really we should just make sure that two loops aren't created that conflict eachother.
+// Slipping allowed for two force_move components to be added, this breaks the movement loop signals and if slide distance is too high,
+// it causes people to get stuck until the loop expires. So is to prevent the creation of an unmanaged loop.
 /datum/component/force_move/InheritComponent(datum/component/force_move/new_mover, i_am_original, atom/target, slip_spin, slip_crash)
 	if(!i_am_original)
 		return
 
-	clean_loop()
+	// Remove the old loop such it doesn't delete us with it
+	if(!QDELETED(our_looper))
+		UnregisterSignal(our_looper, list(COMSIG_MOVELOOP_POSTPROCESS, COMSIG_QDELETING))
+		QDEL_NULL(our_looper)
 
 	src.slip_spin = slip_spin
 	src.slip_crash = slip_crash
@@ -55,13 +57,6 @@
 	if(slip_spin || slip_crash)
 		RegisterSignal(our_looper, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(post_process))
 	RegisterSignal(our_looper, COMSIG_QDELETING, PROC_REF(loop_ended))
-
-/// Safely remove the old loop in case of inheritance
-/datum/component/force_move/proc/clean_loop()
-	if(QDELETED(our_looper))
-		return
-	UnregisterSignal(our_looper, list(COMSIG_MOVELOOP_POSTPROCESS, COMSIG_QDELETING))
-	QDEL_NULL(our_looper)
 
 /// Signal proc to prevent client movement
 /datum/component/force_move/proc/stop_move(datum/source)

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -4,7 +4,7 @@
 ///Supports slip and crashing interactions. Like slamming into a wall or slipping into disposals
 /datum/component/force_move
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	/// Current movement loop, so we can keep it if this component is added twice
+	/// Current movement loop, so we can prevent a duplicate
 	var/datum/move_loop/has_target/our_looper = null
 	// Making these vars for ease of inheritance
 	/// If TRUE the movement causes a spin every step


### PR DESCRIPTION

## About The Pull Request
Since it was made the component lacks safety for cases where two components are added, this causes two movement loops to be active at once. 

This isn't usually an issue due to the short distance and lifespan of the component but there is an exception if the distance is very long https://github.com/Monkestation/Monkestation2.0/pull/11484...

This resolves that by safely deleting the old loop and creating a new one while keeping the orginal component.
## Why It's Good For The Game
Bug bad
## Testing
<img width="532" height="176" alt="image" src="https://github.com/user-attachments/assets/11c259b7-c89a-44fb-a131-3fcb2b688143" />

## Changelog
:cl:
fix: Fixed an edge case issue with forced movement
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
