### PR TITLE
Examining a ID card will now show its mining / bitrunning points, if it has any (qql miners)

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -792,6 +792,10 @@
 		if(ACCESS_COMMAND in access)
 			var/datum/bank_account/linked_dept = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
 			. += "The [linked_dept.account_holder] linked to the ID reports a balance of [linked_dept.account_balance] cr."
+		if(registered_account.mining_points)
+			. += "The account linked to the ID has [registered_account.mining_points] mining points available."
+		if(registered_account.bitrunning_points)
+			. += "The account linked to the ID has [registered_account.bitrunning_points] bitrunning points available."
 
 	if(HAS_TRAIT(user, TRAIT_ID_APPRAISER))
 		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Hmm... yes, this ID was issued from Central Command!") : span_boldnotice("This ID was created in this sector, not by Central Command.")

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -793,9 +793,9 @@
 			var/datum/bank_account/linked_dept = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
 			. += "The [linked_dept.account_holder] linked to the ID reports a balance of [linked_dept.account_balance] cr."
 		if(registered_account.mining_points)
-			. += "The account linked to the ID has [registered_account.mining_points] mining points available."
+			. += span_notice("The account linked to the ID has [registered_account.mining_points] mining points available.")
 		if(registered_account.bitrunning_points)
-			. += "The account linked to the ID has [registered_account.bitrunning_points] bitrunning points available."
+			. += span_notice("The account linked to the ID has [registered_account.bitrunning_points] bitrunning points available.")
 
 	if(HAS_TRAIT(user, TRAIT_ID_APPRAISER))
 		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Hmm... yes, this ID was issued from Central Command!") : span_boldnotice("This ID was created in this sector, not by Central Command.")


### PR DESCRIPTION
## About The Pull Request
Makes examining a ID card show the relevant point totals. QQL

## Why It's Good For The Game
Having to go to a specific machine or whatever to check the point balance of something is a bit annoying

## Testing
<img width="634" height="148" alt="image" src="https://github.com/user-attachments/assets/7c66e632-12da-479a-91c1-660a0fe050c0" />

## Changelog
:cl:
qol: Examining a ID card will now show its amounts of bitrunning and mining points, should it have any.
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
