### PR TITLE
explosive guardians cannot place traps on stealth boxes

### DIFF
--- a/code/modules/mob/living/basic/guardian/guardian_types/explosive.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/explosive.dm
@@ -41,11 +41,16 @@
 	var/decay_time = 1 MINUTES
 	/// Static list of signals that activate the bomb.
 	var/static/list/boom_signals = list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_BUMPED, COMSIG_ATOM_ATTACK_HAND)
+	/// Blacklisted trap targets. used in PreActivate(atom/target)
+	var/list/blacklist = list(/obj/structure/closet/cardboard/agent) //evil fucked up boombox
 
 /datum/action/cooldown/mob_cooldown/explosive_booby_trap/PreActivate(atom/target)
 	if (!isobj(target))
 		return FALSE
 	if (!owner.Adjacent(target))
+		return FALSE
+	if(target.type in blacklist)
+		owner.balloon_alert(owner, "invalid target!")
 		return FALSE
 	return ..()
 

--- a/code/modules/mob/living/basic/guardian/guardian_types/explosive.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/explosive.dm
@@ -49,7 +49,7 @@
 		return FALSE
 	if (!owner.Adjacent(target))
 		return FALSE
-	if(target.type in blacklist)
+	if(is_type_in_list(target, blacklist))
 		owner.balloon_alert(owner, "invalid target!")
 		return FALSE
 	return ..()


### PR DESCRIPTION

## About The Pull Request
asked by admins to make this PR. does as the title says
## Why It's Good For The Game
a player movable invisible object that explodes when bumped into is kinda bullshit

## Changelog

:cl:
balance: explosive guardians cannot place traps on stealth boxes.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

