### PR TITLE
adds minor slowdown to regular syndicate modsuit

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1004,7 +1004,7 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	slowdown_inactive = 0.5
-	slowdown_active = 0
+	slowdown_active = 0.25
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/night, /obj/item/mod/module/hearing_protection)
 	allowed_suit_storage = list(

--- a/code/modules/uplink/uplink_items/utility_clothing.dm
+++ b/code/modules/uplink/uplink_items/utility_clothing.dm
@@ -44,7 +44,7 @@
 	// This one costs more than the nuke op counterpart
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	progression_minimum = 90 MINUTES
-	cost = 16
+	cost = 12
 	cant_discount = TRUE
 
 //---- MODULES


### PR DESCRIPTION
## About The Pull Request

syndicate modsuit now has 0.25 active slowdown (same as hos and captain mods)
elite modsuit cost is down to 12 from 16 as compromise

## Why It's Good For The Game

syndie mod is super strong now so it needs something to tone it down
0.25 is barely noticeable to the point where you can pretty much walk around in it comfortably so its not super bad in combat
elite remains with no slowdown

## Testing

just walked around in the modsuit on local host

## Changelog

:cl:
balance: syndicate modsuit now has 0.25 active slowdown
balance: elite modsuit now cost 12 TC
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
