### PR TITLE
Fix titanium/plastitanium not being rustable at all

### DIFF
--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -77,9 +77,6 @@
 /turf/open/floor/mineral/titanium/broken_states()
 	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 
-/turf/open/floor/mineral/titanium/rust_heretic_act(rust_strength)
-	return // titanium does not rust
-
 /turf/open/floor/mineral/titanium/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
@@ -161,9 +158,6 @@
 
 /turf/open/floor/mineral/plastitanium/broken_states()
 	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
-
-/turf/open/floor/mineral/plastitanium/rust_heretic_act(rust_strength)
-	return // plastitanium does not rust
 
 /turf/open/floor/mineral/plastitanium/airless
 	initial_gas_mix = AIRLESS_ATMOS


### PR DESCRIPTION

## About The Pull Request

Forgot to remove these overrides from my heretic rework port - they're handled by the whole `rust_strength` thing now.

Also I was asked to fix this.

## Why It's Good For The Game

fixing a bug from my pr.

## Changelog
:cl:
fix: Fixed titanium/plastitanium not being rustable at all.
/:cl: