### PR TITLE
Camera static fix for camera consoles

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -45,7 +45,9 @@
 	seenby -= eye
 
 	var/client/client = eye.GetViewerClient()
-	if(client && eye.use_visibility && seenby.len == 0)
+	// Bandaid fix for AI multicamera. Static disappears on other cameras when focused camera is far away.
+	// seenby.len check fixes that, but prevents static removal for those, who exit camera console, when a chunk was observed by 2 or more eye mobs.
+	if(client && eye.use_visibility && (seenby.len == 0 || (isliving(client.mob) && !isAI(client.mob)))) // Bypass for non-AIs, to unsure static removal.
 		client.images -= active_static_images
 
 /// Called when a chunk has changed. I.E: A wall was deleted.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ports: https://github.com/tgstation/tgstation/pull/96036
fixes: https://github.com/Monkestation/Monkestation2.0/issues/11027

> Scientists and other camera users should no longer experience reality glitches related to camera static

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Holoo-1, SirNightKnight
fix: fixed camera static not being removed for console users when it was observed by AI and console user
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->


