### PR TITLE
Return to monke (jungle fever)

### DIFF
--- a/code/__DEFINES/~monkestation/virology.dm
+++ b/code/__DEFINES/~monkestation/virology.dm
@@ -44,6 +44,7 @@
 #define DISEASE_SLIME "slime"
 #define DISEASE_MORPH "morph"
 #define DISEASE_ROBOT "robot"
+#define DISEASE_MONKEY "monkey"
 #define DISEASE_COLD "cold"
 #define DISEASE_HEART "heart"
 #define DISEASE_SANDWICH "sandwich"

--- a/monkestation/code/modules/virology/disease/premades/transformations.dm
+++ b/monkestation/code/modules/virology/disease/premades/transformations.dm
@@ -131,3 +131,24 @@
 	. = ..()
 	if(mob.has_reagent(/datum/reagent/medicine/system_cleaner, 1))
 		cure()
+
+/datum/disease/acute/premade/jungle_fever
+	name = "Jungle Fever"
+	form = "Ape Cells"
+	origin = "Ape Colonies"
+	category = DISEASE_MONKEY
+
+	symptoms = list(
+		new /datum/symptom/transformation/jungle_fever
+	)
+	spread_flags = DISEASE_SPREAD_BLOOD
+	robustness = 75
+
+	infectionchance = 20
+	infectionchance_base = 20
+	stage_variance = 0
+
+/datum/disease/acute/premade/jungle_fever/activate(mob/living/mob, starved, seconds_per_tick)
+	. = ..()
+	if(mob.has_reagent(/datum/reagent/medicine/coagulant/banana_peel, 1)) // mmmmh banana
+		cure()

--- a/monkestation/code/modules/virology/disease/premades/transformations.dm
+++ b/monkestation/code/modules/virology/disease/premades/transformations.dm
@@ -141,7 +141,7 @@
 	symptoms = list(
 		new /datum/symptom/transformation/jungle_fever
 	)
-	spread_flags = DISEASE_SPREAD_BLOOD
+	spread_flags = DISEASE_SPREAD_CONTACT_SKIN
 	robustness = 75
 
 	infectionchance = 20

--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
@@ -77,8 +77,6 @@
 
 /datum/symptom/transformation/jungle_fever
 	name = "Jungle Fever"
-	new_form = /mob/living/carbon/human/species/monkey
-	bantype = ROLE_MONKEY_HELMET
 	desc = "Restructures the subject cells into a Monkey. Cure: Pulped Banana"
 
 /datum/symptom/transformation/jungle_fever/activate(mob/living/carbon/mob)

--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
@@ -75,6 +75,15 @@
 	bantype = JOB_CYBORG
 	desc = "Restructures the subject cells into a Cyborg. Cure: Synthetic Cleaner"
 
+/datum/symptom/transformation/jungle_fever
+	name = "Jungle Fever"
+	new_form = /mob/living/carbon/human/species/monkey
+	bantype = ROLE_MONKEY_HELMET
+	desc = "Restructures the subject cells into a Monkey. Cure: Pulped Banana"
+
+/datum/symptom/transformation/jungle_fever/activate(mob/living/carbon/mob)
+	mob.monkeyize() // so that they keep the virus
+
 /datum/symptom/transformation/xeno
 	name = "Xenomorph Transformation"
 	new_form = /mob/living/carbon/alien/adult/hunter


### PR DESCRIPTION

## About The Pull Request
Adds jungle fever symptom/disease, this disease is admin only

Symptom turns you into a monkey, and spreads via monkeys with this symptom biting others, it can be cured via pulped banana before you turn.

## Why It's Good For The Game
Request by a admin I believe for a event, but also just kinda funny little callback to jungle fever when it was a antag. I think its a neat thing to HAVE considering we are 'monke'station

## Testing
Yes tested, disease converts people, spreads on bites

## Changelog

:cl:
add: adds jungle fever symptom, admin only
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

