### PR TITLE
cyborgs can now interact with wall mounted intercoms

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -94,6 +94,9 @@
 /obj/item/radio/intercom/attack_ai(mob/user)
 	interact(user)
 
+/obj/item/radio/intercom/attack_robot(mob/user)
+	interact(user)
+
 /obj/item/radio/intercom/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)


### PR DESCRIPTION

## About The Pull Request
Cyborgs can now interact with wall mounted intercoms (e.g. "station intercom").

## Why It's Good For The Game
AIs can do it, but cyborgs can't. Why? I don't know. Bugfix.

## Testing
The TGUI menu opens.
<img width="550" height="197" alt="image" src="https://github.com/user-attachments/assets/68455d6a-af3f-4f1c-89c3-794cce05cc48" />

## Changelog
:cl:
fix: Cyborgs now correctly can interact with wall mounted intercoms.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
