### PR TITLE
exploding while jaunting causes a tear in the fabric of reality + chem explosions originate from their reagent holder atom

### DIFF
--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -96,11 +96,7 @@
 /datum/effect_system/reagents_explosion/set_up(amt, loca, flash = FALSE, flash_fact = 0, message = TRUE)
 	amount = amt
 	explosion_message = message
-	if(isturf(loca))
-		location = loca
-	else
-		location = get_turf(loca)
-
+	location = loca
 	flashing = flash
 	flashing_factor = flash_fact
 

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -311,7 +311,7 @@
 		// monkestation edit end
 
 		var/datum/effect_system/reagents_explosion/e = new()
-		e.set_up(power , T, 0, 0)
+		e.set_up(power , holder.my_atom, 0, 0)
 		e.start(holder.my_atom)
 	holder.clear_reagents()
 

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -19,6 +19,9 @@
 	/// What dummy mob type do we put jaunters in on jaunt?
 	var/jaunt_type = /obj/effect/dummy/phased_mob
 
+	/// Do we gib when an explosion originates from us when jaunting?
+	var/gib_from_internal_explosion = TRUE
+
 /datum/action/cooldown/spell/jaunt/get_caster_from_target(atom/target)
 	if(istype(target.loc, jaunt_type))
 		return target
@@ -78,7 +81,26 @@
 
 	// This needs to happen at the end, after all the traits and stuff is handled
 	SEND_SIGNAL(jaunter, COMSIG_MOB_ENTER_JAUNT, src, jaunt)
+	if(gib_from_internal_explosion)
+		RegisterSignal(jaunter, COMSIG_ATOM_INTERNAL_EXPLOSION, PROC_REF(poof), jaunter)
 	return jaunt
+
+/// If you try using chemical grenades or other methods to explode while invicible by jaunting, expect a consequence
+/datum/action/cooldown/spell/jaunt/proc/poof(mob/living/jaunter)
+	SIGNAL_HANDLER
+
+	if(!jaunter || !gib_from_internal_explosion)
+		return
+	exit_jaunt(jaunter)
+	jaunter.visible_message(span_danger("[jaunter] suddenly appears as the air around them warps stretching them apart!"),
+			span_userdanger("You feel a sudden cosmic force push from within as your body starts to stretch itself apart. Your last thought is \"Oh, fuck.\""),
+			span_hear("You hear a high-pitched shear as the air around you warps."))
+	var/turf/rift_loc = get_turf(jaunter)
+	jaunter.gib()
+	var/obj/reality_tear/temporary/tear = new(rift_loc)
+	tear.start_disaster()
+	jaunter.investigate_log("has been gibbed by an internal explosion while jaunting.", INVESTIGATE_DEATHS)
+	playsound(rift_loc,'sound/effects/supermatter.ogg', 200, TRUE)
 
 /**
  * Ejects the [unjaunter] from jaunt
@@ -102,6 +124,8 @@
 	if(loc_override)
 		jaunt.forceMove(loc_override)
 	jaunt.eject_jaunter()
+	if(gib_from_internal_explosion)
+		UnregisterSignal(unjaunter, COMSIG_ATOM_INTERNAL_EXPLOSION)
 	return TRUE
 
 /**

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -85,7 +85,7 @@
 		RegisterSignal(jaunter, COMSIG_ATOM_INTERNAL_EXPLOSION, PROC_REF(poof), jaunter)
 	return jaunt
 
-/// If you try using chemical grenades or other methods to explode while invicible by jaunting, expect a consequence
+/// If you try using chemical grenades or other methods to explode while invincible by jaunting, expect a consequence
 /datum/action/cooldown/spell/jaunt/proc/poof(mob/living/jaunter)
 	SIGNAL_HANDLER
 

--- a/monkestation/code/game/machinery/bomb_actualizer.dm
+++ b/monkestation/code/game/machinery/bomb_actualizer.dm
@@ -1,5 +1,5 @@
 /obj/machinery/bomb_actualizer
-	name = "Bomb Actualizer"
+	name = "bomb actualizer"
 	desc = "An advanced machine capable of releasing the normally bluespace-inhibited destructive potential of a bomb assembly... or so the sticker says"
 	circuit = /obj/item/circuitboard/machine/bomb_actualizer
 	icon = 'icons/obj/machines/research.dmi'


### PR DESCRIPTION

## About The Pull Request
if an explosion originates from someone whose jaunting it forces them out of the jaunt and creates a tear in the fabric of reality ontop of them.

also made chem explosions originate from their reagent holder instead of always the turf the reagent holder atom is on.

## Why It's Good For The Game
invincible jaunt bombing is unfun to be on the receiving end of

## Testing

https://github.com/user-attachments/assets/63a74254-98f0-45f7-a922-5c93bf861b67


## Changelog

:cl:
balance: if an explosion originates from someone whose jaunting it forces them out of the jaunt and creates a tear in the fabric of reality ontop of them.
balance: made chem explosions originate from their reagent holder instead of always the turf the reagent holder atom is on.
spellcheck: corrected the capitalization on the naming of the bomb actualizer
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

