### PR TITLE
Nerfs oozeling blood syringes to no longer oneshot non-oozelings 

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -223,7 +223,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
+	if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE) && (rand(0, 5) == 0))
 		to_chat(affected_mob, span_danger("Your insides are burning!"))
 	affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 	. = TRUE

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -226,7 +226,7 @@
 	if(SPT_PROB(5, seconds_per_tick))
 		if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
 			to_chat(affected_mob, span_danger("Your insides are burning!"))
-		affected_mob.adjustToxLoss(rand(20, 30), FALSE, required_biotype = affected_biotype)
+		affected_mob.adjustToxLoss(rand(20, 30) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 		. = TRUE
 	else if(SPT_PROB(23, seconds_per_tick))
 		affected_mob.heal_bodypart_damage(5)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -228,7 +228,7 @@
 	affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 	. = TRUE
 	if(SPT_PROB(23, seconds_per_tick))
-		affected_mob.heal_bodypart_damage(5)
+		affected_mob.heal_bodypart_damage(5 * REM * seconds_per_tick)
 		. = TRUE
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -225,8 +225,8 @@
 /datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
 		to_chat(affected_mob, span_danger("Your insides are burning!"))
-		affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 		. = TRUE
+	affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(23, seconds_per_tick))
 		affected_mob.heal_bodypart_damage(5)
 		. = TRUE

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -223,15 +223,15 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-    . = ..()
-    if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
-        if(SPT_PROB(3, seconds_per_tick))
-            to_chat(affected_mob, span_danger("Your insides are burning!"))
-    else if(SPT_PROB(23, seconds_per_tick))
-        affected_mob.heal_bodypart_damage(5 * REM * seconds_per_tick)
+	. = ..()
+	if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
+		if(SPT_PROB(3, seconds_per_tick))
+			to_chat(affected_mob, span_danger("Your insides are burning!"))
+	else if(SPT_PROB(23, seconds_per_tick))
+		affected_mob.heal_bodypart_damage(5 * REM * seconds_per_tick)
 
-    affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
-    return TRUE
+	affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
+	return TRUE
 
 /datum/reagent/toxin/carpotoxin
 	name = "Carpotoxin"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -223,14 +223,15 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE) && (rand(0, 5) == 0))
-		to_chat(affected_mob, span_danger("Your insides are burning!"))
-	affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
-	. = TRUE
-	if(SPT_PROB(23, seconds_per_tick))
-		affected_mob.heal_bodypart_damage(5 * REM * seconds_per_tick)
-		. = TRUE
-	..()
+    . = ..()
+    if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
+        if(SPT_PROB(3, seconds_per_tick))
+            to_chat(affected_mob, span_danger("Your insides are burning!"))
+    else if(SPT_PROB(23, seconds_per_tick))
+        affected_mob.heal_bodypart_damage(5 * REM * seconds_per_tick)
+
+    affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
+    return TRUE
 
 /datum/reagent/toxin/carpotoxin
 	name = "Carpotoxin"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -229,7 +229,7 @@
 		affected_mob.adjustToxLoss(rand(20, 30) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 		. = TRUE
 	else if(SPT_PROB(23, seconds_per_tick))
-		affected_mob.heal_bodypart_damage(5)
+		affected_mob.heal_bodypart_damage(5 * REM * seconds_per_tick)
 		. = TRUE
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -225,8 +225,8 @@
 /datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
 		to_chat(affected_mob, span_danger("Your insides are burning!"))
-		. = TRUE
 	affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
+	. = TRUE
 	if(SPT_PROB(23, seconds_per_tick))
 		affected_mob.heal_bodypart_damage(5)
 		. = TRUE

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -223,12 +223,11 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	if(SPT_PROB(5, seconds_per_tick))
-		if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
-			to_chat(affected_mob, span_danger("Your insides are burning!"))
-		affected_mob.adjustToxLoss(rand(20, 30), FALSE, required_biotype = affected_biotype)
+	if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
+		to_chat(affected_mob, span_danger("Your insides are burning!"))
+		affected_mob.adjustToxLoss(rand(1, 4) * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 		. = TRUE
-	else if(SPT_PROB(23, seconds_per_tick))
+	if(SPT_PROB(23, seconds_per_tick))
 		affected_mob.heal_bodypart_damage(5)
 		. = TRUE
 	..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -226,7 +226,7 @@
 	if(SPT_PROB(5, seconds_per_tick))
 		if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !HAS_TRAIT(affected_mob, TRAIT_TOXIMMUNE))
 			to_chat(affected_mob, span_danger("Your insides are burning!"))
-		affected_mob.adjustToxLoss(rand(20, 60), FALSE, required_biotype = affected_biotype)
+		affected_mob.adjustToxLoss(rand(20, 30), FALSE, required_biotype = affected_biotype)
 		. = TRUE
 	else if(SPT_PROB(23, seconds_per_tick))
 		affected_mob.heal_bodypart_damage(5)


### PR DESCRIPTION

## About The Pull Request
Changes slime jelly to deal rand(1,4) tox damage
## Why It's Good For The Game
These damage numbers are kind of insane for something that you can do roundstart with syringes and a syringe gun. This requires 0 prep and has a decently high chance to kill someone unless they can purge their chems within 40 seconds. Chloral hydrate is super nerfed because it was super easy to make, and this is something that can be made within seconds of a round... it should not be killing someone if they are hit by 1 syringe.

tested both using 1 syringe of 15 units
With the old numbers and 10 bodies, it did an average of 103.2 toxin damage ((76+105+36+76+141+76+200+137+50+135)/10)
With the new numbers and 10 bodies, it did an average of 73.7 toxin damage(72 + 71 + 73 + 77 + 72 + 70 + 75 + 67 + 77 + 83)/10

it's now more consistent and not a random bulk insert of tox damage.
## Testing
Tested in local host along with some numbers testing above. numbers change anyways
## Changelog
:cl: Cujo
balance: Slime jelly now deals consistent tox damage (1-4) per second
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
