### PR TITLE
Raise cost of busted necropolis chests by 25% (nerf miners)

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -81,7 +81,7 @@
 /datum/orderable_item/mining/surplusnecro
 	item_path = /obj/structure/closet/crate/necropolis/surplus
 	desc = "A leftover necropolis crate from the Mining RND storage warehouse. Content quality not guranteed, but you dont need a key."
-	cost_per_order = 5384 //your literally buying a necropolis crate, for no key, and no risk of combat or being dumped in a pit so it costs 3500 to shuttle buy
+	cost_per_order = 6730 //your literally buying a necropolis crate, for no key, and no risk of combat or being dumped in a pit so it costs 4375 to shuttle buy
 
 /datum/orderable_item/mining/conscription_kit
 	item_path = /obj/item/storage/backpack/duffelbag/mining_conscript


### PR DESCRIPTION
## About The Pull Request

Raises the mining point cost of busted chests by 25%, as requested by headmins

## Why It's Good For The Game

A decent arcmining setup can yield hundreds of thousands of points if done properly, which means miners can get tons of loot without any risk whatsoever beyond the time investment of setting up arcmining, and doing vents (which are one and done)
Ordering through the shuttle rather than pod still discounts the purchase by 35%, so the new shuttle price is still 10% cheaper than the old pod price
## Testing
Number change

## Changelog

:cl:
balance: The mining point cost of busted necropolis chests has been raised by 25%
/:cl:


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
