### PR TITLE
smol bugfixes

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher/crusher_variants/knives.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/crusher_variants/knives.dm
@@ -86,7 +86,7 @@
 	var/obj/projectile/knives/knife = new(proj_turf)
 	knife.aim_projectile(target, user, modifiers)
 	knife.firer = user
-	knife.hammer_synced = src
+	knife.fired_from = src
 	playsound(user, 'sound/weapons/fwoosh.ogg', 100, TRUE)
 	knife.fire()
 
@@ -107,40 +107,41 @@
 	bare_wound_bonus = 10
 	hitsound = 'sound/weapons/guillotine.ogg'
 	hitsound_wall = 'sound/weapons/guillotine.ogg'
-	var/obj/item/kinetic_crusher/knives/hammer_synced
 
 //we have more copy pasted crusher code here because the damage from a projectile is different from a melee strike
-/obj/projectile/knives/on_hit(atom/target, Firer, blocked = 0, pierce_hit)
+/obj/projectile/knives/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	if(isliving(target))
-		var/mob/living/living_target = target
-		var/datum/status_effect/crusher_mark/crusher_mark = living_target.has_status_effect(/datum/status_effect/crusher_mark)
-		if(!crusher_mark || !living_target.remove_status_effect(/datum/status_effect/crusher_mark))
-			return
-		var/datum/status_effect/crusher_damage/mark_damage = living_target.has_status_effect(/datum/status_effect/crusher_damage)
-		if(!mark_damage)
-			mark_damage = living_target.apply_status_effect(/datum/status_effect/crusher_damage)
-		var/target_health = living_target.health
-		for(var/thing in hammer_synced.trophies)
-			var/obj/item/crusher_trophy/trophy = thing
-			trophy.on_mark_detonation(target, firer)
-		if(!QDELETED(living_target))
-			if(!QDELETED(mark_damage))
-				mark_damage.total_damage += target_health - living_target.health //we did some damage, but let's not assume how much we did
-			new /obj/effect/temp_visual/kinetic_blast(get_turf(living_target))
-			var/backstabbed = FALSE
-			var/combined_damage = hammer_synced.detonation_damage
-			var/backstab_dir = get_dir(firer, living_target)
-			var/def_check = living_target.getarmor(type = BOMB)
-			if((firer.dir & backstab_dir) && (living_target.dir & backstab_dir))
-				backstabbed = TRUE
-				combined_damage += hammer_synced.backstab_bonus
-				playsound(firer, 'sound/weapons/kenetic_accel.ogg', 50, TRUE)
+	if(!istype(fired_from, /obj/item/kinetic_crusher))
+		return
+	var/obj/item/kinetic_crusher/used_crusher = fired_from
+	if(!isliving(target))
+		return
+	var/mob/living/living_target = target
+	var/datum/status_effect/crusher_mark/crusher_mark = living_target.has_status_effect(/datum/status_effect/crusher_mark)
+	if(!living_target.remove_status_effect(crusher_mark))
+		return
+	// Detonation effect
+	var/datum/status_effect/crusher_damage/mark_damage = living_target.has_status_effect(/datum/status_effect/crusher_damage) || living_target.apply_status_effect(/datum/status_effect/crusher_damage)
+	var/target_health = living_target.health
+	for(var/obj/item/crusher_trophy/crusher_trophy as anything in used_crusher.trophies)
+		crusher_trophy.on_mark_detonation(target, firer)
+	if(QDELETED(living_target))
+		return
+	if(!QDELETED(mark_damage))
+		mark_damage.total_damage += target_health - living_target.health //we did some damage, but let's not assume how much we did
+	new /obj/effect/temp_visual/kinetic_blast(get_turf(living_target))
+	var/backstabbed = FALSE
+	var/combined_damage = used_crusher.detonation_damage
+	var/backstab_dir = get_dir(firer, living_target)
+	var/def_check = living_target.getarmor(type = BOMB)
+	// Backstab bonus
+	if((firer.dir & backstab_dir) && (living_target.dir & backstab_dir))
+		backstabbed = TRUE
+		combined_damage += used_crusher.backstab_bonus
+		playsound(firer, 'sound/weapons/kenetic_accel.ogg', 50, TRUE)
 
-			if(!QDELETED(mark_damage))
-				mark_damage.total_damage += combined_damage
+	if(!QDELETED(mark_damage))
+		mark_damage.total_damage += combined_damage
 
-
-			SEND_SIGNAL(firer, COMSIG_LIVING_CRUSHER_DETONATE, living_target, src, backstabbed)
-			living_target.apply_damage(combined_damage, BRUTE, blocked = def_check)
-	. = ..()
+	SEND_SIGNAL(firer, COMSIG_LIVING_CRUSHER_DETONATE, living_target, src, backstabbed)
+	living_target.apply_damage(combined_damage, BRUTE, blocked = def_check)

--- a/code/modules/mob/living/basic/minebots/minebot.dm
+++ b/code/modules/mob/living/basic/minebots/minebot.dm
@@ -106,10 +106,8 @@
 	return ..()
 
 /mob/living/basic/mining_drone/attack_hand(mob/living/carbon/human/user, list/modifiers)
-	. = ..()
-
-	if(. ||( user.istate & ISTATE_HARM))
-		return
+	if(user.istate & ISTATE_HARM)
+		return ..()
 	set_combat_mode(!(istate & ISTATE_HARM))
 	balloon_alert(user, "now [(istate & ISTATE_HARM) ? "attacking wildlife" : "collecting loose ore"]")
 

--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -110,7 +110,6 @@
 		notify_ghosts(
 			"[src] is ready to hatch!",
 			source = src,
-			action = NOTIFY_PLAY,
 			ignore_key = POLL_IGNORE_SPIDER,
 			notify_flags = notify_flags_to_pass,
 		)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -568,6 +568,8 @@
 	worn_icon_state = "protokshotgunauto"
 	icon_state = "protokshotgunauto"
 	slot_flags = ITEM_SLOT_BACK
+	inhand_x_dimension = 32
+	inhand_y_dimension = 32
 	burst_size = 1
 	fire_delay = 0
 	base_pixel_x = -2


### PR DESCRIPTION
## About The Pull Request

fixes fenrir inhand sprite
closes #10253 
makes it so spider eggs hatching would just make your ghost jump to the egg cluster 
closes #7572 
fixes minebots not being able to swap to combat mode
also improves crusher knives code because it was weird and ugly

## Why It's Good For The Game

bugfixes and code improvement

## Testing

i tested it i guess

## Changelog

:cl:
fix: fixed fenrir shotgun inhand sprite
fix: spider eggs hatching will now teleport your ghost to the cluster
fix: fixes non-sentient minebots not being able to enter combat mode
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
