### PR TITLE
Engiborg Long-Range Analyzer Upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -713,6 +713,34 @@
 	model_flags = BORG_MODEL_ENGINEERING
 	items_to_add = list(/obj/item/borg/charger)
 
+/obj/item/borg/upgrade/ranged_analyzer
+	name = "engineering ranged analyzer upgrade"
+	desc = "An upgrade that improves the standard built-in gas analyzer's range."
+	icon_state = "module_engineer"
+	require_model = TRUE
+	model_type = list(/obj/item/robot_model/engineering, /obj/item/robot_model/saboteur) // Engineering-exclusive. Do not give this to science cyborgs.
+	model_flags = BORG_MODEL_ENGINEERING
+
+/obj/item/borg/upgrade/ranged_analyzer/action(mob/living/silicon/robot/borg, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+	for(var/obj/obj/item/analyzer/gas_analyzer in borg.model.modules)
+		gas_analyzer.name = /obj/item/analyzer/ranged::name
+		gas_analyzer.desc = /obj/item/analyzer/ranged::desc
+		gas_analyzer.icon_state = /obj/item/analyzer/ranged::icon_state
+		gas_analyzer.ranged_scan_distance = /obj/item/analyzer/ranged::ranged_scan_distance
+
+/obj/item/borg/upgrade/ranged_analyzer/deactivate(mob/living/silicon/robot/borg, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+	for(var/obj/obj/item/analyzer/gas_analyzer in borg.model.modules)
+		gas_analyzer.name = initial(gas_analyzer.name)
+		gas_analyzer.desc = initial(gas_analyzer.desc)
+		gas_analyzer.icon_state = initial(gas_analyzer.icon_state)
+		gas_analyzer.ranged_scan_distance = initial(gas_analyzer.ranged_scan_distance)
+
 /obj/item/borg/upgrade/beaker_app
 	name = "beaker storage apparatus"
 	desc = "A supplementary beaker storage apparatus for medical cyborgs."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -730,6 +730,7 @@
 		gas_analyzer.desc = /obj/item/analyzer/ranged::desc
 		gas_analyzer.icon_state = /obj/item/analyzer/ranged::icon_state
 		gas_analyzer.ranged_scan_distance = /obj/item/analyzer/ranged::ranged_scan_distance
+		gas_analyzer.update_appearance()
 
 /obj/item/borg/upgrade/ranged_analyzer/deactivate(mob/living/silicon/robot/borg, user = usr)
 	. = ..()
@@ -740,6 +741,7 @@
 		gas_analyzer.desc = initial(gas_analyzer.desc)
 		gas_analyzer.icon_state = initial(gas_analyzer.icon_state)
 		gas_analyzer.ranged_scan_distance = initial(gas_analyzer.ranged_scan_distance)
+		gas_analyzer.update_appearance()
 
 /obj/item/borg/upgrade/beaker_app
 	name = "beaker storage apparatus"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -725,7 +725,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	for(var/obj/obj/item/analyzer/gas_analyzer in borg.model.modules)
+	for(var/obj/item/analyzer/gas_analyzer in borg.model.modules)
 		gas_analyzer.name = /obj/item/analyzer/ranged::name
 		gas_analyzer.desc = /obj/item/analyzer/ranged::desc
 		gas_analyzer.icon_state = /obj/item/analyzer/ranged::icon_state
@@ -735,7 +735,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	for(var/obj/obj/item/analyzer/gas_analyzer in borg.model.modules)
+	for(var/obj/item/analyzer/gas_analyzer in borg.model.modules)
 		gas_analyzer.name = initial(gas_analyzer.name)
 		gas_analyzer.desc = initial(gas_analyzer.desc)
 		gas_analyzer.icon_state = initial(gas_analyzer.icon_state)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1426,7 +1426,7 @@
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 0.1,
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 0.02,
 		/datum/material/gold = SHEET_MATERIAL_AMOUNT * 0.3,
-		/datum/material/bluespace= SHEET_MATERIAL_AMOUNT * 0.2
+		/datum/material/bluespace = SHEET_MATERIAL_AMOUNT * 0.2
 	)
 	construction_time = 12 SECONDS
 	category = list(

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1417,6 +1417,22 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING
 	)
 
+/datum/design/borg_upgrade_ranged_analyzer
+	name = "Ranged Analyzer"
+	id = "borg_upgrade_ranged_analyzer"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/ranged_analyzer
+	materials = list( // Same cost as a ranged analyzer.
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 0.1,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 0.02,
+		/datum/material/gold = SHEET_MATERIAL_AMOUNT * 0.3,
+		/datum/material/bluespace= SHEET_MATERIAL_AMOUNT * 0.2
+	)
+	construction_time = 12 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING
+	)
+
 /datum/design/borg_upgrade_beaker_app
 	name = "Secondary Beaker Storage"
 	id = "borg_upgrade_beakerapp"

--- a/code/modules/research/techweb/cyborg_nodes.dm
+++ b/code/modules/research/techweb/cyborg_nodes.dm
@@ -49,7 +49,8 @@
 	)
 	design_ids = list(
 		"borg_upgrade_charger",
-		"borg_upgrade_extra_sheet_manipulator"
+		"borg_upgrade_extra_sheet_manipulator",
+		"borg_upgrade_ranged_analyzer"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS / 2)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE)


### PR DESCRIPTION
## About The Pull Request
Adds a new cyborg upgrade that can be used on engiborgs that upgrades the range of their analyzer.

## Why It's Good For The Game
Regular people can print and use long range analyzer. No reason why cyborgs can't have it either.

## Testing
Printable and cost:
<img width="413" height="112" alt="image" src="https://github.com/user-attachments/assets/0735c12d-7eaf-4a46-b1a6-ea92897faad0" />

Upgraded item:
<img width="306" height="137" alt="image" src="https://github.com/user-attachments/assets/8ae1046b-c69d-4a9f-a09d-e494d8cfde18" />

## Changelog
:cl:
add: New engineering cyborg upgrade that increases the range of their analyzer on-par with a long ranged analyzer.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
