### PR TITLE
reworks multi_hit component a little

### DIFF
--- a/monkestation/code/datums/components/multi_hit.dm
+++ b/monkestation/code/datums/components/multi_hit.dm
@@ -54,21 +54,18 @@
 	return ..()
 
 /datum/component/multi_hit/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ITEM_PRE_ATTACK, PROC_REF(pre_hit_callback))
+	RegisterSignal(parent, COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM_SECONDARY, PROC_REF(on_ranged_interaction_secondary))
 
 /datum/component/multi_hit/UnregisterFromParent()
 	. = ..()
-	UnregisterSignal(parent, COMSIG_ITEM_PRE_ATTACK)
+	UnregisterSignal(parent, COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM_SECONDARY)
 
-/datum/component/multi_hit/proc/pre_hit_callback(datum/source, obj/item/thing, mob/user, params)
+/datum/component/multi_hit/proc/on_ranged_interaction_secondary(datum/source, mob/user, atom/target, list/modifiers)
 	SIGNAL_HANDLER
 
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("You can't bring youself to swing this!"))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
-
-	if(!(user.istate & ISTATE_SECONDARY))
-		return
 
 	if(iscarbon(user))
 		var/mob/living/carbon/carbon_user = user
@@ -84,6 +81,10 @@
 
 	if(true_starting.density && true_center.density)
 		return
+
+	if(!user.has_movespeed_modifier(/datum/movespeed_modifier/multi_hit))
+		user.add_movespeed_modifier(/datum/movespeed_modifier/multi_hit)
+		addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/multi_hit), 0.3 SECONDS, TIMER_UNIQUE)
 
 	var/climbing_dir
 	if(attacking_direction == WEST)
@@ -113,12 +114,12 @@
 	for(var/turf/listed_turf as anything in targeted_turfs)
 		if(breaks)
 			break
-		for(var/mob/living/target in listed_turf.contents)
+		for(var/mob/living/living_target in listed_turf.contents)
 			if(pre_hit_callback)
-				pre_hit_callback.Invoke(parent, target, user, targeted_turfs)
-			item_parent.attack(target, user)
+				pre_hit_callback.Invoke(parent, living_target, user, targeted_turfs)
+			item_parent.attack(living_target, user)
 			if(after_hit_callback)
-				after_hit_callback.Invoke(parent, target, user, targeted_turfs)
+				after_hit_callback.Invoke(parent, living_target, user, targeted_turfs)
 			if(!continues_travel)
 				breaks = TRUE
 				break
@@ -145,7 +146,6 @@
 	user.changeNext_move(item_parent.attack_speed * 1.2)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
-
 /datum/component/multi_hit/proc/get_attacking_direction(starting_dir, mob/user)
 	switch(user.dir)
 		if(NORTH)
@@ -166,6 +166,8 @@
 			else
 				return NORTH
 
+/datum/movespeed_modifier/multi_hit
+	multiplicative_slowdown = 3
 
 /obj/effect/hit_effect
 	name = "Whoops!"


### PR DESCRIPTION
## About The Pull Request

multihit is based on goonstations special attacks i assume so i made them work similar (also fixes some stuff)

instead of having to click on tile directly near you, you have to click on a tile that would be a tile away from you
you can no longer proc it by directly clicking mob with it and it just does regular attack
tho, if you click behind them they'd still be hit with the swing
additionally when you do the multihit it applies slowdown for a short duration because i feel like it would be easier to land hits on people with that

this fixes kneecapping
closes #7940 

## Why It's Good For The Game

bug fix mostly, also makes it less janky to use

## Testing

https://github.com/user-attachments/assets/5db0573b-2229-48e2-ae90-d5161ea38ebf

## Changelog
:cl:
refactor: refactored multi-hit component, now you have to right-click one tile or more away from yourself, and it no longer works when directly clicking things or clicking a tile right near you
balance: using multi-hit now applies slowdown for a very short duration
fix: fixed baseball bats kneecapping not working
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
