### PR TITLE
Adds a command vendor to Helio

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -82376,16 +82376,7 @@
 /area/station/maintenance/department/security/upper)
 "ylg" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/radio{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/radio,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 2
-	},
+/obj/machinery/vending/access/command,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)


### PR DESCRIPTION
## About The Pull Request

Adds a missing command vending machine to Heliostation

## Why It's Good For The Game

Consistency between maps.


## Changelog

:cl:
fix: Heliostation now has a Command vending machine in the Bridge.
/:cl: