### PR TITLE
rubbershot has the same speed as other ballistics + lower cost in the uplink

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -76,7 +76,6 @@
 	stamina = 10
 	sharpness = NONE
 	embed_type = null
-	speed = 0.8
 	stamina_falloff_tile = 0
 	damage_falloff_tile = 0
 	ricochets_max = 4

--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -110,5 +110,5 @@
 /datum/uplink_item/ammo/rubber
 	name = "Rubber Ammo Box"
 	desc = "A box with 16 rubber shells. A less-lethal high stamina damage spread of rubber pellets."
-	cost = 3
+	cost = 2
 	item = /obj/item/ammo_box/advanced/s12gauge/rubber


### PR DESCRIPTION

## About The Pull Request
title

## Why It's Good For The Game
0.8 feels quite slow and you cant use it effectively because of it. ill lower the stamina damage if it becomes a bit much

## Changelog

:cl:
balance: rubbershot has the same speed as other ballistics.
balance: lowered the cost of rubbershot ammo boxes to 2 TC from 3 in the uplink.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

