### PR TITLE
Fix capitalization of limb targeting keybindings

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -169,7 +169,7 @@
 /datum/keybinding/mob/target/r_arm
 	hotkey_keys = list("Numpad4")
 	name = "target_r_arm"
-	full_name = "Target: right arm"
+	full_name = "Target: Right arm"
 	description = "Pressing this key targets the right arm. This will impact where you hit people, and can be used for surgery."
 	keybind_signal = COMSIG_KB_MOB_TARGETRIGHTARM_DOWN
 
@@ -183,7 +183,7 @@
 /datum/keybinding/mob/target/left_arm
 	hotkey_keys = list("Numpad6")
 	name = "target_left_arm"
-	full_name = "Target: left arm"
+	full_name = "Target: Left arm"
 	description = "Pressing this key targets the body. This will impact where you hit people, and can be used for surgery."
 	keybind_signal = COMSIG_KB_MOB_TARGETLEFTARM_DOWN
 
@@ -204,7 +204,7 @@
 /datum/keybinding/mob/target/left_leg
 	hotkey_keys = list("Numpad3")
 	name = "target_left_leg"
-	full_name = "Target: left leg"
+	full_name = "Target: Left leg"
 	description = "Pressing this key targets the left leg. This will impact where you hit people, and can be used for surgery."
 	keybind_signal = COMSIG_KB_MOB_TARGETLEFTLEG_DOWN
 

--- a/code/genesis_call.dme
+++ b/code/genesis_call.dme
@@ -50,3 +50,12 @@
  */
 /world/proc/_()
 	var/static/_ = world.Genesis()
+// BEGIN_INTERNALS
+// END_INTERNALS
+// BEGIN_FILE_DIR
+#define FILE_DIR .
+// END_FILE_DIR
+// BEGIN_PREFERENCES
+// END_PREFERENCES
+// BEGIN_INCLUDE
+// END_INCLUDE

--- a/code/genesis_call.dme
+++ b/code/genesis_call.dme
@@ -50,12 +50,3 @@
  */
 /world/proc/_()
 	var/static/_ = world.Genesis()
-// BEGIN_INTERNALS
-// END_INTERNALS
-// BEGIN_FILE_DIR
-#define FILE_DIR .
-// END_FILE_DIR
-// BEGIN_PREFERENCES
-// END_PREFERENCES
-// BEGIN_INCLUDE
-// END_INCLUDE


### PR DESCRIPTION

## About The Pull Request

Fix inconsistent capitalization of the "Target: Right arm", "Target: Left arm" and "Target: Left leg" keybindings
## Why It's Good For The Game
Once noticed, these careless mistakes are annoying.
## Testing
Tested on a private server. It works fine
## Changelog

"Target: right arm" changed to "Target: Right arm"
"Target: left arm" changed to "Target: Left arm"
"Target: left leg" changed to "Target: Left leg"
:cl:
spellcheck: fixed a few typos
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
