### PR TITLE
pAIs can play music again

### DIFF
--- a/code/modules/instruments/songs/editor.dm
+++ b/code/modules/instruments/songs/editor.dm
@@ -116,7 +116,7 @@
 
 /datum/song/Topic(href, href_list)
 	if(cares_about_distance)
-		if(!usr.can_perform_action(parent, ALLOW_RESTING))
+		if(!usr.can_perform_action(parent, ALLOW_RESTING|ALLOW_PAI))
 			usr << browse(null, "window=instrument")
 			usr.unset_machine()
 			return


### PR DESCRIPTION
## About The Pull Request

Fixes pAIs not being able to use their music synthesizer.

Closes https://github.com/Monkestation/Monkestation2.0/issues/11632

## Changelog

:cl:
fix: pAIs can play music again.
/:cl: