### PR TITLE
you can now slice apart base floor plating

### DIFF
--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -148,7 +148,7 @@
 	user.visible_message(span_notice("[user] begins slicing apart \the [src]..."),
 		span_notice("You begin cutting \the [src] apart with \the [item]..."),
 		span_hear("You hear welding."))
-	if(!item.use_tool(src, user, 10 SECONDS, volume=80))
+	if(!item.use_tool(src, user, 15 SECONDS, volume=80))
 		return FALSE
 	user.visible_message(span_notice("[user] slices apart \the [src]."),
 	span_notice("You cut \the [src] apart with \the [item]."),

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -23,6 +23,9 @@
 	//Used for upgrading this into R-Plating
 	var/upgradable = TRUE
 
+	//If we can slice apart this plating
+	var/can_slice_apart = TRUE
+
 /turf/open/floor/plating/broken_states()
 	return list("damaged1", "damaged2", "damaged4")
 
@@ -126,9 +129,9 @@
 					balloon_alert(user, "too damaged, use a welding or plating repair tool!")
 
 
-/turf/open/floor/plating/welder_act(mob/living/user, obj/item/I)
+/turf/open/floor/plating/welder_act(mob/living/user, obj/item/item)
 	..()
-	if((broken || burnt) && I.use_tool(src, user, 0, volume=80))
+	if((broken || burnt) && item.use_tool(src, user, 0, volume=80))
 		to_chat(user, span_danger("You fix some dents on the broken plating."))
 		icon_state = base_icon_state
 		burnt = FALSE
@@ -136,6 +139,24 @@
 		update_appearance()
 
 	return TRUE
+
+/turf/open/floor/plating/welder_act_secondary(mob/living/user, obj/item/item)
+	if(!can_slice_apart)
+		return FALSE
+	if(!item.tool_start_check(user, amount=3))
+		return FALSE
+	user.visible_message(span_notice("[user] begins slicing apart \the [src]..."),
+		span_notice("You begin cutting \the [src] apart with \the [item]..."),
+		span_hear("You hear welding."))
+	if(!item.use_tool(src, user, 10 SECONDS, volume=80))
+		return FALSE
+	user.visible_message(span_notice("[user] slices apart \the [src]."),
+	span_notice("You cut \the [src] apart with \the [item]."),
+	span_hear("You hear welding."))
+	new /obj/item/stack/tile/iron/large(src)
+	attempt_lattice_replacement(1)
+	return TRUE
+
 
 #undef PLATE_REINFORCE_COST
 
@@ -147,6 +168,7 @@
 	desc = "Thin, fragile flooring created with metal foam."
 	icon_state = "foam_plating"
 	upgradable = FALSE
+	can_slice_apart = FALSE
 
 /turf/open/floor/plating/foam/burn_tile()
 	return //jetfuel can't melt steel foam
@@ -215,6 +237,7 @@
 	baseturfs = /turf/open/floor/plating
 	rcd_proof = TRUE
 	upgradable = FALSE
+	can_slice_apart = FALSE
 	rust_resistance = RUST_RESISTANCE_REINFORCED
 
 	//Used to track which stage of deconstruction the plate is currently in, Intact > Bolts Loosened > Cut

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -50,6 +50,7 @@
 	initial_gas_mix = FROZEN_ATMOS
 	temperature = 180
 	attachment_holes = FALSE
+	can_slice_apart = FALSE
 	planetary_atmos = TRUE
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND

--- a/monkestation/code/modules/liquids/liquid_ocean.dm
+++ b/monkestation/code/modules/liquids/liquid_ocean.dm
@@ -79,6 +79,7 @@ GLOBAL_LIST_EMPTY(initalized_ocean_areas)
 
 	upgradable = FALSE
 	attachment_holes = FALSE
+	can_slice_apart = FALSE
 
 	resistance_flags = INDESTRUCTIBLE
 


### PR DESCRIPTION

## About The Pull Request
title, takes 15 seconds
## Why It's Good For The Game
deconstructing base floor plating is really hard and can only be done with about three methods. sometimes you do need to remove plating tho. might be too griefy to add this since anyone with a crowbar and a welding tool can space any part of the station

## Changelog

:cl:
add: you can slice apart base floor plating with welding tools.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

