### PR TITLE
security gets bungo donuts as heirlooms instead of ERRORs

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -32,7 +32,7 @@
 	display_order = JOB_DISPLAY_ORDER_HEAD_OF_SECURITY
 	bounty_types = CIV_JOB_SEC
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator, /obj/item/megaphone/sec)
+	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut/bungo, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator, /obj/item/megaphone/sec)
 	rpg_title = "Guard Leader"
 	job_flags = STATION_JOB_FLAGS | HEAD_OF_STAFF_JOB_FLAGS
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -28,7 +28,7 @@
 		/datum/job_department/security,
 		)
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator)
+	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut/bungo, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator)
 
 	mail_goodies = list(
 		/obj/item/food/donut/caramel = 10,

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -29,7 +29,7 @@
 		/datum/job_department/security,
 		)
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator)
+	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/restraints/handcuffs, /obj/item/assembly/flash/handheld, /obj/item/clothing/mask/whistle, /obj/item/food/donut/bungo, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/citationinator)
 
 	mail_goodies = list(
 		/obj/item/storage/fancy/cigarettes = 15,


### PR DESCRIPTION

## About The Pull Request
fixes:https://github.com/Monkestation/Monkestation2.0/issues/11647

## Why It's Good For The Game
bug fix

## Changelog

:cl:
fix: security gets bungo donuts as heirlooms instead of ERRORs.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

