### PR TITLE
gives all security related plasmaman outfits proper gloves

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -12,7 +12,7 @@
 	name = "Security Plasmaman"
 
 	uniform = /obj/item/clothing/under/plasmaman/security
-	gloves = /obj/item/clothing/gloves/color/plasmaman/black
+	gloves = /obj/item/clothing/gloves/color/black/security
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
 	mask = /obj/item/clothing/mask/gas/sechailer/plasmaman
 
@@ -27,7 +27,7 @@
 	name = "Warden Plasmaman"
 
 	uniform = /obj/item/clothing/under/plasmaman/security/warden
-	gloves = /obj/item/clothing/gloves/color/plasmaman/black
+	gloves = /obj/item/clothing/gloves/color/black/security
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security/warden
 	mask = /obj/item/clothing/mask/gas/sechailer/plasmaman
 
@@ -203,7 +203,7 @@
 	name = "Head of Security Plasmaman"
 
 	uniform = /obj/item/clothing/under/plasmaman/security/head_of_security
-	gloves = /obj/item/clothing/gloves/color/plasmaman/black
+	gloves = /obj/item/clothing/gloves/color/black/security
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security/head_of_security
 	mask = /obj/item/clothing/mask/gas/sechailer/plasmaman
 

--- a/monkestation/code/modules/jobs/job_types/blueshield.dm
+++ b/monkestation/code/modules/jobs/job_types/blueshield.dm
@@ -92,3 +92,4 @@
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blueshield
 	uniform = /obj/item/clothing/under/plasmaman/blueshield
+	gloves = /obj/item/clothing/gloves/tackler/combat


### PR DESCRIPTION

## About The Pull Request
all security plasmaman outfits spawn with security gloves since they are fireproof also.

blueshield plasmaman outfit spawns with tackler gloves like normal blueshields.

## Why It's Good For The Game
gives plasmamen the proper gloves for their job compared to their other species counterparts.


## Changelog

:cl:
fix: gave all security related plasmaman proper security gloves.
fix: plasmamen blueshields start with tackling gloves.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

