### PR TITLE
Increase sandevistans price and removes bundle from name of two items in uplink

### DIFF
--- a/code/modules/uplink/uplink_items/cybernetics.dm
+++ b/code/modules/uplink/uplink_items/cybernetics.dm
@@ -8,7 +8,7 @@
 	cant_discount = FALSE
 
 /datum/uplink_item/cybernetics/sandy
-	name = "Sandevistan Bundle"
+	name = "Sandevistan Implant"
 	desc = "A box containing an autosurgeon for a sandevistan, allowing you to outspeed targets."
 	item = /obj/item/autosurgeon/syndicate/sandy
 	cost = 13
@@ -26,7 +26,7 @@
 	new /obj/item/autosurgeon/syndicate/syndie_mantis/l(src)
 
 /datum/uplink_item/cybernetics/dualwield
-	name = "C.C.M.S Bundle"
+	name = "C.C.M.S Implant"
 	desc = "A box containing an autosurgeon a C.C.M.S implant that lets you dual wield melee weapons."
 	item = /obj/item/autosurgeon/syndicate/dualwield
 	cost = 8

--- a/code/modules/uplink/uplink_items/cybernetics.dm
+++ b/code/modules/uplink/uplink_items/cybernetics.dm
@@ -11,7 +11,7 @@
 	name = "Sandevistan Bundle"
 	desc = "A box containing an autosurgeon for a sandevistan, allowing you to outspeed targets."
 	item = /obj/item/autosurgeon/syndicate/sandy
-	cost = 10
+	cost = 13
 	purchasable_from = UPLINK_TRAITORS
 
 /datum/uplink_item/cybernetics/mantis


### PR DESCRIPTION

## About The Pull Request
Ups sandevistans price to 13 tc from 10

Removes bundle from the names of CCMS and Sandevistan in uplink since neither are bundles, now named CCMS Implant and Sandevistan Implant.

## Why It's Good For The Game
In https://github.com/Monkestation/Monkestation2.0/pull/11401 I gave sandy a fix/buffed which made it much better, I originally didn't increase the price from 10 TC since I figured it was a good buff but a minor one, I kinda underestimated how much better the fixed sandy is so corrects its price to 13 tc.

## Testing
Booted and checked yes names and price change applied properly

## Changelog

:cl:
balance: increases sandevistans price to 13 TC
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

