### PR TITLE
fixes typo in borg health analyzer upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -766,7 +766,7 @@
 
 /obj/item/borg/upgrade/adv_healthanalyzer
 	name = "health analyzer upgrade"
-	desc = "An updated sensor and driver kit for medical cyborgs. Allowing the cyborg unit to preform more in-depth analysis of patients."
+	desc = "An updated sensor and driver kit for medical cyborgs. Allowing the cyborg unit to perform more in-depth analysis of patients."
 	icon_state = "module_medical"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/medical, /obj/item/robot_model/syndicate_medical) // The fact that syndicate medical doesn't get advanced stock suprises me just as much as you.


### PR DESCRIPTION

## About The Pull Request
Fixes a typo in health analyzer upgrade's description.

## Why It's Good For The Game
Typo bad.

## Testing
<img width="645" height="72" alt="image" src="https://github.com/user-attachments/assets/001cd4ba-fda2-4dc9-8ed1-50f7fec18c37" />

## Changelog
:cl:
spellcheck: Fixes a typo in medical cyborg health analyzer upgrade's description.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
