### PR TITLE
you can now tip over flashed cyborgs

### DIFF
--- a/code/datums/components/tippable.dm
+++ b/code/datums/components/tippable.dm
@@ -100,7 +100,7 @@
  * tipper - the mob tipping the tipped_mob
  */
 /datum/component/tippable/proc/try_tip(mob/living/tipped_mob, mob/tipper)
-	if(tipped_mob.stat != DEAD)
+	if(tipped_mob.stat == DEAD)
 		return
 
 	if(pre_tipped_callback?.Invoke(tipper))

--- a/code/datums/components/tippable.dm
+++ b/code/datums/components/tippable.dm
@@ -100,7 +100,7 @@
  * tipper - the mob tipping the tipped_mob
  */
 /datum/component/tippable/proc/try_tip(mob/living/tipped_mob, mob/tipper)
-	if(tipped_mob.stat != CONSCIOUS)
+	if(tipped_mob.stat != DEAD)
 		return
 
 	if(pre_tipped_callback?.Invoke(tipper))


### PR DESCRIPTION

## About The Pull Request
title. tippable only checks if they aren't dead now. shouldnt cause issues.

## Why It's Good For The Game
feels like an oversight you cant

## Changelog

:cl:
fix: you can tip over flashed cyborgs.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

