### PR TITLE
Cleans up stasis bed examine text

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -39,9 +39,6 @@
 	. = ..()
 	. += span_notice("Alt-click to [stasis_enabled ? "turn off" : "turn on"] the machine.")
 	. += span_notice("The [src] is [op_computer ? "linked" : "<b>NOT</b> linked"] to a nearby operating computer.")
-	. += span_notice("patient = [patient]")
-	. += span_notice("op_computer = [op_computer]")
-	. += span_notice("Alt-click to [stasis_enabled ? "turn off" : "turn on"] the machine.")
 
 /obj/machinery/stasis/proc/play_power_sound()
 	var/_running = stasis_running()


### PR DESCRIPTION

## About The Pull Request
removes a few repetitive and useless lines of examine text from stasis beds
## Why It's Good For The Game
5 lines of examine text when 2 of them are duplicated and 1 of them is telling you the name of a person that's infront of you. we can trim this down
## Testing
yep it works. i did test this
## Changelog
:cl: Cujo
qol: Cleans up stasis bed examine text.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
