### PR TITLE
Hear prot for the blueshield mod

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1973,6 +1973,7 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	slowdown_inactive = 1
 	slowdown_active = 0.5
+	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
 	allowed_suit_storage = list(
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/restraints/handcuffs,


### PR DESCRIPTION

## About The Pull Request
Gives the blueshield modsuit the hearing protection module, like all the other combat modsuits.
## Why It's Good For The Game
combat modsuit gets combat modsuit stuff
## Testing
Works perfect.
## Changelog
:cl:
fix: Blueshield MODsuit now comes with a hearing protection module.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
