### PR TITLE
fix belt reskins

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -666,6 +666,7 @@
 	worn_icon_state = "security"
 	content_overlays = TRUE
 	uses_advanced_reskins = FALSE
+	unique_reskin = null
 
 /obj/item/storage/belt/military/abductor/full/PopulateContents()
 	new /obj/item/screwdriver/abductor(src)
@@ -683,6 +684,7 @@
 	inhand_icon_state = "security"
 	worn_icon_state = "military"
 	uses_advanced_reskins = FALSE
+	unique_reskin = null
 
 /obj/item/storage/belt/military/assault
 	name = "assault belt"
@@ -691,6 +693,7 @@
 	inhand_icon_state = "security"
 	worn_icon_state = "assault"
 	uses_advanced_reskins = FALSE
+	unique_reskin = null
 
 /obj/item/storage/belt/military/assault/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

setting `uses_advanced_reskins = FALSE` doesnt actually prevent items from using reskins it just makes them use not advanced reskin or whatever i dont know
have to set `unique_reskin = null ` instead

fixes #11609 

## Why It's Good For The Game

bug fix

## Testing

alt clicked assault belts in game and they didnt try to reskin them woaw

## Changelog

:cl:
fix: fixed being able to reskin assault, abductor and ect. belts into...errors
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
