### PR TITLE
Science Cyborg Analysis Forms + Pen

### DIFF
--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -474,7 +474,7 @@
 	. = ITEM_INTERACT_BLOCKING
 	var/datum/component/artifact/artifact_component = interacting_with.GetComponent(/datum/component/artifact)
 	if(!artifact_component)
-		user.balloon_alert(user, "not an artfact!")
+		user.balloon_alert(user, "not an artifact!")
 		return
 	var/item_interact_result = sticker_to_apply.interact_with_atom(interacting_with, user, modifiers)
 	if(item_interact_result & ITEM_INTERACT_SUCCESS)

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -449,3 +449,35 @@
 		shake_camera(living_mob, 2 SECONDS, 1)
 		ADD_TRAIT(living_mob, TRAIT_POOR_AIM, type)
 		addtimer(TRAIT_CALLBACK_REMOVE(living_mob, TRAIT_POOR_AIM, type), 8 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+
+/obj/item/borg/artifact_sticker_holder
+	name = "analysis form holder"
+	desc = "An built-in holder that automatically generates artifact analysis forms to write on and label artifacts with!"
+	icon = 'icons/obj/service/bureaucracy.dmi'
+	icon_state = "analysisbin1"
+	base_icon_state = "analysisbin"
+	/// The sticker that we are holding.
+	var/obj/item/sticker/analysis_form/sticker_to_apply
+
+/obj/item/borg/artifact_sticker_holder/Initialize(mapload)
+	. = ..()
+	sticker_to_apply = new(src)
+
+/obj/item/borg/artifact_sticker_holder/Destroy(force)
+	QDEL_NULL(sticker_to_apply)
+	return ..()
+
+/obj/item/borg/artifact_sticker_holder/attackby(obj/item/item, mob/user, params)
+	sticker_to_apply.attackby(item, user, params)
+
+/obj/item/borg/artifact_sticker_holder/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	. = ITEM_INTERACT_BLOCKING
+	var/datum/component/artifact/artifact_component = interacting_with.GetComponent(/datum/component/artifact)
+	if(!artifact_component)
+		user.balloon_alert(user, "not an artfact!")
+		return
+	var/item_interact_result = sticker_to_apply.interact_with_atom(interacting_with, user, modifiers)
+	if(item_interact_result & ITEM_INTERACT_SUCCESS)
+		// Need to create a new sticker since the last one was used up.
+		sticker_to_apply = new(src)
+		return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/sticker.dm
+++ b/code/game/objects/items/sticker.dm
@@ -67,6 +67,7 @@
 	register_signals(user)
 	moveToNullspace()
 	SEND_SIGNAL(attached, COMSIG_STICKER_STICKED, src, user)
+	return TRUE
 
 ///Makes this sticker move from nullspace and cut the overlay from the object it is attached to, silent for no visible message.
 /obj/item/sticker/proc/peel(datum/source)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -1004,6 +1004,9 @@
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/borg/apparatus/organ_storage/limb, // They need to be able to hold limbs to hit artifacts with it.
+		/obj/item/borg/artifact_sticker_holder,
+		/obj/item/pen/fountain
+
 	)
 	emag_modules = list(
 		/obj/item/borg/handheld_jaunter,


### PR DESCRIPTION

## About The Pull Request
Science cyborgs get a fountain pen (to write with) along with a new item that makes analysis forms to write on (with their pen) which they can hit artifacts with in order to stick the form onto said artifact.

## Why It's Good For The Game
Apparently, they need this to do artifact research.

## Testing
New items
<img width="132" height="65" alt="image" src="https://github.com/user-attachments/assets/ba5386b2-8104-43dc-bc74-d9f678748277" />

Description of analysis form holder
<img width="646" height="91" alt="image" src="https://github.com/user-attachments/assets/c42fdc2a-d525-467b-96cd-677601e7bd2d" />

Can interact with form holder with pen
<img width="295" height="184" alt="image" src="https://github.com/user-attachments/assets/88243e39-d62a-4292-92f5-31dc3aebf242" />

Placed sticker
<img width="168" height="105" alt="image" src="https://github.com/user-attachments/assets/c3d818ba-a2b8-4cb3-afac-a3a314830bf9" />

## Changelog
:cl:
add: Science cyborgs now get a fountain pen along with analysis forms that they can write on and stickto artifacts.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
