### PR TITLE
bluespace crystals and teleprods cause confusion and disgust + cattleprod rebalance

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -36,7 +36,7 @@
 	/// The volume of the above.
 	var/on_stun_volume = 75
 	/// Do we animate the "hit" when stunning something?
-	var/stun_animation = TRUE
+	var/stun_animation = FALSE
 	/// Whether the stun attack is logged. Only relevant for abductor batons, which have different modes.
 	var/log_stun_attack = TRUE
 	/// Boolean on whether people with chunky fingers can use this baton.
@@ -436,6 +436,7 @@
 	on_stun_volume = 50
 	active = FALSE
 	context_living_rmb_active = "Harmful Stun"
+	stun_animation = TRUE
 
 	///Does this baton knock the user down if they harmbaton with it on?
 	var/self_knockdown = TRUE
@@ -701,13 +702,13 @@
 	worn_icon_state = null
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	w_class = WEIGHT_CLASS_HUGE
 	force = 3
 	throwforce = 5
 	cell_hit_cost = 2000
 	throw_stun_chance = 10
 	slot_flags = ITEM_SLOT_BACK
 	convertible = FALSE
+	cell_hit_cost = STANDARD_CELL_CHARGE * 1.5
 	var/obj/item/assembly/igniter/sparkler
 	///Determines whether or not we can improve the cattleprod into a new type. Prevents turning the cattleprod subtypes into different subtypes, or wasting materials on making it....another version of itself.
 	var/can_upgrade = TRUE
@@ -791,7 +792,6 @@
 /obj/item/melee/baton/security/cattleprod/teleprod
 	name = "teleprod"
 	desc = "A prod with a bluespace crystal on the end. The crystal doesn't look too fun to touch."
-	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "teleprod"
 	inhand_icon_state = "teleprod"
 	slot_flags = null
@@ -808,11 +808,12 @@
 	if(!. || target.move_resist >= MOVE_FORCE_OVERPOWERING)
 		return
 	do_teleport(target, get_turf(target), 15, channel = TELEPORT_CHANNEL_BLUESPACE)
+	target.adjust_disgust(15)	//Two teleports is safe
+	target.adjust_confusion(3 SECONDS)
 
 /obj/item/melee/baton/security/cattleprod/telecrystalprod
 	name = "snatcherprod"
 	desc = "A prod with a telecrystal on the end. It sparks with a desire for theft and subversion."
-	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "telecrystalprod"
 	inhand_icon_state = "telecrystalprod"
 	slot_flags = null

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -39,7 +39,7 @@
 	use(1)
 
 /obj/item/stack/ore/bluespace_crystal/proc/blink_mob(mob/living/target)
-	do_teleport(target, get_turf(L), blink_range, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
+	do_teleport(target, get_turf(target), blink_range, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
 	target.adjust_disgust(15)	//Two teleports is safe
 	target.adjust_confusion(3 SECONDS)
 

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -38,8 +38,10 @@
 	blink_mob(user)
 	use(1)
 
-/obj/item/stack/ore/bluespace_crystal/proc/blink_mob(mob/living/L)
-	do_teleport(L, get_turf(L), blink_range, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
+/obj/item/stack/ore/bluespace_crystal/proc/blink_mob(mob/living/target)
+	do_teleport(target, get_turf(L), blink_range, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
+	target.adjust_disgust(15)	//Two teleports is safe
+	target.adjust_confusion(3 SECONDS)
 
 /obj/item/stack/ore/bluespace_crystal/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!..()) // not caught in mid-air

--- a/monkestation/code/modules/antagonists/contractor/items/baton.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/baton.dm
@@ -30,6 +30,7 @@
 	on_inhand_icon_state = "contractor_baton_on"
 	on_sound = 'sound/weapons/contractorbatonextend.ogg'
 	active_force = 16
+	stun_animation = TRUE
 
 	/// Ref to the baton holster, should the baton have one.
 	var/obj/item/mod/module/baton_holster/holster


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
bluespace crystals and teleprods cause some confusion and disgust to the target.

cattleprods take 1.5 more change than stun batons but are the same size.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
we recently made the bluespace activity plant gene do the same so there's some downside to teleporting so it's not a get out of jail free card.

cattleprods are easier to carry around for antags to do antag stuff
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: cattleprods are normal sized but take 1.5 more charge than stun batons.
balance: bluespace crystals and teleprods make the victim confused and disgusted when they teleport
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
