### PR TITLE
Adds MOD Megaphone module to cargo goodies

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -374,3 +374,10 @@
 	desc = "It really is just that shrimple."
 	cost = PAYCHECK_CREW * 4
 	contains = list(/obj/item/toy/plush/shrimp)
+
+/datum/supply_pack/goody/modmegaphone
+	name = "MOD Megaphone Module"
+	desc = "Contains one MOD mounted megaphone to force underlings to pay attention."
+	cost = PAYCHECK_COMMAND * 2.5
+	access_view = ACCESS_COMMAND
+	contains = list(/obj/item/mod/module/megaphone)


### PR DESCRIPTION

## About The Pull Request
Adds the MOD megaphone module to cargo goodies under a command restriction.
## Why It's Good For The Game
I am getting paid a low to do this.
the HOS is the only one that gets this module and its available nowhere else. This adds a method to attain it for the other heads.
## Testing
Attempted purchase with assistant ID, prevented by access, attempted with spare captains in runtime, permitted, arrived as expected.
## Changelog
:cl:
add: Added the MOD megaphone module to Cargo Goodies for 250cr.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
