### PR TITLE
Fixes engineering cyborgs being unable to recharge their light replacers normally.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -413,6 +413,14 @@
 	hat_offset = -4
 	badge_offset = -4
 
+/obj/item/robot_model/engineering/respawn_consumable(mob/living/silicon/robot/cyborg, coeff = 1)
+	..()
+	var/obj/item/lightreplacer/light_replacer = locate(/obj/item/lightreplacer) in basic_modules
+	if(light_replacer)
+		for(var/charge in 1 to coeff)
+			light_replacer.Charge(cyborg)
+
+
 /obj/item/robot_model/standard
 	name = "Standard"
 	basic_modules = list(


### PR DESCRIPTION

## About The Pull Request
Light replacers were added to the toolset of engi borgs, but the related charge function from janiborgs was not. thus making it so engiborgs have to use glass to refuel it instead of following the same method of their janitor counterpart.
## Why It's Good For The Game
Consistency and bugfixes good
## Testing
inserted a testing() into the respawn_consumable proc, called when in recharger and lights readded.
## Changelog
:cl:
fix: engineering cyborgs can recharge their light replacer in cyborg rechargers again.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
