### PR TITLE
Adds seclites, Sandbags, to MP Vendor, and buffs explorer vest a small bit (buff miners)

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -62,6 +62,10 @@
 	item_path = /obj/item/storage/box/minertracker
 	cost_per_order = 600
 
+/datum/orderable_item/mining/sandbags
+	item_path = /obj/item/stack/sheet/mineral/sandbags/five
+	cost_per_order = 300
+
 /datum/orderable_item/mining/fulton_core //i really have to wonder why the fulton core and the fulton were not next to each other from the beginning
 	item_path = /obj/item/fulton_core
 	cost_per_order = 400
@@ -86,6 +90,10 @@
 /datum/orderable_item/mining/conscription_kit
 	item_path = /obj/item/storage/backpack/duffelbag/mining_conscript
 	cost_per_order = 1500
+
+/datum/orderable_item/mining/seclite
+	item_path = /obj/item/flashlight/seclite
+	cost_per_order = 200
 
 /datum/orderable_item/mining/mining_drone //welcome to the big boy tab fellah
 	item_path = /mob/living/basic/mining_drone

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -104,6 +104,9 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	. = ..()
 	. += span_notice("You can build a sandbag by right clicking on an empty floor.")
 
+/obj/item/stack/sheet/mineral/sandbags/five
+	amount = 5
+
 /obj/item/emptysandbag
 	name = "empty sandbag"
 	desc = "A bag to be filled with sand."

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -444,9 +444,9 @@
 
 /obj/item/storage/belt/mining/Initialize(mapload)
 	. = ..()
-	atom_storage.max_slots = 6
+	atom_storage.max_slots = 7
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
-	atom_storage.max_total_storage = 20
+	atom_storage.max_total_storage = 24
 	atom_storage.set_holdable(list(
 		/obj/item/analyzer,
 		/obj/item/clothing/gloves,


### PR DESCRIPTION
## About The Pull Request
Adds a stack of 5 prefilled sandbags to the MP vendor for 300 points 
Adds a seclite to the MP vendor for 200 points
Buffs explorer's vest to have 7 slots, and to hold 24 max weight, from 20

## Why It's Good For The Game
Sandbags and seclites are mostly a convivence, you can already get seclites from conscription kits and sandbags spawn in the miner lockers
Explorers vest is mildly overshadowed by the trenchjockey or similar packs and wearing a satchel on your belt

## Testing
Tested, works in game
<img width="584" height="316" alt="image" src="https://github.com/user-attachments/assets/d421704b-478c-4fbf-ab10-e571a2b68c49" />

## Changelog

:cl:
add: Seclites can now be bought from the mining points vendor
add: 5 prefilled sandbags can now be bought from the mining points vendor
balance: Explorer's vest now has 7 slots and 24 max weight
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
