### PR TITLE
Ascended Moon Heretic's lunatics now get a giant moon icon above their head.

### DIFF
--- a/code/modules/antagonists/heretic/moon_lunatic.dm
+++ b/code/modules/antagonists/heretic/moon_lunatic.dm
@@ -15,6 +15,8 @@
 	var/mob/living/carbon/human/ascended_body
 	// Our objective
 	var/datum/objective/lunatic/lunatic_obj
+	// Overlay used to show that this mob is a lunatic
+	var/mutable_appearance/moon_insanity_overlay
 
 /datum/antagonist/lunatic/on_gain()
 	// Masters gain an objective before so we dont want duplicates
@@ -43,16 +45,27 @@
 	our_mob.faction += FACTION_HERETIC
 	add_team_hud(our_mob, /datum/antagonist/lunatic)
 	ADD_TRAIT(our_mob, TRAIT_MADNESS_IMMUNE, REF(src))
-
+	moon_insanity_overlay = mutable_appearance('icons/effects/eldritch.dmi', "moon_insanity_overlay", ABOVE_MOB_LAYER)
+	moon_insanity_overlay.pixel_y = 12
+	moon_insanity_overlay.appearance_flags |= RESET_COLOR
+	RegisterSignal(our_mob, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(update_owner_overlay))
+	our_mob.update_appearance(UPDATE_OVERLAYS)
 	var/datum/action/cooldown/lunatic_track/moon_track = new /datum/action/cooldown/lunatic_track()
 	var/datum/action/cooldown/spell/touch/mansus_grasp/mad_touch = new /datum/action/cooldown/spell/touch/mansus_grasp()
 	mad_touch.Grant(our_mob)
 	moon_track.Grant(our_mob)
 
+/datum/antagonist/lunatic/proc/update_owner_overlay(atom/source, list/overlays)
+	SIGNAL_HANDLER
+	overlays += moon_insanity_overlay
+
 /datum/antagonist/lunatic/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/our_mob = mob_override || owner.current
 	handle_clown_mutation(our_mob, removing = FALSE)
 	our_mob.faction -= FACTION_HERETIC
+	moon_insanity_overlay = null
+	UnregisterSignal(our_mob, COMSIG_ATOM_UPDATE_OVERLAYS)
+	our_mob.update_appearance(UPDATE_OVERLAYS)
 
 // Mood event given to moon acolytes
 /datum/mood_event/heretics/lunatic

--- a/code/modules/antagonists/heretic/status_effects/debuffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/debuffs.dm
@@ -232,6 +232,7 @@
 	. = ..()
 	moon_insanity_overlay = mutable_appearance(effect_icon, effect_icon_state, ABOVE_MOB_LAYER)
 	moon_insanity_overlay.appearance_flags |= RESET_COLOR
+	moon_insanity_overlay.pixel_y = 12
 
 /datum/status_effect/moon_converted/Destroy()
 	moon_insanity_overlay = null


### PR DESCRIPTION
## About The Pull Request
Requested by admin team
Becoming a lunatic, through a moon heretic ascending, now puts a moon above your head, denoting you as a antag

## Why It's Good For The Game
Makes it clear that lunatics are a antag that dont? have escalation.

## Testing
<img width="159" height="140" alt="image" src="https://github.com/user-attachments/assets/24218414-034b-4fd9-a444-7b1208ba9929" />

## Changelog
:cl:
add: Becoming a lunatic via the moon heretics ascension now puts a giant moon icon above your head, denoting you as a antag. 
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
