### PR TITLE
Powerfist from 14 to 10 TC

### DIFF
--- a/code/modules/uplink/uplink_items/melees.dm
+++ b/code/modules/uplink/uplink_items/melees.dm
@@ -28,7 +28,7 @@
 			deal extra damage and hit targets further. Use a screwdriver to take out any attached tanks."
 	progression_minimum = 20 MINUTES
 	item = /obj/item/melee/powerfist
-	cost = 14
+	cost = 10
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/melees/rapid


### PR DESCRIPTION

## About The Pull Request
Powerfist is now only 10 TC down from 14

## Why It's Good For The Game
I nerfed powerfist pretty heavily in progtot removal PR, while I still think the nerf to the item itself is good, did increase its price a little to much and 10 tc is a little more reasonable for what it is now

## Testing
compiled no run times, one var change

## Changelog

:cl:
balance: powerfist is now 10 tc down from 14
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

