### PR TITLE
Lock heretics labyrinth forcefields now have health and can be destroyed, along with a small recipe change

### DIFF
--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -176,7 +176,7 @@
 	},
 /area/awaymission/caves/bmp_asteroid/level_four)
 "aR" = (
-/obj/effect/forcefield/cult,
+/obj/structure/forcefield/cult,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
@@ -188,7 +188,7 @@
 	},
 /area/awaymission/caves/bmp_asteroid/level_four)
 "aV" = (
-/obj/effect/forcefield/cult,
+/obj/structure/forcefield/cult,
 /turf/open/lava/smooth{
 	desc = "Looks hot.";
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7";
@@ -1470,7 +1470,7 @@
 /turf/open/floor/iron,
 /area/awaymission/caves/listeningpost)
 "vX" = (
-/obj/effect/forcefield/cult,
+/obj/structure/forcefield/cult,
 /turf/open/misc/asteroid/basalt/lava{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},

--- a/_maps/shuttles/emergency_arena.dmm
+++ b/_maps/shuttles/emergency_arena.dmm
@@ -34,11 +34,11 @@
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
 "n" = (
-/obj/effect/forcefield/arena_shuttle_entrance,
+/obj/structure/forcefield/arena_shuttle_entrance,
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
 "o" = (
-/obj/effect/forcefield/arena_shuttle_entrance,
+/obj/structure/forcefield/arena_shuttle_entrance,
 /obj/docking_port/mobile/emergency{
 	name = "The Arena"
 	},

--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/cult,
 /area/shuttle/escape)
 "c" = (
-/obj/effect/forcefield/cult/permanent,
+/obj/structure/forcefield/cult/permanent,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "d" = (

--- a/_maps/shuttles/hunter_psyker.dmm
+++ b/_maps/shuttles/hunter_psyker.dmm
@@ -571,7 +571,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/hunter)
 "FC" = (
-/obj/effect/forcefield/psychic{
+/obj/structure/forcefield/psychic{
 	initial_duration = 0
 	},
 /obj/structure/lattice,
@@ -598,7 +598,7 @@
 /area/shuttle/hunter)
 "Gr" = (
 /obj/structure/lattice,
-/obj/effect/forcefield/psychic{
+/obj/structure/forcefield/psychic{
 	initial_duration = 0
 	},
 /turf/template_noop,

--- a/_maps/templates/the_arena.dmm
+++ b/_maps/templates/the_arena.dmm
@@ -128,7 +128,7 @@
 /turf/open/floor/stone,
 /area/shuttle/shuttle_arena)
 "xA" = (
-/obj/effect/forcefield/arena_shuttle,
+/obj/structure/forcefield/arena_shuttle,
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/shuttle_arena)
 "yX" = (

--- a/_maps/~monkestation/RandomBars/Icebox/cultbar_icebox.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/cultbar_icebox.dmm
@@ -118,7 +118,7 @@
 /obj/item/toy/plush/ratplush{
 	name = "Imprisoned God"
 	},
-/obj/effect/forcefield/cult/permanent,
+/obj/structure/forcefield/cult/permanent,
 /turf/open/floor/cult,
 /area/station/service/bar)
 "gn" = (

--- a/code/datums/elements/effect_trail.dm
+++ b/code/datums/elements/effect_trail.dm
@@ -8,7 +8,7 @@
 	/// The effect used for the trail generation.
 	var/chosen_effect
 
-/datum/element/effect_trail/Attach(datum/target, chosen_effect = /obj/effect/forcefield/cosmic_field)
+/datum/element/effect_trail/Attach(datum/target, chosen_effect = /obj/structure/forcefield/cosmic_field)
 	. = ..()
 	if(!ismovable(target))
 		return ELEMENT_INCOMPATIBLE
@@ -48,14 +48,14 @@
 
 /datum/element/effect_trail/cosmic_field/Attach(datum/target, chosen_effect)
 	. = ..()
-	if(!ispath(chosen_effect, /obj/effect/forcefield/cosmic_field))
+	if(!ispath(chosen_effect, /obj/structure/forcefield/cosmic_field))
 		stack_trace("Tried to attach a cosmic_field effect trail with a non-cosmic field as the chosen effect")
 
 /datum/element/effect_trail/cosmic_field/generate_effect(atom/movable/target_object)
 	var/turf/open/open_turf = get_turf(target_object)
 	if(!istype(open_turf))
 		return
-	var/obj/effect/forcefield/cosmic_field/new_field = new chosen_effect(open_turf)
+	var/obj/structure/forcefield/cosmic_field/new_field = new chosen_effect(open_turf)
 	if(isliving(target_object))
 		new_field.summoner = WEAKREF(target_object)
 

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -257,17 +257,17 @@
 	has_gravity = STANDARD_GRAVITY
 	requires_power = FALSE
 
-/obj/effect/forcefield/arena_shuttle
+/obj/structure/forcefield/arena_shuttle
 	name = "portal"
 	initial_duration = 0
 	var/list/warp_points = list()
 
-/obj/effect/forcefield/arena_shuttle/Initialize(mapload)
+/obj/structure/forcefield/arena_shuttle/Initialize(mapload)
 	. = ..()
 	for(var/obj/effect/landmark/shuttle_arena_safe/exit in GLOB.landmarks_list)
 		warp_points += exit
 
-/obj/effect/forcefield/arena_shuttle/Bumped(atom/movable/AM)
+/obj/structure/forcefield/arena_shuttle/Bumped(atom/movable/AM)
 	if(!isliving(AM))
 		return
 
@@ -294,12 +294,12 @@
 	name = "\proper the arena"
 	desc = "A lava filled battlefield."
 
-/obj/effect/forcefield/arena_shuttle_entrance
+/obj/structure/forcefield/arena_shuttle_entrance
 	name = "portal"
 	initial_duration = 0
 	var/list/warp_points = list()
 
-/obj/effect/forcefield/arena_shuttle_entrance/Bumped(atom/movable/AM)
+/obj/structure/forcefield/arena_shuttle_entrance/Bumped(atom/movable/AM)
 	if(!isliving(AM))
 		return
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -73,7 +73,7 @@
 			payload.defuse()
 		return
 
-	for(var/obj/effect/forcefield/cosmic_field/potential_field as anything in GLOB.active_cosmic_fields)
+	for(var/obj/structure/forcefield/cosmic_field/potential_field as anything in GLOB.active_cosmic_fields)
 		if(get_dist(potential_field, src) < 3)
 			new /obj/effect/temp_visual/revenant(get_turf(src))
 			end_processing()

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -1,36 +1,44 @@
-/obj/effect/forcefield
+/obj/structure/forcefield
 	name = "FORCEWALL"
 	desc = "A space wizard's magic wall."
+	icon = 'icons/effects/effects.dmi'
 	icon_state = "m_shield"
 	anchored = TRUE
 	opacity = FALSE
 	density = TRUE
 	can_atmos_pass = ATMOS_PASS_DENSITY
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	armor_type = /datum/armor/none
+	flags_ricochet = NONE
+	move_resist = INFINITY
+	obj_flags = NONE
+	blocks_emissive = EMISSIVE_BLOCK_GENERIC
+	uses_integrity = FALSE
 	/// If set, how long the force field lasts after it's created. Set to 0 to have infinite duration forcefields.
 	var/initial_duration = 30 SECONDS
 
-/obj/effect/forcefield/Initialize(mapload)
+/obj/structure/forcefield/Initialize(mapload)
 	. = ..()
 	if(initial_duration > 0 SECONDS)
 		QDEL_IN(src, initial_duration)
 
-/obj/effect/forcefield/singularity_pull()
+/obj/structure/forcefield/singularity_pull()
 	return
 
 /// The wizard's forcefield, summoned by forcewall
-/obj/effect/forcefield/wizard
+/obj/structure/forcefield/wizard
 	/// Flags for what antimagic can just ignore our forcefields
 	var/antimagic_flags = MAGIC_RESISTANCE
 	/// A weakref to whoever casted our forcefield.
 	var/datum/weakref/caster_weakref
 
-/obj/effect/forcefield/wizard/Initialize(mapload, mob/caster, flags = MAGIC_RESISTANCE)
+/obj/structure/forcefield/wizard/Initialize(mapload, mob/caster, flags = MAGIC_RESISTANCE)
 	. = ..()
 	if(caster)
 		caster_weakref = WEAKREF(caster)
 	antimagic_flags = flags
 
-/obj/effect/forcefield/wizard/CanAllowThrough(atom/movable/mover, border_dir)
+/obj/structure/forcefield/wizard/CanAllowThrough(atom/movable/mover, border_dir)
 	if(IS_WEAKREF_OF(mover, caster_weakref))
 		return TRUE
 	if(isliving(mover))
@@ -41,7 +49,7 @@
 	return ..()
 
 /// Cult forcefields
-/obj/effect/forcefield/cult
+/obj/structure/forcefield/cult
 	name = "glowing wall"
 	desc = "An unholy shield that blocks all attacks."
 	icon = 'icons/effects/cult/effects.dmi'
@@ -51,24 +59,24 @@
 
 /// A form of the cult forcefield that lasts permanently.
 /// Used on the Shuttle 667.
-/obj/effect/forcefield/cult/permanent
+/obj/structure/forcefield/cult/permanent
 	initial_duration = 0
 
 /// Mime forcefields (invisible walls)
 
-/obj/effect/forcefield/mime
+/obj/structure/forcefield/mime
 	icon_state = "nothing"
 	name = "invisible wall"
 	desc = "You have a bad feeling about this."
 	alpha = 0
 
-/obj/effect/forcefield/mime/advanced
+/obj/structure/forcefield/mime/advanced
 	name = "invisible blockade"
 	desc = "You're gonna be here awhile."
 	initial_duration = 1 MINUTES
 
 /// Psyker forcefield
-/obj/effect/forcefield/psychic
+/obj/structure/forcefield/psychic
 	name = "psychic forcefield"
 	desc = "A wall of psychic energy powerful enough stop the motion of objects. Projectiles ricochet."
 	icon_state = "psychic"
@@ -80,10 +88,10 @@
 /// Used to track if a projectile has already been reflected by a cosmic field.
 #define TRAIT_REFLECTED_BY_COSMIC_FIELD "reflected_by_cosmic_field"
 
-GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_field)
+GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/structure/forcefield/cosmic_field)
 
 /// The cosmic heretics forcefield
-/obj/effect/forcefield/cosmic_field
+/obj/structure/forcefield/cosmic_field
 	name = "Cosmic Field"
 	desc = "A field that cannot be passed by people marked with a cosmic star."
 	icon = 'icons/effects/eldritch.dmi'
@@ -106,7 +114,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_fiel
 		/obj/projectile/bullet/bloodsilver,
 	)
 
-/obj/effect/forcefield/cosmic_field/Initialize(mapload, flags = MAGIC_RESISTANCE)
+/obj/structure/forcefield/cosmic_field/Initialize(mapload, flags = MAGIC_RESISTANCE)
 	. = ..()
 	antimagic_flags = flags
 	var/static/list/loc_connections = list(
@@ -118,7 +126,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_fiel
 	for(var/atom/movable/thing in get_turf(src))
 		on_entered(src, thing)
 
-/obj/effect/forcefield/cosmic_field/Destroy(force)
+/obj/structure/forcefield/cosmic_field/Destroy(force)
 	summoner = null
 	// Make sure when the field goes away that the effects don't persist
 	for(var/atom/movable/thing in get_turf(src))
@@ -126,7 +134,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_fiel
 	GLOB.active_cosmic_fields -= src
 	return ..()
 
-/obj/effect/forcefield/cosmic_field/CanAllowThrough(atom/movable/mover, border_dir)
+/obj/structure/forcefield/cosmic_field/CanAllowThrough(atom/movable/mover, border_dir)
 	if(!isliving(mover))
 		return ..()
 	var/mob/living/living_mover = mover
@@ -143,12 +151,12 @@ GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_fiel
 		return FALSE
 	return ..()
 
-/obj/effect/forcefield/cosmic_field/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
+/obj/structure/forcefield/cosmic_field/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
 	if(try_reflect_projectile(hitting_projectile))
 		return BULLET_ACT_FORCE_PIERCE
 	return ..()
 
-/obj/effect/forcefield/cosmic_field/proc/should_reflect_projectile(obj/projectile/bullet)
+/obj/structure/forcefield/cosmic_field/proc/should_reflect_projectile(obj/projectile/bullet)
 	if(is_type_in_list(bullet, allowed_projectiles))
 		return FALSE
 	if(IS_WEAKREF_OF(bullet.firer, summoner))
@@ -159,7 +167,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_fiel
 			return FALSE
 	return TRUE
 
-/obj/effect/forcefield/cosmic_field/proc/try_reflect_projectile(obj/projectile/bullet)
+/obj/structure/forcefield/cosmic_field/proc/try_reflect_projectile(obj/projectile/bullet)
 	if(HAS_TRAIT(bullet, TRAIT_REFLECTED_BY_COSMIC_FIELD))
 		return TRUE
 	if(!should_reflect_projectile(bullet))
@@ -185,7 +193,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_fiel
 	ADD_TRAIT(bullet, TRAIT_REFLECTED_BY_COSMIC_FIELD, REF(src))
 	return TRUE
 
-/obj/effect/forcefield/cosmic_field/proc/on_entered(datum/source, atom/movable/thing)
+/obj/structure/forcefield/cosmic_field/proc/on_entered(datum/source, atom/movable/thing)
 	SIGNAL_HANDLER
 	if(isprojectile(thing))
 		var/obj/projectile/bullet = thing
@@ -199,7 +207,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_fiel
 	if(living_mover.has_status_effect(/datum/status_effect/heretic_passive/cosmic))
 		living_mover.add_movespeed_modifier(/datum/movespeed_modifier/cosmic_field)
 
-/obj/effect/forcefield/cosmic_field/proc/on_loc_exited(datum/source, atom/movable/thing)
+/obj/structure/forcefield/cosmic_field/proc/on_loc_exited(datum/source, atom/movable/thing)
 	SIGNAL_HANDLER
 	if(isprojectile(thing))
 		var/obj/projectile/bullet = thing
@@ -217,26 +225,26 @@ GLOBAL_LIST_EMPTY_TYPED(active_cosmic_fields, /obj/effect/forcefield/cosmic_fiel
 		living_mover.remove_movespeed_modifier(/datum/movespeed_modifier/cosmic_field)
 
 /// Adds the ability to reflect incoming projectiles.
-/obj/effect/forcefield/cosmic_field/proc/reflects_projectiles()
+/obj/structure/forcefield/cosmic_field/proc/reflects_projectiles()
 	reflects_projectiles = TRUE
 
 /// Adds our cosmic field to the global list which bombs check to see if they have to stop exploding
-/obj/effect/forcefield/cosmic_field/proc/prevents_explosions()
+/obj/structure/forcefield/cosmic_field/proc/prevents_explosions()
 	GLOB.active_cosmic_fields += src
 
 /datum/movespeed_modifier/cosmic_field
 	multiplicative_slowdown = -0.25
 
-/obj/effect/forcefield/cosmic_field/star_blast
+/obj/structure/forcefield/cosmic_field/star_blast
 	initial_duration = 5 SECONDS
 
-/obj/effect/forcefield/cosmic_field/star_touch
+/obj/structure/forcefield/cosmic_field/star_touch
 	initial_duration = 30 SECONDS
 
-/obj/effect/forcefield/cosmic_field/fast
+/obj/structure/forcefield/cosmic_field/fast
 	initial_duration = 5 SECONDS
 
-/obj/effect/forcefield/cosmic_field/extrafast
+/obj/structure/forcefield/cosmic_field/extrafast
 	initial_duration = 2.5 SECONDS
 
 #undef TRAIT_REFLECTED_BY_COSMIC_FIELD

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -143,7 +143,7 @@
 	if(!istype(target) || (target != tank_one && target != tank_two))
 		return FALSE
 
-	for(var/obj/effect/forcefield/cosmic_field/potential_field as anything in GLOB.active_cosmic_fields)
+	for(var/obj/structure/forcefield/cosmic_field/potential_field as anything in GLOB.active_cosmic_fields)
 		if(get_dist(potential_field, src) < 3)
 			new /obj/effect/temp_visual/revenant(get_turf(src))
 			return FALSE

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -175,7 +175,7 @@
 		update_appearance()
 		return FALSE
 
-	for(var/obj/effect/forcefield/cosmic_field/potential_field as anything in GLOB.active_cosmic_fields)
+	for(var/obj/structure/forcefield/cosmic_field/potential_field as anything in GLOB.active_cosmic_fields)
 		if(get_dist(potential_field, src) < 3)
 			new /obj/effect/temp_visual/revenant(get_turf(src))
 			active = FALSE

--- a/code/modules/antagonists/heretic/items/labyrinth_handbook.dm
+++ b/code/modules/antagonists/heretic/items/labyrinth_handbook.dm
@@ -2,17 +2,25 @@
 	name = "labyrinth pages"
 	desc = "A field of papers flying in the air, stopping heathens with impossible force."
 	icon_state = "lintel"
-	initial_duration = 15 SECONDS //was 15, charge time is still 15
+	initial_duration = 15 SECONDS
 	uses_integrity = 1
 	max_integrity = 60
 	integrity_failure = 0
 	obj_flags = CAN_BE_HIT
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	var/paper_sound = 'sound/items/handling/paper_drop.ogg'
 
 /obj/structure/forcefield/wizard/heretic/CanAllowThrough(atom/movable/mover, border_dir)
 	if(istype(mover.throwing?.thrower, /obj/structure/forcefield/wizard/heretic))
 		return TRUE
 	return ..()
+
+/obj/structure/forcefield/wizard/heretic/attack_hand(mob/living/carbon/human/user, list/modifiers)
+	. = ..()
+	user.visible_message(span_notice("[user] rips at [src]."), \
+		span_notice("You attempt to rip apart [src] to no avail."))
+	playsound(src, paper_sound, 20, TRUE)
+	return TRUE //monkestation edit
 
 ///A heretic item that spawns a barrier at the clicked turf, 5 uses
 /obj/item/heretic_labyrinth_handbook

--- a/code/modules/antagonists/heretic/items/labyrinth_handbook.dm
+++ b/code/modules/antagonists/heretic/items/labyrinth_handbook.dm
@@ -1,27 +1,20 @@
-/obj/effect/forcefield/wizard/heretic
+/obj/structure/forcefield/wizard/heretic
 	name = "labyrinth pages"
-	desc = "A field of papers flying in the air, repulsing heathens with impossible force."
+	desc = "A field of papers flying in the air, stopping heathens with impossible force."
 	icon_state = "lintel"
-	initial_duration = 15 SECONDS
+	initial_duration = 15 SECONDS //was 15, charge time is still 15
+	uses_integrity = 1
+	max_integrity = 60
+	integrity_failure = 0
+	obj_flags = CAN_BE_HIT
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
-/obj/effect/forcefield/wizard/heretic/CanAllowThrough(atom/movable/mover, border_dir)
-	if(istype(mover.throwing?.thrower, /obj/effect/forcefield/wizard/heretic))
+/obj/structure/forcefield/wizard/heretic/CanAllowThrough(atom/movable/mover, border_dir)
+	if(istype(mover.throwing?.thrower, /obj/structure/forcefield/wizard/heretic))
 		return TRUE
 	return ..()
 
-/obj/effect/forcefield/wizard/heretic/Bumped(mob/living/bumpee)
-	. = ..()
-	if(ismecha(bumpee))
-		var/obj/vehicle/sealed/mecha/mecha = bumpee
-		mecha.emp_act(EMP_LIGHT) // lol
-		return
-	if(!isliving(bumpee) || IS_HERETIC_OR_MONSTER(bumpee))
-		return
-	var/throwtarget = get_edge_target_turf(loc, get_dir(loc, get_step_away(bumpee, loc)))
-	bumpee.safe_throw_at(throwtarget, 10, 10, src, force = MOVE_FORCE_EXTREMELY_STRONG)
-	visible_message(span_danger("[src] repulses [bumpee] in a storm of paper!"))
-
-///A heretic item that spawns a barrier at the clicked turf, 3 uses
+///A heretic item that spawns a barrier at the clicked turf, 5 uses
 /obj/item/heretic_labyrinth_handbook
 	name = "labyrinth handbook"
 	desc = "A book containing the laws and regulations of the Locked Labyrinth, penned on an unknown substance. Its pages squirm and strain, looking to lash out and escape."
@@ -39,7 +32,7 @@
 	drop_sound = 'sound/items/handling/book_drop.ogg'
 	pickup_sound = 'sound/items/handling/book_pickup.ogg'
 	///what type of barrier do we spawn when used
-	var/barrier_type = /obj/effect/forcefield/wizard/heretic
+	var/barrier_type = /obj/structure/forcefield/wizard/heretic
 	/// Current charges remaining
 	var/charges = 5
 	/// Max possible amount of charges
@@ -53,7 +46,7 @@
 	. = ..()
 	if(!IS_HERETIC_OR_MONSTER(user))
 		return
-	. += span_hypnophrase("Materializes a barrier upon any tile in sight, which only you can pass through. Lasts 8 seconds.")
+	. += span_hypnophrase("Materializes a barrier upon any tile in sight, which only you can pass through. Lasts 15 seconds.")
 	. += span_notice("It has <b>[charges]</b> charge\s remaining.")
 
 /obj/item/heretic_labyrinth_handbook/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -193,7 +193,7 @@
 			if(combo_counter == 3)
 				if(target.mind && target.stat != DEAD)
 					increase_combo_duration()
-					source.AddElement(cosmic_trail_based_on_passive(source), /obj/effect/forcefield/cosmic_field/fast)
+					source.AddElement(cosmic_trail_based_on_passive(source), /obj/structure/forcefield/cosmic_field/fast)
 		third_target = second_target
 	second_target = WEAKREF(target)
 
@@ -201,7 +201,7 @@
 /datum/heretic_knowledge/blade_upgrade/cosmic/proc/reset_combo(mob/living/source)
 	second_target = null
 	third_target = null
-	source.RemoveElement(cosmic_trail_based_on_passive(source), /obj/effect/forcefield/cosmic_field/fast)
+	source.RemoveElement(cosmic_trail_based_on_passive(source), /obj/structure/forcefield/cosmic_field/fast)
 	combo_duration = combo_duration_amount
 	combo_counter = 0
 	new /obj/effect/temp_visual/cosmic_cloud(get_turf(source))

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -160,11 +160,11 @@
 	desc = "Author a Labyrinth Handbook.<br>\
 		It can materialize a barricade at range that only you and people resistant to magic can pass.<br>\
 		Has 5 charges which regenerate over time."
-	transmute_text = "Transmute a crayon, a wooden plank, and a multitool."
+	transmute_text = "Transmute a crayon, a book, and a multitool."
 	gain_text = "The Concierge scribbled my name into the Handbook. \"Welcome to your new home, fellow Steward.\""
 	required_atoms = list(
 		/obj/item/toy/crayon = 1,
-		/obj/item/stack/sheet/mineral/wood = 1,
+		/obj/item/book = 1,,
 		/obj/item/multitool = 1,
 	)
 	result_atoms = list(/obj/item/heretic_labyrinth_handbook)

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -164,7 +164,7 @@
 	gain_text = "The Concierge scribbled my name into the Handbook. \"Welcome to your new home, fellow Steward.\""
 	required_atoms = list(
 		/obj/item/toy/crayon = 1,
-		/obj/item/book = 1,,
+		/obj/item/book = 1,
 		/obj/item/multitool = 1,
 	)
 	result_atoms = list(/obj/item/heretic_labyrinth_handbook)

--- a/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
@@ -17,7 +17,7 @@
 
 	summon_amount = 9
 	summon_radius = 1
-	summon_type = list(/obj/effect/forcefield/cosmic_field)
+	summon_type = list(/obj/structure/forcefield/cosmic_field)
 	/// The range at which people will get marked with a star mark.
 	var/star_mark_range = 7
 	/// Effect for when the spell triggers
@@ -45,7 +45,7 @@
 		target_turfs += get_ranged_target_turf(target_turf, direction, 3)
 	return target_turfs
 
-/datum/action/cooldown/spell/conjure/cosmic_expansion/post_summon(obj/effect/forcefield/cosmic_field/summoned_object, atom/cast_on)
+/datum/action/cooldown/spell/conjure/cosmic_expansion/post_summon(obj/structure/forcefield/cosmic_field/summoned_object, atom/cast_on)
 	. = ..()
 	if(isstargazer(owner))
 		summoned_object.reflects_projectiles()

--- a/code/modules/antagonists/heretic/magic/star_blast.dm
+++ b/code/modules/antagonists/heretic/magic/star_blast.dm
@@ -27,7 +27,7 @@
 /datum/action/cooldown/spell/pointed/projectile/star_blast/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)
 	. = ..()
 	projectile_weakref = WEAKREF(to_fire)
-	to_fire.AddElement(cosmic_trail_based_on_passive(user), /obj/effect/forcefield/cosmic_field/fast)
+	to_fire.AddElement(cosmic_trail_based_on_passive(user), /obj/structure/forcefield/cosmic_field/fast)
 
 /datum/action/cooldown/spell/pointed/projectile/star_blast/apply_button_overlay(atom/movable/screen/movable/action_button/current_button, force)
 	var/obj/projectile/magic/star_ball/active_ball = projectile_weakref?.resolve()
@@ -63,7 +63,7 @@
 	for(var/turf/spawn_turf in range(1, get_turf(owner)))
 		if(spawn_turf.density)
 			continue
-		create_cosmic_field(spawn_turf, owner, /obj/effect/forcefield/cosmic_field/star_blast)
+		create_cosmic_field(spawn_turf, owner, /obj/structure/forcefield/cosmic_field/star_blast)
 	for(var/mob/living/nearby_mob in view(2, owner))
 		if(nearby_mob == owner || nearby_mob == summoner?.resolve())
 			continue

--- a/code/modules/antagonists/heretic/magic/star_touch.dm
+++ b/code/modules/antagonists/heretic/magic/star_touch.dm
@@ -232,11 +232,11 @@
 	if(isstargazer(target))
 		return
 	ADD_TRAIT(target, TRAIT_NO_TELEPORT, REF(src))
-	target.AddElement(cosmic_effect_trail, /obj/effect/forcefield/cosmic_field/star_touch)
+	target.AddElement(cosmic_effect_trail, /obj/structure/forcefield/cosmic_field/star_touch)
 
 /// What to remove when the beam disconnects from a target
 /datum/status_effect/cosmic_beam/proc/on_beam_release(mob/living/target)
 	if(isstargazer(target))
 		return
 	REMOVE_TRAIT(target, TRAIT_NO_TELEPORT, REF(src))
-	target.RemoveElement(cosmic_effect_trail, /obj/effect/forcefield/cosmic_field/star_touch)
+	target.RemoveElement(cosmic_effect_trail, /obj/structure/forcefield/cosmic_field/star_touch)

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -225,7 +225,7 @@
 
 /datum/status_effect/heretic_passive/cosmic/tick(seconds_between_ticks)
 	. = ..()
-	if(locate(/obj/effect/forcefield/cosmic_field) in get_turf(owner))
+	if(locate(/obj/structure/forcefield/cosmic_field) in get_turf(owner))
 		var/delta_time = DELTA_WORLD_TIME(SSclient_mobs) * 0.5 // SSmobs.wait is 2 secs, so this should be halved.
 		owner.stamina?.adjust(15 * delta_time/* , updating_stamina = FALSE */)
 
@@ -237,8 +237,8 @@
  * * Optional `creator`: Checks if the passed mob has a cosmic passive. Upgrades the cosmic field based on their passive level
  * * Optional `type`: Makes a specific type of cosmic field if we don't want the default
  */
-/proc/create_cosmic_field(loc, mob/living/creator, type = /obj/effect/forcefield/cosmic_field)
-	var/obj/effect/forcefield/cosmic_field/new_field
+/proc/create_cosmic_field(loc, mob/living/creator, type = /obj/structure/forcefield/cosmic_field)
+	var/obj/structure/forcefield/cosmic_field/new_field
 	new_field = new type(loc)
 
 	if(!creator || !ismob(creator))

--- a/code/modules/mob/living/basic/heretic/star_gazer.dm
+++ b/code/modules/mob/living/basic/heretic/star_gazer.dm
@@ -78,7 +78,7 @@
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_SHOE)
 	AddElement(/datum/element/wall_smasher, ENVIRONMENT_SMASH_RWALLS)
 	AddElement(/datum/element/simple_flying)
-	AddElement(/datum/element/effect_trail/cosmic_field/antiprojectile, /obj/effect/forcefield/cosmic_field/fast)
+	AddElement(/datum/element/effect_trail/cosmic_field/antiprojectile, /obj/structure/forcefield/cosmic_field/fast)
 	AddElement(/datum/element/ai_target_damagesource)
 	AddComponent(/datum/component/regenerator, outline_colour = "#b97a5d")
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -241,7 +241,7 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 	spell_max_level = 1
 	invocation_type = INVOCATION_NONE
-	wall_type = /obj/effect/forcefield/psychic
+	wall_type = /obj/structure/forcefield/psychic
 
 /datum/action/cooldown/spell/forcewall/psychic_wall/spawn_wall(turf/cast_turf)
 	. = ..()

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -114,7 +114,7 @@ Slimecrossing Items
 	max_integrity = 60
 
 //Melting Gel Wall - Chilling Metal
-/obj/effect/forcefield/slimewall
+/obj/structure/forcefield/slimewall
 	name = "solidified gel"
 	desc = "A mass of solidified slime gel - completely impenetrable, but it's melting away!"
 	icon = 'icons/obj/xenobiology/slimecrossing.dmi'
@@ -124,7 +124,7 @@ Slimecrossing Items
 	initial_duration = 10 SECONDS
 
 //Rainbow barrier - Chilling Rainbow
-/obj/effect/forcefield/slimewall/rainbow
+/obj/structure/forcefield/slimewall/rainbow
 	name = "rainbow barrier"
 	desc = "Despite others' urgings, you probably shouldn't taste this."
 	icon_state = "rainbowbarrier"

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -81,7 +81,7 @@ Chilling extracts:
 	user.visible_message(span_danger("[src] melts like quicksilver, and surrounds [user] in a wall!"))
 	for(var/turf/T in orange(get_turf(user),1))
 		if(get_dist(get_turf(user), T) > 0)
-			new /obj/effect/forcefield/slimewall(T)
+			new /obj/structure/forcefield/slimewall(T)
 	..()
 
 /obj/item/slimecross/chilling/yellow
@@ -349,5 +349,5 @@ Chilling extracts:
 	for (var/list/zlevel_turfs as anything in area.get_zlevel_turf_lists())
 		for(var/turf/area_turf as anything in zlevel_turfs)
 			for(var/obj/machinery/door/airlock/door in area_turf)
-				new /obj/effect/forcefield/slimewall/rainbow(door.loc)
+				new /obj/structure/forcefield/slimewall/rainbow(door.loc)
 	return ..()

--- a/code/modules/spells/spell_types/conjure/invisible_wall.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_wall.dm
@@ -20,7 +20,7 @@
 	spell_max_level = 1
 
 	summon_radius = 0
-	summon_type = list(/obj/effect/forcefield/mime)
+	summon_type = list(/obj/structure/forcefield/mime)
 	summon_lifespan = 30 SECONDS
 
 /datum/action/cooldown/spell/conjure/invisible_wall/before_cast(atom/cast_on)

--- a/code/modules/spells/spell_types/self/forcewall.dm
+++ b/code/modules/spells/spell_types/self/forcewall.dm
@@ -13,7 +13,7 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 
 	/// The typepath to the wall we create on cast.
-	var/wall_type = /obj/effect/forcefield/wizard
+	var/wall_type = /obj/structure/forcefield/wizard
 
 /datum/action/cooldown/spell/forcewall/cast(atom/cast_on)
 	. = ..()
@@ -40,7 +40,7 @@
 	cooldown_time = 40 SECONDS
 	invocation_type = INVOCATION_NONE
 
-	wall_type = /obj/effect/forcefield/cult
+	wall_type = /obj/structure/forcefield/cult
 
 /datum/action/cooldown/spell/forcewall/mime
 	name = "Invisible Blockade"
@@ -64,7 +64,7 @@
 	invocation_self_message = span_notice("You form a blockade in front of yourself.")
 	spell_max_level = 1
 
-	wall_type = /obj/effect/forcefield/mime/advanced
+	wall_type = /obj/structure/forcefield/mime/advanced
 
 /datum/action/cooldown/spell/forcewall/mime/before_cast(atom/cast_on)
 	. = ..()

--- a/monkestation/code/game/objects/effects/forcefields.dm
+++ b/monkestation/code/game/objects/effects/forcefields.dm
@@ -1,4 +1,4 @@
-/obj/effect/forcefield/cosmic_field/CanAllowThrough(atom/movable/mover, border_dir)
+/obj/structure/forcefield/cosmic_field/CanAllowThrough(atom/movable/mover, border_dir)
 	if(isprojectile(mover))
 		var/obj/projectile/projectile = mover
 		if(isliving(projectile.firer))

--- a/monkestation/code/modules/art_sci_overrides/asteroids/asteroid_generation.dm
+++ b/monkestation/code/modules/art_sci_overrides/asteroids/asteroid_generation.dm
@@ -66,7 +66,7 @@
 	mineralAmt = 1
 	scan_state = "rock_BScrystal"
 
-/obj/effect/forcefield/asteroid_magnet
+/obj/structure/forcefield/asteroid_magnet
 	name = "magnetic field"
 	desc = "This looks dangerous."
 	icon = 'goon/icons/obj/effects.dmi'

--- a/monkestation/code/modules/art_sci_overrides/asteroids/asteroid_magnet.dm
+++ b/monkestation/code/modules/art_sci_overrides/asteroids/asteroid_magnet.dm
@@ -201,7 +201,7 @@
 	. = list()
 	var/list/turfs = RANGE_TURFS(area_size, center_turf) ^ RANGE_TURFS(area_size + 1, center_turf)
 	for(var/turf/T as anything in turfs)
-		. += new /obj/effect/forcefield/asteroid_magnet(T)
+		. += new /obj/structure/forcefield/asteroid_magnet(T)
 
 /// Generates the random map for the magnet.
 /obj/machinery/asteroid_magnet/proc/GenerateMap(initial = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so the labyrinth forcefields now have health and can be destroyed. They have 60 hp (3 egun shots/2 buckshot/5 toolbox hits)
The labyrinth forcefield has sounds and text that lets people know you cant punch through it.

For this PR to work all forcefields were turned into structures instead of effects. They all work as before.

Also removed the code that was supposed to fling people backwards when touching the labyrinth forcefield since it wasn't working.

Small text changes to since some of it wasn't correct (it said walls lasted 8 seconds when they last 15). 

Recipe changed to use a book instead of a wooden plank.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game


[I cant embed this but heres a video of ed dee 1v4ing as lock heretic.](https://www.youtube.com/watch?v=kFJChKSchmw)


Lock heretic can easily trap you inside an inescapable box for 15 seconds, which is plenty of time for them to kill you. The only way out was teleporting or having antimagic. You can still be trapped, but at least you can try to escape.

Im not sure why the crafting was changed to use wood. The book item now takes a book. It just makes sense.

Fixing misleading text is never bad, same for removing code that wasnt working.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing

Tested if you could break labyrinth forcefields. You can both shoot and melee them, eventually destroying them.
Tested wizard, cosmic heretic, mime and psychic forcefields. They work as they did before. So hopefully that applies to the rest of them.

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: lock heretic labyrinth forcefields can now be destroyed
qol: lock heretic labyrinth book crafting changed to use a book instead of a wooden plank
refactor: forcefields are structures instead of effects, but functionally have not changed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
