### PR TITLE
triple citrus tox heal

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -862,6 +862,12 @@
 	taste_description = "extreme bitterness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
+/datum/reagent/consumable/triple_citrus/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	if(affected_mob.getToxLoss() && SPT_PROB(15, seconds_per_tick))
+		affected_mob.adjustToxLoss(-1, FALSE, required_biotype = affected_biotype)
+		. = TRUE
+	..()
+
 /datum/reagent/consumable/grape_soda
 	name = "Grape Soda"
 	description = "Beloved by children and teetotalers."


### PR DESCRIPTION
## About The Pull Request

This small PR adds a toxin healing to triple citrus. It has a proc chance of 15% per tick, compared to lime juice's 10%. It has the same heal rate of -1.
## Why It's Good For The Game

Naturally makes sense for the evolution of lime juice to its empowered triple citrus form would provide a greater benefit. Citrus powergamers rejoice!
## Testing

I just copied over the lime juice effect to triple citrus. It's exceedingly simple. Server booted so it should work perfectly fine without issue.
## Changelog
:cl: cam_dev
add: triple-citrus now heals toxins at the same rate as lime juice with a 50% higher chance to proc
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
