### PR TITLE
Silicons can be PDA bombed, causing disruptions instead of an explosion.

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -340,34 +340,12 @@
 
 /obj/item/modular_computer/pda/silicon/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_TABLET_CHECK_DETONATE, PROC_REF(tab_no_detonate))
 	vis_flags |= VIS_INHERIT_ID
 	silicon_owner = loc
 	if(!istype(silicon_owner))
 		silicon_owner = null
 		stack_trace("[type] initialized outside of a silicon, deleting.")
 		return INITIALIZE_HINT_QDEL
-
-/obj/item/modular_computer/pda/silicon/proc/tab_no_detonate() // if a silicon PDA blows up, thats Not Great and Cant Be Fixed
-	SIGNAL_HANDLER
-	. = COMPONENT_TABLET_NO_DETONATE
-	to_chat(silicon_owner, span_danger("POWER SURGE DETECTED/"))
-	do_sparks(4, FALSE, src)
-	if(isAI(silicon_owner))
-		silicon_owner.adjustFireLoss(25)
-		if(!isturf(silicon_owner.loc)) //AI not in core? not wise to disable a random APC then.
-			silicon_owner.Paralyze(10 SECONDS)
-		else
-			var/area/AIarea = get_area(silicon_owner)
-			var/obj/machinery/power/apc/AIapc = AIarea.apc
-			if(AIapc)
-				AIapc.energy_fail(45, forced = TRUE)
-				do_sparks(4, FALSE, AIapc)
-	else if(ispAI(silicon_owner))
-		silicon_owner.emp_act(EMP_HEAVY)
-	else //how did this happen cyborgs shouldnt have messengers, oh well!
-		silicon_owner.Paralyze(5 SECONDS)
-
 
 /obj/item/modular_computer/pda/silicon/Destroy()
 	silicon_owner = null
@@ -449,6 +427,28 @@
 
 /obj/item/modular_computer/pda/silicon/ui_state(mob/user)
 	return GLOB.reverse_contained_state
+
+/obj/item/modular_computer/pda/silicon/explode(mob/target, mob/bomber, from_message_menu)
+	if(from_message_menu)
+		log_bomber(null, null, target, "'s induced disruption as [target.p_they()] tried to open their tablet message menu because of a recent tablet bomb sent to a silicon.")
+	else
+		log_bomber(bomber, "successfully tablet-disrupted", target, "as [target.p_they()] tried to reply to a rigged tablet message sent to a silicon [bomber && !is_special_character(bomber) ? "(SENT BY NON-ANTAG)" : ""]")
+	to_chat(silicon_owner, span_danger("POWER SURGE DETECTED/"))
+	do_sparks(4, FALSE, src)
+	if(isAI(silicon_owner))
+		silicon_owner.adjustFireLoss(25)
+		if(!isturf(silicon_owner.loc)) //AI not in core? not wise to disable a random APC then.
+			silicon_owner.Unconscious(10 SECONDS,  TRUE)
+		else
+			var/area/AIarea = get_area(silicon_owner)
+			var/obj/machinery/power/apc/AIapc = AIarea.apc
+			if(AIapc)
+				AIapc.energy_fail(45, forced = TRUE)
+				do_sparks(4, FALSE, AIapc)
+	else if(ispAI(silicon_owner))
+		silicon_owner.emp_act(EMP_HEAVY)
+	else //how did this happen cyborgs shouldnt have messengers, oh well!
+		silicon_owner.Paralyze(5 SECONDS)
 
 /obj/item/modular_computer/pda/silicon/cyborg/syndicate
 	icon_state = "tablet-silicon-syndicate"

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -350,7 +350,24 @@
 
 /obj/item/modular_computer/pda/silicon/proc/tab_no_detonate() // if a silicon PDA blows up, thats Not Great and Cant Be Fixed
 	SIGNAL_HANDLER
-	return COMPONENT_TABLET_NO_DETONATE
+	. = COMPONENT_TABLET_NO_DETONATE
+	to_chat(silicon_owner, span_danger("POWER SURGE DETECTED/"))
+	do_sparks(4, FALSE, src)
+	if(isAI(silicon_owner))
+		silicon_owner.adjustFireLoss(25)
+		if(!isturf(silicon_owner.loc)) //AI not in core? not wise to disable a random APC then.
+			silicon_owner.Paralyze(10 SECONDS)
+		else
+			var/area/AIarea = get_area(silicon_owner)
+			var/obj/machinery/power/apc/AIapc = AIarea.apc
+			if(AIapc)
+				AIapc.energy_fail(45, forced = TRUE)
+				do_sparks(4, FALSE, AIapc)
+	else if(ispAI(silicon_owner))
+		silicon_owner.emp_act(EMP_HEAVY)
+	else //how did this happen cyborgs shouldnt have messengers, oh well!
+		silicon_owner.Paralyze(5 SECONDS)
+
 
 /obj/item/modular_computer/pda/silicon/Destroy()
 	silicon_owner = null

--- a/code/modules/power/apc/apc_power_proc.dm
+++ b/code/modules/power/apc/apc_power_proc.dm
@@ -122,14 +122,15 @@
 		terminal.master = null
 		terminal = null
 
-/obj/machinery/power/apc/proc/energy_fail(duration)
-	for(var/obj/machinery/failing_machine in area.contents)
-		if(failing_machine.critical_machine)
-			return
+/obj/machinery/power/apc/proc/energy_fail(duration, forced = FALSE)
+	if(forced == FALSE)
+		for(var/obj/machinery/failing_machine in area.contents)
+			if(failing_machine.critical_machine)
+				return
 
-	for(var/mob/living/silicon/ai as anything in GLOB.ai_list)
-		if(get_area(ai) == area)
-			return
+		for(var/mob/living/silicon/ai as anything in GLOB.ai_list)
+			if(get_area(ai) == area)
+				return
 
 	failure_timer = max(failure_timer, round(duration))
 	update()


### PR DESCRIPTION

## About The Pull Request
enables the ability to PDA bomb silicons again, creating a disrupting effect depending on the type of silicon that opened it instead of blowing up and bricking the silicons toolkit.

When an AI is bombed:
It takes 25 burn damage
If the AI is in a core, it causes an energy failure on its APC, disabling it for 45 seconds, or until the AI reestablishes a link to the APC and reboots it manually. A forced var is added to APC power failure to do this.
If the AI is not in a core, such as a mech it is made unconscious for 10 seconds.

When a pAI is bombed:
It takes a heavy EMP.

When anything else with a silicon PDA is bombed
how did this happen, it gets paralyzed for 5 seconds.
## Why It's Good For The Game
I am being paid 2 med 1 high for this by the rat.
Swaps out a bug for a Feature:tm:, could probably use this to get a headstart breaching an AIs core, or disrupting them off your antics.
## Testing


<img width="299" height="112" alt="image" src="https://github.com/user-attachments/assets/af0b026f-9530-43ea-a6b3-bf2c5a911345" />

<img width="315" height="325" alt="image" src="https://github.com/user-attachments/assets/373876c1-cd04-42dc-92e9-81923b65560f" />


## Changelog
:cl:
add: Silicons may be PDA bombed again, creating a disrupting effect instead of an explosion.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
