### PR TITLE
wabbajacked station cyborgs correctly start fully disconnected from ai (if any)

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1493,7 +1493,7 @@
 
 		if(WABBAJACK_ROBOT)
 			var/static/list/robot_options = list(
-				/mob/living/silicon/robot/disconnected = 200, // Gets the roundstart lawset.
+				/mob/living/silicon/robot/disconnected = 200,
 				/mob/living/basic/drone/polymorphed = 200,
 				/mob/living/silicon/robot/model/syndicate = 100,
 				/mob/living/silicon/robot/model/syndicate/medical = 100,

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1493,7 +1493,7 @@
 
 		if(WABBAJACK_ROBOT)
 			var/static/list/robot_options = list(
-				/mob/living/silicon/robot = 200,
+				/mob/living/silicon/robot/disconnected = 200, // Gets the roundstart lawset.
 				/mob/living/basic/drone/polymorphed = 200,
 				/mob/living/silicon/robot/model/syndicate = 100,
 				/mob/living/silicon/robot/model/syndicate/medical = 100,
@@ -1507,8 +1507,6 @@
 				new_mob.gender = gender
 				new_mob.SetInvisibility(INVISIBILITY_NONE)
 				new_mob.job = JOB_CYBORG
-				created_robot.lawupdate = FALSE
-				created_robot.connected_ai = null
 				created_robot.mmi.transfer_identity(src) //Does not transfer key/client.
 				created_robot.clear_inherent_laws(announce = FALSE)
 				created_robot.clear_zeroth_law(announce = FALSE)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -38,12 +38,12 @@
 	model = new /obj/item/robot_model(src)
 	model.rebuild_modules()
 
-	if(lawupdate)
+	if(!laws)
 		make_laws()
-		for (var/law in laws.inherent)
+		for(var/law in laws.inherent)
 			lawcheck += law
-		if(!TryConnectToAI())
-			lawupdate = FALSE
+	if(lawupdate && !TryConnectToAI())
+		lawupdate = FALSE
 
 	if(!scrambledcodes && !builtInCamera)
 		builtInCamera = new (src)

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -95,7 +95,7 @@
 	var/emag_cooldown = 0
 	var/wiresexposed = FALSE
 
-	///Cyborgs will sync their laws with their AI by default
+	/// Should their laws sync with their master AI? Upon initialization, will try to assign and connect them to an AI.
 	var/lawupdate = TRUE
 	///Used to determine if a borg shows up on the robotics console.  Setting to TRUE hides them.
 	var/scrambledcodes = FALSE
@@ -146,6 +146,9 @@
 ///This is the subtype that gets created by robot suits. It's needed so that those kind of borgs don't have a useless cell in them
 /mob/living/silicon/robot/nocell
 	cell = null
+
+/mob/living/silicon/robot/disconnected
+	lawupdate = FALSE
 
 /mob/living/silicon/robot/shell
 	name = "AI Shell"


### PR DESCRIPTION

## About The Pull Request
People who have been polymorphed / wabbajacked into a regular cyborg (aka non-syndicate cyborg) no longer are briefly connected to the AI, if any, before being disconnected.


This means:
- AIs no longer have to deal with "ghost" connections in their status panel since these cyborgs will not be connected in the first place.
- These cyborgs no longer will inherit hacked, ion, and supplied laws since wabbajack does not clear these specific types of laws.

Closes https://github.com/Monkestation/Monkestation2.0/issues/9533

## Why It's Good For The Game
Bugfix.
## Testing

(Left: Spawned cyborg) (Right: Moth `/wabbajack` into a cyborg)
<img width="210" height="89" alt="image" src="https://github.com/user-attachments/assets/007c655b-1b8b-4b9f-9fdd-25c0d33c1547" />

Status panel correctly only saying the spawned cyborg is connected.
<img width="625" height="50" alt="image" src="https://github.com/user-attachments/assets/d4f5559f-ab36-44f0-9b57-55e1a34141ef" />
## Changelog
:cl:
fix: Being wabbajacked into a standard cyborg no longer (briefly) connects you to the AI, if any.
fix: AIs no longer have "ghost" connections from people that get wabbajacked into a station cyborg.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
