### PR TITLE
hopefully fix infinitely stacking salt piles

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -415,7 +415,12 @@
 	if(!istype(exposed_turf) || (reac_volume < 1))
 		return
 
-	new/obj/effect/decal/cleanable/food/salt(exposed_turf)
+	var/obj/effect/decal/cleanable/food/salt/old_salt = locate() in exposed_turf
+	if(QDELETED(old_salt))
+		new /obj/effect/decal/cleanable/food/salt(exposed_turf)
+	else
+		old_salt.safepasses = initial(old_salt.safepasses)
+
 
 /datum/reagent/consumable/salt/expose_mob(mob/living/carbon/exposed_carbon, methods, reac_volume)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -412,7 +412,7 @@
 
 /datum/reagent/consumable/salt/expose_turf(turf/exposed_turf, reac_volume) //Creates an umbra-blocking salt pile
 	. = ..()
-	if(!istype(exposed_turf) || (reac_volume < 1))
+	if(!istype(exposed_turf) || isgroundlessturf(exposed_turf) || (reac_volume < 1))
 		return
 
 	var/obj/effect/decal/cleanable/food/salt/old_salt = locate() in exposed_turf

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -421,7 +421,6 @@
 	else
 		old_salt.safepasses = initial(old_salt.safepasses)
 
-
 /datum/reagent/consumable/salt/expose_mob(mob/living/carbon/exposed_carbon, methods, reac_volume)
 	. = ..()
 	if(!iscarbon(exposed_carbon) || !(methods & (PATCH|TOUCH|VAPOR)))


### PR DESCRIPTION
## About The Pull Request

makes it so that if salt reagent is exposed to a turf that already has salt on it, it just "resets" it instead of making a new salt pile on top of it.

in theory decals should merge anyways, but they don't actually in practice for some reason, and I do _not_ want to deep dive into that at the moment. fixing it this way is still far better than having my FPS drop to 5 whenever someone uses a smoke machine against a revenant.

also made it so salt piles won't spawn on groundless turfs.

Fixes https://github.com/Monkestation/Monkestation2.0/issues/11677

## Why It's Good For The Game

<img width="597" height="939" alt="2026-05-22 (1779507960) ~ dreamseeker" src="https://github.com/user-attachments/assets/3779bb14-414a-468b-9c20-d4cda072a997" />

<img width="211" height="1400" alt="2026-05-22 (1779507800)" src="https://github.com/user-attachments/assets/c83b0f0a-f840-4f92-8599-5d475f8f7ee1" />


## Changelog

:cl:
fix: Hopefully fixed infinitely stacking salt piles that would kill the FPS of anyone unfortunate enough to be nearby.
fix: Salt piles will no longer spawn in mid-air / on groundless turfs.
/:cl:
