### PR TITLE
Silicons may no longer be PDA bombed.

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -340,12 +340,17 @@
 
 /obj/item/modular_computer/pda/silicon/Initialize(mapload)
 	. = ..()
+	RegisterSignal(src, COMSIG_TABLET_CHECK_DETONATE, PROC_REF(tab_no_detonate))
 	vis_flags |= VIS_INHERIT_ID
 	silicon_owner = loc
 	if(!istype(silicon_owner))
 		silicon_owner = null
 		stack_trace("[type] initialized outside of a silicon, deleting.")
 		return INITIALIZE_HINT_QDEL
+
+/obj/item/modular_computer/pda/silicon/proc/tab_no_detonate() // if a silicon PDA blows up, thats Not Great and Cant Be Fixed
+	SIGNAL_HANDLER
+	return COMPONENT_TABLET_NO_DETONATE
 
 /obj/item/modular_computer/pda/silicon/Destroy()
 	silicon_owner = null


### PR DESCRIPTION

## About The Pull Request
Adds the captains detomatix immunity to silicon PDAs.
## Why It's Good For The Game
When a silicon PDA is destroyed, it results in a Not Good situation where the silicon permanently loses an important tool from its set barring reconstruction and relinkage.
This is reflected in Revelation, the hard drive destruction program, by instakilling cyborgs instead of disabling their PDA, on this vein, i may find it interesting in the future to replace this with like, shutting down the AI temporarily.
## Testing

<img width="295" height="113" alt="image" src="https://github.com/user-attachments/assets/c028a83a-48f1-4688-ab7f-dd1f48eb7161" />
failed to send an AI a PDA bomb.


## Changelog
:cl:
fix: silicons can no longer have their integrated PDA permanently bricked by receiving a PDA bomb.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
