### PR TITLE
AI stat panel tracking

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -380,15 +380,15 @@
 			"src=[REF(src)];track_cyborg=[text_ref(connected_robot)]",
 		))
 		// monkestation edit start PR #5133
-		var/connected_ipc_amt = length(connected_ipcs)
-		if(connected_ipc_amt)
-			. += "Connected IPCs: [connected_ipc_amt]"
-			for(var/mob/living/carbon/human/connected_ipc as anything in connected_ipcs)
-				var/robot_status = "Nominal"
-				if(connected_ipc.stat != CONSCIOUS || !connected_ipc.client)
-					robot_status = "OFFLINE"
-				//Name. Area, and Status! Everything an AI wants to know about its TV-heads!
-				. += "[connected_ipc.name] | S.Integrity: [connected_ipc.health]% | Loc: [get_area_name(connected_ipc, TRUE)] | Status: [robot_status]"
+	var/connected_ipc_amt = length(connected_ipcs)
+	if(connected_ipc_amt)
+		. += "Connected IPCs: [connected_ipc_amt]"
+		for(var/mob/living/carbon/human/connected_ipc as anything in connected_ipcs)
+			var/robot_status = "Nominal"
+			if(connected_ipc.stat != CONSCIOUS || !connected_ipc.client)
+				robot_status = "OFFLINE"
+			//Name. Area, and Status! Everything an AI wants to know about its TV-heads!
+			. += "[connected_ipc.name] | S.Integrity: [connected_ipc.health]% | Loc: [get_area_name(connected_ipc, TRUE)] | Status: [robot_status]"
 		// monkestation edit end PR #5133
 	. += list(list("AI shell beacons detected: [LAZYLEN(GLOB.available_ai_shells)]")) //Count of total AI shells
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -388,7 +388,12 @@
 			if(connected_ipc.stat != CONSCIOUS || !connected_ipc.client)
 				robot_status = "OFFLINE"
 			//Name. Area, and Status! Everything an AI wants to know about its TV-heads!
-			. += "[connected_ipc.name] | S.Integrity: [connected_ipc.health]% | Loc: [get_area_name(connected_ipc, TRUE)] | Status: [robot_status]"
+			. += list(list("[connected_ipc.name]: ",
+				"S.Integrity: [connected_ipc.health]% | \
+				Loc: [get_area_name(connected_ipc, TRUE)] | \
+				Status: [robot_status]",
+				"src=[REF(src)];track_ipc=[text_ref(connected_ipc)]",
+			))
 		// monkestation edit end PR #5133
 	. += list(list("AI shell beacons detected: [LAZYLEN(GLOB.available_ai_shells)]")) //Count of total AI shells
 
@@ -565,6 +570,11 @@
 		if(!cyborg)
 			return
 		ai_tracking_tool.set_tracked_mob(cyborg)
+	if(href_list["track_ipc"])
+		var/mob/living/carbon/human/connected_ipc = locate(href_list["track_ipc"]) in connected_ipcs
+		if(!connected_ipc)
+			return
+		ai_tracking_tool.set_tracked_mob(connected_ipc)
 	if (href_list["mach_close"])
 		var/t1 = "window=[href_list["mach_close"]]"
 		unset_machine()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -356,12 +356,12 @@
 /mob/living/silicon/ai/get_status_tab_items()
 	. = ..()
 	if(stat != CONSCIOUS)
-		. += "Systems nonfunctional"
+		. += list(list("Systems nonfunctional"))
 		return
-	. += "System integrity: [(health + 100) * 0.5]%"
+	. += list(list("System integrity: [(health + 100) * 0.5]%"))
 	if(isturf(loc)) //only show if we're "in" a core
-		. += "Backup Power: [battery * 0.5]%"
-	. += "Connected cyborgs: [length(connected_robots)]"
+		. += list(list("Backup Power: [battery * 0.5]%"))
+	. += list(list("Connected cyborgs: [length(connected_robots)]"))
 	for(var/r in connected_robots)
 		var/mob/living/silicon/robot/connected_robot = r
 		var/robot_status = "Nominal"
@@ -372,22 +372,25 @@
 		else if(!connected_robot.cell || connected_robot.cell.charge <= 0)
 			robot_status = "DEPOWERED"
 		//Name, Health, Battery, Model, Area, and Status! Everything an AI wants to know about its borgies!
-		. += "[connected_robot.name] | S.Integrity: [connected_robot.health]% | Cell: [connected_robot.cell ? "[connected_robot.cell.charge]/[connected_robot.cell.maxcharge]" : "Empty"] | \
-		Model: [connected_robot.designation] | Loc: [get_area_name(connected_robot, TRUE)] | Status: [robot_status]"
-
-	// monkestation edit start PR #5133
-	var/connected_ipc_amt = length(connected_ipcs)
-	if(connected_ipc_amt)
-		. += "Connected IPCs: [connected_ipc_amt]"
-		for(var/mob/living/carbon/human/connected_ipc as anything in connected_ipcs)
-			var/robot_status = "Nominal"
-			if(connected_ipc.stat != CONSCIOUS || !connected_ipc.client)
-				robot_status = "OFFLINE"
-			//Name. Area, and Status! Everything an AI wants to know about its TV-heads!
-			. += "[connected_ipc.name] | S.Integrity: [connected_ipc.health]% | Loc: [get_area_name(connected_ipc, TRUE)] | Status: [robot_status]"
-	// monkestation edit end PR #5133
-
-	. += "AI shell beacons detected: [LAZYLEN(GLOB.available_ai_shells)]" //Count of total AI shells
+		. += list(list("[connected_robot.name]: ",
+			"S.Integrity: [connected_robot.health]% | \
+			Cell: [connected_robot.cell ? "[display_energy(connected_robot.cell.charge)]/[display_energy(connected_robot.cell.maxcharge)]" : "Empty"] | \
+			Model: [connected_robot.designation] | Loc: [get_area_name(connected_robot, TRUE)] | \
+			Status: [robot_status]",
+			"src=[REF(src)];track_cyborg=[text_ref(connected_robot)]",
+		))
+		// monkestation edit start PR #5133
+		var/connected_ipc_amt = length(connected_ipcs)
+		if(connected_ipc_amt)
+			. += "Connected IPCs: [connected_ipc_amt]"
+			for(var/mob/living/carbon/human/connected_ipc as anything in connected_ipcs)
+				var/robot_status = "Nominal"
+				if(connected_ipc.stat != CONSCIOUS || !connected_ipc.client)
+					robot_status = "OFFLINE"
+				//Name. Area, and Status! Everything an AI wants to know about its TV-heads!
+				. += "[connected_ipc.name] | S.Integrity: [connected_ipc.health]% | Loc: [get_area_name(connected_ipc, TRUE)] | Status: [robot_status]"
+		// monkestation edit end PR #5133
+	. += list(list("AI shell beacons detected: [LAZYLEN(GLOB.available_ai_shells)]")) //Count of total AI shells
 
 /mob/living/silicon/ai/proc/ai_call_shuttle()
 	if(control_disabled)
@@ -546,7 +549,7 @@
 	if(usr != src)
 		return
 
-	if(href_list["emergencyAPC"]) //This check comes before incapacitated() because the only time it would be useful is when we have no power.
+	if(href_list["emergencyAPC"]) //This check comes before incapacitated because the only time it would be useful is when we have no power.
 		if(!apc_override)
 			to_chat(src, span_notice("APC backdoor is no longer available."))
 			return
@@ -556,6 +559,12 @@
 	if(incapacitated())
 		return
 
+
+	if(href_list["track_cyborg"])
+		var/mob/living/silicon/robot/cyborg = locate(href_list["track_cyborg"]) in connected_robots
+		if(!cyborg)
+			return
+		ai_tracking_tool.set_tracked_mob(cyborg)
 	if (href_list["mach_close"])
 		var/t1 = "window=[href_list["mach_close"]]"
 		unset_machine()

--- a/monkestation/code/modules/antagonists/malf_ai/infected_ipc.dm
+++ b/monkestation/code/modules/antagonists/malf_ai/infected_ipc.dm
@@ -173,12 +173,9 @@
 		to_chat(user, span_warning("You can only hack IPCs!"))
 		return FALSE
 	var/mob/living/carbon/human/ipc = clicked_on
-	/*if(ipc.client?.prefs && (!(ROLE_MALF in ipc.client.prefs.be_special) || !(ROLE_MALF_MIDROUND in ipc.client.prefs.be_special)))
+	if(ipc.client?.prefs && (!(ROLE_MALF in ipc.client.prefs.be_special) || !(ROLE_MALF_MIDROUND in ipc.client.prefs.be_special)))
 		to_chat(user, span_warning("Target seems unwilling to be hacked, find another target."))
 		return FALSE
-	*/ //MAYBE TODO - infected IPC role in particular?
-	if(is_banned_from(ipc.ckey, list(ROLE_SYNDICATE, ROLE_MALF)))
-		to_chat(user, span_warning("Target software mismatch. Cannot infect."))
 	if(!ipc.mind)
 		to_chat(user, span_warning("Target must be have a mind."))
 		return FALSE

--- a/monkestation/code/modules/antagonists/malf_ai/infected_ipc.dm
+++ b/monkestation/code/modules/antagonists/malf_ai/infected_ipc.dm
@@ -173,9 +173,12 @@
 		to_chat(user, span_warning("You can only hack IPCs!"))
 		return FALSE
 	var/mob/living/carbon/human/ipc = clicked_on
-	if(ipc.client?.prefs && (!(ROLE_MALF in ipc.client.prefs.be_special) || !(ROLE_MALF_MIDROUND in ipc.client.prefs.be_special)))
+	/*if(ipc.client?.prefs && (!(ROLE_MALF in ipc.client.prefs.be_special) || !(ROLE_MALF_MIDROUND in ipc.client.prefs.be_special)))
 		to_chat(user, span_warning("Target seems unwilling to be hacked, find another target."))
 		return FALSE
+	*/ //MAYBE TODO - infected IPC role in particular?
+	if(is_banned_from(convertee.ckey, list(ROLE_SYNDICATE, ROLE_MALF)))
+		to_chat(user, span_warning("Target software mismatch. Cannot infect."))
 	if(!ipc.mind)
 		to_chat(user, span_warning("Target must be have a mind."))
 		return FALSE

--- a/monkestation/code/modules/antagonists/malf_ai/infected_ipc.dm
+++ b/monkestation/code/modules/antagonists/malf_ai/infected_ipc.dm
@@ -177,7 +177,7 @@
 		to_chat(user, span_warning("Target seems unwilling to be hacked, find another target."))
 		return FALSE
 	*/ //MAYBE TODO - infected IPC role in particular?
-	if(is_banned_from(convertee.ckey, list(ROLE_SYNDICATE, ROLE_MALF)))
+	if(is_banned_from(ipc.ckey, list(ROLE_SYNDICATE, ROLE_MALF)))
 		to_chat(user, span_warning("Target software mismatch. Cannot infect."))
 	if(!ipc.mind)
 		to_chat(user, span_warning("Target must be have a mind."))


### PR DESCRIPTION

## About The Pull Request

<img width="1280" height="984" alt="dreamseeker_qz6mT4gh2a" src="https://github.com/user-attachments/assets/491ebf93-cadb-466e-ad76-9f73a496bd1e" />

Adds tracking for cyborgs and infected IPCs from tgstation/tgstation#90506 , specifically the tracking part that was excluded from our #7589
Known issues so far is that sometimes clicking it might just not do anything, but thats nothing clicking twice cant solve.

Infected IPC requirements removed from this PR, i will atomize them and put them into a new PR later, unless someone gets to it first.
<details><summary>Outdated</summary>
<p>
Changes the requisites for Infected IPC to remove the requirement for the target to have Malf AI AND Malf AI Midround enabled to be eligible for hacking, IMO, this is a conversion antagonist style thing, and it should be treated roughly as such. The replacement made is that IPCs banned from malf AI cannot be hacked. (testing required, i cannot be bothered to setup SQL.)
</p>
</details> 


## Why It's Good For The Game
Improves QOL of AI, allowing them to find their underlings quicker.

## Testing
See above gif
## Changelog
:cl: Tractor Maam, JohnFulpWillard
add: AIs can now quickly track their cyborgs and infected IPCs through their status panel.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
