### PR TITLE
fixes cyborg items inserting into normal bags + cyborg soh fix

### DIFF
--- a/code/__DEFINES/traits/sources.dm
+++ b/code/__DEFINES/traits/sources.dm
@@ -23,6 +23,8 @@
 /// cannot be removed without admin intervention
 #define ROUNDSTART_TRAIT "roundstart"
 #define JOB_TRAIT "job"
+/// Trait given by cyborg actively holding it.
+#define CYBORG_ITEM_TRAIT "cyborg-item"
 /// Any traits granted by quirks.
 #define QUIRK_TRAIT "quirk_trait"
 /// (B)admins only.

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -51,7 +51,7 @@
 	var/locked = STORAGE_NOT_LOCKED
 	/// whether or not we should open when clicked
 	var/attack_hand_interact = TRUE
-	/// whether or not we allow storage objects of the same size inside
+	/// Whether or not we allow storage objects of the same size inside. Will skip the check that stops inserting items into it if it is inside of a smaller storage object.
 	var/allow_big_nesting = FALSE
 
 	/// should we be allowed to pickup an object by clicking it
@@ -391,7 +391,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	// this is valid if the container our location is being held in is a storage item
 	var/datum/storage/bigger_fish = parent.loc.atom_storage
-	if(bigger_fish && bigger_fish.max_specific_storage < max_specific_storage)
+	if(bigger_fish && bigger_fish.max_specific_storage < max_specific_storage && !bigger_fish.allow_big_nesting)
 		if(messages && user)
 			user.balloon_alert(user, "[LOWER_TEXT(parent.loc.name)] is in the way!")
 		return FALSE

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -49,10 +49,11 @@
 		return
 	item_module.mouse_opacity = initial(item_module.mouse_opacity)
 	observer_screen_update(item_module)
-
+	ADD_TRAIT(item_module, TRAIT_NODROP, CYBORG_ITEM_TRAIT) // This prevents items being from inserted anywhere that isn't our inventory (e.g. no more putting it in someone else's dufflebag).
 
 /// Helper for cyborgs unequipping things.
 /mob/living/silicon/robot/proc/deactivate_module(obj/item/item_module)
+	REMOVE_TRAIT(item_module, TRAIT_NODROP, CYBORG_ITEM_TRAIT)
 	transferItemToLoc(item_module, newloc = model)
 
 /mob/living/silicon/robot/doUnEquip(obj/item/item_dropping, force, atom/newloc, no_move, invdrop, silent)


### PR DESCRIPTION

## About The Pull Request
Cyborg items (aka modules) can no longer be inserted in non-cyborg inventories by giving it nodrop until it is about to be unequipped and sent to the cyborg's inventory.

Cyborg inventory now allows items to be inserted into bigger storage datums. This is only used to allow mining satchel of holding to to pick up ores while it is unequipped.

## Why It's Good For The Game
Bugfix.

## Testing
Spawned as a miner cyborg and dufflebag. Selected scanner and clicked dufflebag. Gave balloon alert that it cannot be dropped.

Spawned as a miner cyborg. Gave satchel of holding upgrade. Equipped it. Unequipped it. Moved over diamond ore. Picked up ore.

## Changelog
:cl:
fix: Cyborg items can no longer be inserted into non-cyborg inventories (e.g. normal satchels).
fix: Miner Cyborg's satchel of holding now correctly picks up ores while unequipped.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
