### PR TITLE
[BALANCE] [QOL] Reverts body bag nerfs (mostly)

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -17,7 +17,6 @@
 	can_weld_shut = FALSE
 	can_install_electronics = FALSE
 	drag_slowdown = 0
-	drag_slowdown = 0.25
 	has_closed_overlay = FALSE
 	can_install_electronics = FALSE
 	paint_jobs = null
@@ -27,7 +26,7 @@
 	/// The tagged name of the bodybag, also used to check if the bodybag IS tagged.
 	var/tag_name
 	/// How long it takes to zip up the bag.
-	var/zip_up_time = 0.5 SECOND
+	var/zip_up_time = 0 SECONDS
 	var/tagged = FALSE // so closet code knows to put the tag overlay back
 	can_install_electronics = FALSE
 
@@ -83,19 +82,15 @@
 /obj/structure/closet/body_bag/after_close(mob/living/user)
 	. = ..()
 	set_density(FALSE)
-	drag_slowdown = 0.25
-	for(var/mob/living/mob_inside in contents)
-		drag_slowdown += 0.25
 
 /obj/structure/closet/body_bag/before_close(mob/living/user, force)
+	if (zip_up_time == 0 SECONDS)
+		return TRUE
+
 	if(!do_after(user, zip_up_time))
 		return FALSE
 	else
 		return TRUE
-
-/obj/structure/closet/body_bag/after_open(mob/living/user)
-	. = ..()
-	drag_slowdown = 0.25
 
 /obj/structure/closet/body_bag/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
@@ -146,7 +141,7 @@
 	foldedbag_path = /obj/item/bodybag/bluespace
 	mob_storage_capacity = 15
 	max_mob_size = MOB_SIZE_LARGE
-	zip_up_time = 3 SECONDS
+	zip_up_time = 1 SECONDS
 
 /obj/structure/closet/body_bag/bluespace/attempt_fold(mob/living/carbon/human/the_folder)
 	. = FALSE
@@ -256,7 +251,6 @@
 	contents_thermal_insulation = 1
 	foldedbag_path = /obj/item/bodybag/environmental/nanotrasen
 	weather_protection = list(TRAIT_WEATHER_IMMUNE)
-	zip_up_time = 1 SECOND
 
 /// Securable enviro. bags
 
@@ -378,7 +372,6 @@
 	weather_protection = list(TRAIT_WEATHER_IMMUNE)
 	breakout_time = 4 MINUTES
 	sinch_time = 20 SECONDS
-	zip_up_time = 1 SECOND
 
 /obj/structure/closet/body_bag/environmental/prisoner/syndicate/refresh_air()
 	air_contents = null
@@ -396,7 +389,6 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	foldedbag_path = null
 	weather_protection = list(TRAIT_SNOWSTORM_IMMUNE)
-	zip_up_time = 1 SECOND
 
 /obj/structure/closet/body_bag/environmental/hardlight/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	if(damage_type in list(BRUTE, BURN))
@@ -409,7 +401,6 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	foldedbag_path = null
 	weather_protection = list(TRAIT_SNOWSTORM_IMMUNE)
-	zip_up_time = 1 SECOND
 
 /obj/structure/closet/body_bag/environmental/prisoner/hardlight/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	if(damage_type in list(BRUTE, BURN))


### PR DESCRIPTION

## About The Pull Request

Reverts most of the recent nerfs to body bags. They now no longer have a drag slowdown or zip up time. Keeps a small 1 second zip up time on bluespace body bags. 

PR discussion thread: https://discord.com/channels/748354466335686736/1508709338108268684

## Why It's Good For The Game

Body bags have felt awful and clunky to use since the change. A faster zip up time is a band-aid solution to a nerf that wasn't needed in the first place, and does nothing about the annoying drag slowdown which makes body bags barely worth using over fireman carrying. My point is that these nerfs were never really justified in the first place, in my opinion. 

There is nothing wrong with having a convenient tool to move bodies and small stacks of items quickly. Not only is it a massive convenience for security and medical players, it's also a very useful tool for antagonists. There is nothing wrong with antagonists (or crew) having a decent tool that allows them to move bodies & stripped items quickly, as this is already one of the hardest parts of playing antagonist. I have never heard a convincing argument why we should make it harder to move bodies for antags. 

"But what about roller beds?" is not a good reason. Add a unique benefit to roller beds if you want to, for example faster application of heals (like faster mesh/suture use and injection time), but it's no excuse to qol-nerf another item into the ground. There is also nothing wrong with just letting one item be slightly better than another. There are still superior use cases for roller beds even now with transporting cuffed people for example.

Small zip up time has been kept on bluespace body bags due to maintainer concerns that they were being powergamed too hard. 

## Testing

Tested on localhost, all works as intended. 

## Changelog
:cl:
balance: Most body bags no longer have a drag slowdown or a zip-up timer. Bluespace body bags retain a small 1 second zip-up timer.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
