### PR TITLE
adds support for requesting basic metadata from the chat websocket

### DIFF
--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -95,6 +95,9 @@
 	if(type == "telemetry")
 		analyze_telemetry(payload)
 		return TRUE
+	if(type == "requestMetadata")
+		send_metadata()
+		return TRUE
 
 /**
  * public
@@ -103,3 +106,16 @@
  */
 /datum/tgui_panel/proc/send_roundrestart()
 	window.send_message("roundrestart")
+
+/**
+ * private
+ *
+ * Sent when a client requests metadata - used for websocket stuff.
+ */
+/datum/tgui_panel/proc/send_metadata()
+	window.send_message("metadata", list(
+		"round_id" = GLOB.round_id,
+		"map_name" = SSmapping.current_map?.map_name,
+		"round_duration" = round(STATION_TIME_PASSED() / 10, 1),
+		"gamestate" = SSticker.current_state,
+	))

--- a/tgui/packages/tgui-panel/websocket/helpers.ts
+++ b/tgui/packages/tgui-panel/websocket/helpers.ts
@@ -130,7 +130,7 @@ const setupWebsocket = (force = false) => {
   });
 
   websocket.addEventListener('message', (event) => {
-    if(event.data === "metadata") {
+    if(event.data === 'requestMetadata') {
       Byond.sendMessage('requestMetadata');
     }
   });

--- a/tgui/packages/tgui-panel/websocket/helpers.ts
+++ b/tgui/packages/tgui-panel/websocket/helpers.ts
@@ -125,7 +125,14 @@ const setupWebsocket = (force = false) => {
   websocket.addEventListener('open', () => {
     clearReconnectTimer();
     sendWSNotice('Websocket connected!', true);
+    Byond.sendMessage('requestMetadata'); // let's be nice and request metadata
     retryCount = 0;
+  });
+
+  websocket.addEventListener('message', (event) => {
+    if(event.data === "metadata") {
+      Byond.sendMessage('requestMetadata');
+    }
   });
 
   websocket.addEventListener('close', (ev) => {


### PR DESCRIPTION

## About The Pull Request

this simply adds a way for websocket clients to request metadata from the server. they send the string `requestMetadata`, and server responses with message type `metadata`,  with the payload containing the current round id, map name, round duration, and game state.

## Why It's Good For The Game

i want to log my chat via the websocket feature and organize them automatically based on round id.

## Testing

<img width="926" height="74" alt="2026-05-16 (1778947413) ~ Code" src="https://github.com/user-attachments/assets/d501852e-9b19-439c-a907-b0dd5d7620ea" />

## Changelog
:cl:
add: For the like, 5 people who actually use the websocket feature, you can now request metadata for them (round id, map name, round duration, game state)
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
