### PR TITLE
shorten ashwalker evolution times by 25%

### DIFF
--- a/monkestation/code/modules/blueshift/species/ashwalker.dm
+++ b/monkestation/code/modules/blueshift/species/ashwalker.dm
@@ -1,14 +1,14 @@
 /**
- * 20 minutes = ash storm immunity
- * 40 minutes = armor
- * 60 minutes = base punch
- * 80 minutes = lavaproof
- * 100 minutes = firebreath
+ * 15 minutes = ash storm immunity
+ * 30 minutes = armor
+ * 45 minutes = base punch
+ * 60 minutes = lavaproof
+ * 75 minutes = firebreath
  */
 
 /datum/component/ash_age
 	/// the amount of minutes after each upgrade
-	var/stage_time = 20 MINUTES
+	var/stage_time = 15 MINUTES
 	/// the current stage of the ash
 	var/current_stage = 0
 	/// the time when upgraded/attached


### PR DESCRIPTION

## About The Pull Request
turns ashwalkers from waiting 20 minutes to evolve to waiting 15
## Why It's Good For The Game
needing to wait 1H 40M in order to get fully evolved ascensions for a ghost role that is usually only picked up thirty minutes in is kind of odd. this shortens it to 1h 15M
ashwalkers are very cool but also they take a very long time to do much of anything so this speeds up the worst offender by just a tad.
requested by "Canadianz" on discord
## Testing
## Changelog
:cl: suffering intensifies
balance: ashwalkers can now do the evolution ritual every 15 minutes instead of every 20
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
