### PR TITLE
The Heirloomening

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -20,7 +20,7 @@ Assistant
 
 	department_for_prefs = /datum/job_department/assistant
 
-	family_heirlooms = list(/obj/item/storage/toolbox/mechanical/old/heirloom, /obj/item/clothing/gloves/cut/heirloom)
+	family_heirlooms = list(/obj/item/storage/toolbox/mechanical/old/heirloom, /obj/item/clothing/gloves/cut/heirloom, /obj/item/screwdriver, /obj/item/crowbar, /obj/item/wirecutters)
 
 	mail_goodies = list(
 		/obj/effect/spawner/random/food_or_drink/donkpockets = 10,

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -25,7 +25,7 @@
 		/datum/job_department/engineering,
 		)
 
-	family_heirlooms = list(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
+	family_heirlooms = list(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches, /obj/item/geiger_counter)
 
 	mail_goodies = list(
 		/obj/item/rpd_upgrade/unwrench = 30,

--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -27,7 +27,7 @@
 		/datum/job_department/security,
 		)
 
-	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom, /obj/item/scalpel, /obj/item/hemostat, /obj/item/circular_saw, /obj/item/retractor, /obj/item/cautery)
+	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom, /obj/item/scalpel, /obj/item/hemostat, /obj/item/circular_saw, /obj/item/retractor, /obj/item/cautery, /obj/item/clothing/neck/stethoscope, /obj/item/flashlight/pen, /obj/item/clothing/mask/surgical)
 
 	mail_goodies = list(
 		/obj/item/healthanalyzer/advanced = 15,

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -22,7 +22,7 @@
 		/datum/job_department/cargo,
 		)
 
-	family_heirlooms = list(/obj/item/clipboard)
+	family_heirlooms = list(/obj/item/clipboard, /obj/item/dest_tagger)
 
 	mail_goodies = list(
 		/obj/item/pizzabox = 10,

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -26,7 +26,7 @@
 		/datum/job_department/medical,
 	)
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/chemistry, /obj/item/ph_booklet)
+	family_heirlooms = list(/obj/item/book/manual/wiki/chemistry, /obj/item/ph_booklet, /obj/item/reagent_containers/cup/beaker, /obj/item/storage/pill_bottle, /obj/item/clothing/mask/surgical)
 
 	mail_goodies = list(
 		/obj/item/reagent_containers/cup/bottle/flash_powder = 15,

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -32,7 +32,7 @@
 	display_order = JOB_DISPLAY_ORDER_CHIEF_ENGINEER
 	bounty_types = CIV_JOB_ENG
 
-	family_heirlooms = list(/obj/item/clothing/head/utility/hardhat/white, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
+	family_heirlooms = list(/obj/item/clothing/head/utility/hardhat/white, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters, /obj/item/clothing/glasses/meson/engine)
 
 	mail_goodies = list(
 		/obj/item/food/cracker = 25, //you know. for poly

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -38,7 +38,7 @@
 		/obj/effect/spawner/random/medical/surgery_tool_advanced = 4,
 		/obj/effect/spawner/random/medical/surgery_tool_alien = 1
 	)
-	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom, /obj/item/scalpel, /obj/item/hemostat, /obj/item/circular_saw, /obj/item/retractor, /obj/item/cautery)
+	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom, /obj/item/scalpel, /obj/item/hemostat, /obj/item/circular_saw, /obj/item/retractor, /obj/item/cautery, /obj/item/clothing/neck/stethoscope, /obj/item/clothing/mask/surgical, /obj/item/flashlight/pen)
 	rpg_title = "High Cleric"
 	job_flags = STATION_JOB_FLAGS | HEAD_OF_STAFF_JOB_FLAGS
 

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -39,7 +39,7 @@
 		/obj/item/storage/belt/holster/detective/full = 1
 	)
 
-	family_heirlooms = list(/obj/item/reagent_containers/cup/glass/bottle/whiskey)
+	family_heirlooms = list(/obj/item/reagent_containers/cup/glass/bottle/whiskey, /obj/item/restraints/handcuffs, /obj/item/toy/crayon/white, /obj/item/taperecorder)
 	rpg_title = "Thiefcatcher" //I guess they caught them all rip thief...
 	job_flags = STATION_JOB_FLAGS
 

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -27,7 +27,7 @@
 		/obj/item/storage/box/monkeycubes = 10
 	)
 
-	family_heirlooms = list(/obj/item/clothing/under/shorts/purple)
+	family_heirlooms = list(/obj/item/clothing/under/shorts/purple, /obj/item/food/monkeycube)
 	rpg_title = "Genemancer"
 	job_flags = STATION_JOB_FLAGS
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -32,7 +32,7 @@
 	display_order = JOB_DISPLAY_ORDER_HEAD_OF_SECURITY
 	bounty_types = CIV_JOB_SEC
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law)
+	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator, /obj/item/megaphone/sec)
 	rpg_title = "Guard Leader"
 	job_flags = STATION_JOB_FLAGS | HEAD_OF_STAFF_JOB_FLAGS
 

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -24,7 +24,7 @@
 		/datum/job_department/medical,
 		)
 
-	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom, /obj/item/scalpel, /obj/item/hemostat, /obj/item/circular_saw, /obj/item/retractor, /obj/item/cautery)
+	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom, /obj/item/scalpel, /obj/item/hemostat, /obj/item/circular_saw, /obj/item/retractor, /obj/item/cautery, /obj/item/clothing/neck/stethoscope, /obj/item/clothing/mask/surgical, /obj/item/flashlight/pen)
 
 	mail_goodies = list(
 		/obj/item/healthanalyzer/advanced = 15,

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -24,7 +24,7 @@
 		/datum/job_department/medical,
 		)
 
-	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom)
+	family_heirlooms = list(/obj/item/storage/medkit/ancient/heirloom, /obj/item/clothing/neck/stethoscope, /obj/item/clothing/mask/surgical, /obj/item/flashlight/pen)
 
 	mail_goodies = list(
 		/obj/item/reagent_containers/medipen = 20,

--- a/code/modules/jobs/job_types/psychologist.dm
+++ b/code/modules/jobs/job_types/psychologist.dm
@@ -23,7 +23,7 @@
 		/datum/job_department/service,
 		)
 
-	family_heirlooms = list(/obj/item/storage/pill_bottle)
+	family_heirlooms = list(/obj/item/storage/pill_bottle, /obj/item/clothing/mask/muzzle)
 
 	mail_goodies = list(
 		/obj/item/storage/pill_bottle/mannitol = 30,

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -27,7 +27,7 @@
 	departments_list = list(
 		/datum/job_department/cargo,
 		)
-	family_heirlooms = list(/obj/item/stamp, /obj/item/stamp/denied)
+	family_heirlooms = list(/obj/item/stamp, /obj/item/stamp/denied, /obj/item/dest_tagger, /obj/item/clipboard)
 	mail_goodies = list(
 		/obj/item/circuitboard/machine/emitter = 3
 	)

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -28,7 +28,7 @@
 		/datum/job_department/security,
 		)
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec)
+	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator)
 
 	mail_goodies = list(
 		/obj/item/food/donut/caramel = 10,

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -26,7 +26,7 @@
 		/datum/job_department/engineering,
 		)
 
-	family_heirlooms = list(/obj/item/clothing/head/utility/hardhat, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
+	family_heirlooms = list(/obj/item/clothing/head/utility/hardhat, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters, /obj/item/storage/belt/utility, /obj/item/clothing/glasses/meson/engine)
 
 	mail_goodies = list(
 		/obj/item/storage/box/lights/mixed = 20,

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -26,7 +26,7 @@
 		/datum/job_department/medical,
 		)
 
-	family_heirlooms = list(/obj/item/reagent_containers/syringe)
+	family_heirlooms = list(/obj/item/reagent_containers/syringe, /obj/item/clothing/neck/stethoscope)
 
 	mail_goodies = list(
 		/* Monkestation Removal

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -29,7 +29,7 @@
 		/datum/job_department/security,
 		)
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law)
+	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator)
 
 	mail_goodies = list(
 		/obj/item/storage/fancy/cigarettes = 15,


### PR DESCRIPTION
## About The Pull Request

adds a bunch of new family heirlooms to some jobs I've noticed were lacking in variety.

Security Officers, the Warden, and the Head of Security can now receive the following:

Handcuffs
Flashes
Donuts
Whistles
Hudsunglasses
Citationinators

Additionally, the HOS can get a security megaphone.

The detective can get a stick of chalk, handcuffs, or a tape recorder.

All medical roles can now get a stethoscope (except chemist) or a sterile mask.
Psychologist can receive a muzzle.
Chemists can get beakers or pill bottles.

Greytiders can get one of three T1 tools, a wirecutter, a crowbar, or a screwdriver.

The QM and cargo technicians can now get destination taggers.
The QM can now get a clipboard like how normal CTs could.

Engineers + CE can get engineering scanner goggles. Normal engi can get a toolbelt. Atmos techs can get a geiger counter.

## Why It's Good For The Game

Having the same heirloom (security players...) every round can be kinda boring. Or irritating, depending on what it is. 

## Testing

lmao (it should work fine if it compiles)

## Changelog

:cl: cark
add: Added a bunch of new family heirlooms.
/:cl:


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

