### PR TITLE
Fixes loadout umbrellas not being recolourable.

### DIFF
--- a/code/game/objects/items/umbrellas.dm
+++ b/code/game/objects/items/umbrellas.dm
@@ -139,3 +139,6 @@
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+
+/obj/item/umbrella/consistent
+	random_color = FALSE

--- a/monkestation/code/modules/loadouts/items/inhand.dm
+++ b/monkestation/code/modules/loadouts/items/inhand.dm
@@ -89,7 +89,7 @@ GLOBAL_LIST_INIT(loadout_inhand_items, generate_loadout_items(/datum/loadout_ite
 
 /datum/loadout_item/inhand/umbrella
 	name = "Umbrella (recolorable)"
-	item_path = /obj/item/umbrella
+	item_path = /obj/item/umbrella/consistent
 
 /datum/loadout_item/inhand/parasol
 	name = "Parasol"

--- a/monkestation/code/modules/store/store_items/in_hand.dm
+++ b/monkestation/code/modules/store/store_items/in_hand.dm
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(store_inhand_items, generate_store_items(/datum/store_item/inha
 
 /datum/store_item/inhand/umbrella
 	name = "Umbrella (recolorable)"
-	item_path = /obj/item/umbrella
+	item_path = /obj/item/umbrella/consistent
 	item_cost = 2000
 
 /datum/store_item/inhand/parasol


### PR DESCRIPTION

## About The Pull Request
Fixes recoulorable umbrellas spawning in random colours.
## Why It's Good For The Game
Bug fix, woops.
## Testing

https://github.com/user-attachments/assets/5ba679f8-d777-4670-8fcc-6018fefe110b
## Changelog
:cl:
fix: Loadout umbrellas no longer colour themselves randomly.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
