### PR TITLE
Give the janiborg a broom

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -679,15 +679,6 @@
 	model_flags = BORG_MODEL_MEDICAL
 	items_to_add = list(/obj/item/borg/apparatus/beaker/extra)
 
-/obj/item/borg/upgrade/broomer
-	name = "experimental push broom"
-	desc = "An experimental push broom used for efficiently pushing refuse."
-	icon_state = "module_janitor"
-	require_model = TRUE
-	model_type = list(/obj/item/robot_model/janitor)
-	model_flags = BORG_MODEL_JANITOR
-	items_to_add = list(/obj/item/pushbroom/cyborg)
-
 /obj/item/borg/upgrade/uwu
 	name = "cyborg UwU-speak \"upgrade\""
 	desc = "As if existence as an artificial being wasn't torment enough for the unit OR the crew."

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -460,7 +460,7 @@
 		/obj/item/holosign_creator,
 		/obj/item/reagent_containers/spray/cyborg_drying,
 		/obj/item/wirebrush,
-		/obj/item/pushbroom,
+		/obj/item/pushbroom/cyborg,
 	)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)
 	emag_modules = list(

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -460,6 +460,7 @@
 		/obj/item/holosign_creator,
 		/obj/item/reagent_containers/spray/cyborg_drying,
 		/obj/item/wirebrush,
+		/obj/item/pushbroom,
 	)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)
 	emag_modules = list(

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1288,17 +1288,6 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MEDICAL
 	)
 
-/datum/design/borg_upgrade_broomer
-	name = "Experimental Push Broom"
-	id = "borg_upgrade_broomer"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/broomer
-	materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT*2, /datum/material/glass =SMALL_MATERIAL_AMOUNT*5)
-	construction_time = 120
-	category = list(
-		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_JANITOR
-	)
-
 /datum/design/borg_upgrade_advanalyzer
 	name = "Advanced Health Analyzer"
 	id = "borg_upgrade_advanalyzer"

--- a/code/modules/research/techweb/cyborg_nodes.dm
+++ b/code/modules/research/techweb/cyborg_nodes.dm
@@ -62,7 +62,6 @@
 	prereq_ids = list("adv_robotics", "cyborg")
 	design_ids = list(
 		"borg_upgrade_advancedmop",
-		"borg_upgrade_broomer",
 		"borg_upgrade_expand",
 		"borg_upgrade_prt",
 		"borg_upgrade_selfrepair",


### PR DESCRIPTION
**Edit:** Originally this was a PR to add a broom to the Janiborg due to being uninformed that a broom ugprade did actually exist. but as per the comments i was recommended to expand the PR to instead make the Broom stock kit instead of an upgrade instead.

Give the janiborg a broom (by default)
## About The Pull Request
it gives the janiborg a broom. i don't know what else to say about it really

## Why It's Good For The Game
The Janiborg struggles cleaning up certain messes as it's only option to pick up items is the garbage bag or dragging things one at a time and there's a large abount of items that are too big for the garbage bag.
**Edit:** again. not really relevent anymore but leaving it for the sake of the original sentiment.
## Testing
Tested all the standard broom behaviors.
LMB: Pushing items 
RMB: Pulling items
Z: Dual Wields for continues pushing
Q: returns it to the module list and properly disables the dual wield status/effect
All states tested in all 3 slots to make sure it works properly. 
Items can be broomed into disposals properly as per usual too.
## Changelog
:cl:
qol: Made broom part of Janiborgs stock loadout.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
