### PR TITLE
Removes trait TRAIT_SUPPRESS_NOFIRE from ashen robes

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -163,11 +163,9 @@
 	flame_generation = !flame_generation
 
 	if(flame_generation)
-		ADD_TRAIT(user, TRAIT_SUPPRESS_NOFIRE, REF(src))
 		START_PROCESSING(SSobj, src)
 	else
 		STOP_PROCESSING(SSobj, src)
-		REMOVE_TRAIT(user, TRAIT_SUPPRESS_NOFIRE, REF(src))
 		user.extinguish()
 
 	user.balloon_alert(user, flame_generation ? "enabled" : "disabled")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ash heretics no longer get the TRAIT_SUPPRESS_NOFIRE which allows them to catch fire even if they have NOFIRE trait

Leaves trait itself in game since could have some good future use even though currently only used here
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This PR is for a few reasons, primarily oozelings, unlike IPCs who have to deal with their downsides of being a IPC when they roll heretic needing to go through the process of removing their heart and getting a new living heart oozelings get to ignore this downside of not catching fire when playing ash path? which makes no sense. They should either have to change their species inround through a few methods or pick a different path the same way IPCs do to get the buffs ash recieves from being on fire

But really any species with the Nofire trait should have that downside(well upside that is a downside in this case) even if they become a ashen heretic, the point of species traits is not for them to disappear the second they are inconvenient or bad for said species. they should be consistent, no other species gets this special treatment


to add, something I've discovered after making this PR, oozelings with hydrophobia can't be extinguished/lose flame stacks from water which is extremely strong and negates one of ash paths main downsides/weaknesses which I do feel is another reason this isn't great.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing
Yes tested, loaded up gave ashen robes no longer give no fire suppress trait and those with no fire do not catch fire
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Ashen robes no longer give TRAIT_SUPPRESS_NOFIRE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
