### PR TITLE
Removes Deprecated `baseUrl` from tsconfig.json

### DIFF
--- a/tgui/tsconfig.json
+++ b/tgui/tsconfig.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"allowSyntheticDefaultImports": true,
-		"baseUrl": ".",
 		"checkJs": false,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
@@ -13,14 +12,14 @@
 		"moduleResolution": "bundler",
 		"noEmit": true,
 		"paths": {
-			"tgui": ["packages/tgui"],
-			"tgui/*": ["packages/tgui/*"],
-			"tgui-panel": ["packages/tgui-panel"],
-			"tgui-panel/*": ["packages/tgui-panel/*"],
-			"tgui-say": ["packages/tgui-say"],
-			"tgui-say/*": ["packages/tgui-say/*"],
-			"tgui-dev-server": ["packages/tgui-dev-server"],
-			"tgui-dev-server/*": ["packages/tgui-dev-server/*"]
+			"tgui": ["./packages/tgui"],
+			"tgui/*": ["./packages/tgui/*"],
+			"tgui-panel": ["./packages/tgui-panel"],
+			"tgui-panel/*": ["./packages/tgui-panel/*"],
+			"tgui-say": ["./packages/tgui-say"],
+			"tgui-say/*": ["./packages/tgui-say/*"],
+			"tgui-dev-server": ["./packages/tgui-dev-server"],
+			"tgui-dev-server/*": ["./packages/tgui-dev-server/*"]
 		},
 		"resolveJsonModule": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/pull/96008

> See why [baseurl is deprecated](https://stackoverflow.com/questions/79923194/option-baseurl-is-deprecated-and-will-stop-functioning-in-typescript-7) moving into typescript 7

the vscode error annoys me constantly.