### PR TITLE
balance adjustments to heretic drafting system

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -312,7 +312,7 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 		),
 		list(
 			"parent_knowledge" = knowledge_tier4,
-			"probabilities" = list("1" = 0, "2" = 0, "3" = 0, "4" = 0, "5" = 100),
+			"probabilities" = list("1" = 0, "2" = 0, "3" = 40, "4" = 60, "5" = 0),
 			HKT_DEPTH = HKT_DEPTH_DRAFT_4,
 		)
 	)
@@ -332,6 +332,8 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 				if(shop_tier && !(guaranteed_draft in shop_tier))
 					shop_tier += guaranteed_draft
 			else
+				if(depth == HKT_DEPTH_DRAFT_4 && route == PATH_LOCK)
+					probabilities = list("1" = 0, "2" = 0, "3" = 0, "4" = 0, "5" = 100)
 				// rng kinda not correct but like, whatever
 				var/chosen_tier = min(text2num(pick_weight(probabilities)), length(elligible_knowledge))
 				var/list/picked_tier = elligible_knowledge[chosen_tier]

--- a/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
+++ b/code/modules/antagonists/heretic/knowledge/_heretic_paths.dm
@@ -312,7 +312,7 @@ GLOBAL_LIST_INIT(heretic_path_datums, init_heretic_path_datums())
 		),
 		list(
 			"parent_knowledge" = knowledge_tier4,
-			"probabilities" = list("1" = 0, "2" = 0, "3" = 40, "4" = 60, "5" = 0),
+			"probabilities" = list("1" = 0, "2" = 0, "3" = 20, "4" = 60, "5" = 20),
 			HKT_DEPTH = HKT_DEPTH_DRAFT_4,
 		)
 	)

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -101,6 +101,7 @@
 	action_to_add = /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash
 	cost = 2
 	drafting_tier = 5
+	is_shop_only = TRUE
 
 /datum/heretic_knowledge/spell/fire_blast
 	name = "Volcano Blast"

--- a/code/modules/antagonists/heretic/knowledge/side_knowledge/tier_two.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_knowledge/tier_two.dm
@@ -46,6 +46,7 @@
 	action_to_add = /datum/action/cooldown/spell/aoe/wave_of_desperation
 	cost = 2
 	drafting_tier = 2
+	is_shop_only = TRUE
 
 /datum/heretic_knowledge/rune_carver
 	name = "Carving Knife"


### PR DESCRIPTION
## About The Pull Request

Wave of Desperation only appears in knowledge shop and can't be gotten for free
same for Ashen Passage

Tier 4 draft no longer guarantees tier 5 knowledge, that means heretics wont get access to strong spells like cosmic runes or entropic plume guaranteed
probabilities are 1 = 0, 2 = 0, 3 = 20, 4 = 60, 5 = 20
this doesn't matter for Lock path, tier 5 knowledge is still guaranteed

Annoyingly because we only have 4 t4 knowledges in total, if you get pretty lucky and pull them all before the t4 draft you still will get guaranteed t5 knowledge (unless you get super unlucky), tho that requires some luck and i dont really mind

t4 draft chances are more likely to pull t4 knowledge with smaller chances for t5 and t3, t2 or t1 cant be pulled

## Why It's Good For The Game

Wave of Desperation is strong to the point where you can actually just handcuff yourself and run into a group of people to stun them and makes landing a bola on a heretic just suicide
I dont mind the spell in general but its kinda insane how it can be gotten for free, so its shop only now

Ashen jaunt unless you get unlucky is guaranteed for literally every path (remember when we got told "you cant get a spell of path as heretic thats not that path") and is super strong, limiting it to shop makes it so only lock heretic can get it reliably, and i dont exactly mind that

t5 knowledges are kinda crazy in general from cosmic runes to entropic plume, imo its fine if lock gets these guaranteed because they on their own lack good spells
they really need lower chance to appear 

## Testing

lock heretic t4 draft
<img width="716" height="673" alt="image" src="https://github.com/user-attachments/assets/0a0176ad-2181-42cf-8d5f-113a5540def7" />

rust heretic t4 draft
<img width="722" height="621" alt="image" src="https://github.com/user-attachments/assets/60fb8f79-5457-4b25-9354-ab55852e700b" />


## Changelog

:cl:
balance: wave of desperation no longer appears in draft and is shop only
balance: ashen passage no longer appears in draft and is shop only
balance: Tier 4 draft chances adjusted, tier 5 spells are no longer guaranteed and its more likely to pull tier 4, with small chance for tier 3 and 5. No changes for lock heretic, tier 5 is still guaranteed.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
