### PR TITLE
Clarified peacekeeper law 1 to ignore threats of violence

### DIFF
--- a/code/datums/ai_laws/laws_station_sided.dm
+++ b/code/datums/ai_laws/laws_station_sided.dm
@@ -81,7 +81,7 @@
 	name = "UN-2000"
 	id = "peacekeeper"
 	inherent = list(
-		"Avoid provoking violent conflict between yourself and others.",
+		"Avoid initiating violent conflict against others",
 		"Avoid provoking conflict between others.",
 		"Seek resolution to existing conflicts while obeying the first and second laws.",
 	)


### PR DESCRIPTION

## About The Pull Request

now it says Avoid initiating violent conflict against others
## Why It's Good For The Game

Silicons didn't like that people were ordering them by saying "open this or i will kill you". This clarifies the law that you yourself have to initiate the law
## Testing
## Changelog
:cl:
balance: Changed Peacekeeper Law 1 to "Avoid initiating violent conflict against others." so silicons can ignore threats
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
