### PR TITLE
Putting paper with contents into your PDA now requires confirmation.

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -854,13 +854,13 @@
 			return ITEM_INTERACT_SUCCESS
 
 	if(istype(tool, /obj/item/paper))
-		//MONKESTATION EDIT START
-		// Don't allow plastic cards (including the spare ID safe code biscuits!) to be inserted
+		var/obj/item/paper/attacking_paper = tool
 		if(istype(tool, /obj/item/paper/paperslip/corporate))
 			return ITEM_INTERACT_BLOCKING
-		//MONKESTATION EDIT END
 		if(stored_paper >= max_paper)
 			balloon_alert(user, "no more room!")
+			return ITEM_INTERACT_BLOCKING
+		if(!attacking_paper.is_empty() && tgui_alert(user, "\the [attacking_paper] has contents on it! Are you sure you want to recycle it?", "Recycling", list("Yes", "No")) != "Yes")
 			return ITEM_INTERACT_BLOCKING
 		if(!user.temporarilyRemoveItemFromInventory(tool))
 			return FALSE


### PR DESCRIPTION

## About The Pull Request
Adds a warning popup to inserting paper into your PDA if it has anything on it. you can still immediately insert paper if it doesnt contain anything.
## Why It's Good For The Game
Immediately losing a piece of paperwork due to an accidental click sucks, and you cant get it back because it immediately qdel's it.
## Testing
Inserting paper with nothing written went past immediately
Inserting paper after saving something to it required a confirmation
## Changelog
:cl:
add: Inserting paper with writing on it into your PDA requires a confirmation.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
