### PR TITLE
Fixes any mecha weapon that isn't ballistic just not working

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -47,8 +47,12 @@
 	. = ..()//start the cooldown early because of sleeps
 	for(var/i in 1 to projectiles_per_shot)
 		//in case we run out of energy mid-burst, such as emp
-		if((energy_drain && !chassis.has_charge(energy_drain)) || (astype(src, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic)?.projectiles <= 0))
+		if((energy_drain && !chassis.has_charge(energy_drain)))
 			break
+		if(istype(src, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic))
+			var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/ballistic = src
+			if(ballistic.projectiles <= 0)
+				break
 		var/spread = 0
 		if(variance)
 			if(randomspread)

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -47,7 +47,7 @@
 	. = ..()//start the cooldown early because of sleeps
 	for(var/i in 1 to projectiles_per_shot)
 		//in case we run out of energy mid-burst, such as emp
-		if((energy_drain && !chassis.has_charge(energy_drain)))
+		if(energy_drain && !chassis.has_charge(energy_drain))
 			break
 		if(istype(src, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic))
 			var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/ballistic = src


### PR DESCRIPTION
## About The Pull Request

I assume because checking for projectile var that just doesnt exist for other types returns null and you check if it equals zero it returns true and breaks the for loop or some stupid shit
just using istype and checking for var directly fixed that
closes #11523 

was hard to figure out what was causing it because the pr that broke it was testmerged alongside 20 other prs...

## Why It's Good For The Game

bug bad

## Testing


https://github.com/user-attachments/assets/fa9a95ef-61aa-45f6-b80d-7f4a360297ee


## Changelog

:cl:
fix: fixed any non ballistic mecha weapons not working
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
