### PR TITLE
cyborg deconstruction now drop upgrades

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -507,6 +507,10 @@
 
 	dump_into_mmi(drop_to)
 
+	// Remove upgrades.
+	for(var/obj/item/borg/upgrade/I in upgrades)
+		I.forceMove(get_turf(src))
+
 	qdel(src)
 
 


### PR DESCRIPTION

## About The Pull Request
Similar to how cyborg upgrades are dropped onto the floor when a cyborg's model is reset, a safe construction will also drop their upgrades onto the floor instead of deleting them from existence.

## Why It's Good For The Game
Bugfix. Upgrades shouldn't be deleted if the cyborg gets safely deconstructed. This usually happens when someone only cuts required lockdown wire to deconstruct instead of being lazy by cutting all the wires (which would reset the model and thus drop the upgrades).

## Testing
Installed cyborg upgrades by hand and then deconstructed a cyborg:
<img width="202" height="191" alt="wrenchCyborg" src="https://github.com/user-attachments/assets/ad22c3b9-12e0-4db2-8f12-71352398936c" />

## Changelog
:cl:
fix: Upon safe deconstruction, cyborg upgrades are now dropped onto the floor instead of being deleted.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
