### PR TITLE
Bloodlings become properly spaceproof >level 2, hivemind no longer works while dead

### DIFF
--- a/monkestation/code/modules/antagonists/bloodling/abilities/bloodling_hivespeak.dm
+++ b/monkestation/code/modules/antagonists/bloodling/abilities/bloodling_hivespeak.dm
@@ -8,6 +8,8 @@
 
 /datum/action/cooldown/bloodling_hivespeak/IsAvailable(feedback = FALSE)
 	. = ..()
+	if(owner.stat == DEAD)
+		return FALSE
 
 	if(IS_BLOODLING_OR_THRALL(owner))
 		return TRUE

--- a/monkestation/code/modules/antagonists/bloodling/mobs/bloodling_mob.dm
+++ b/monkestation/code/modules/antagonists/bloodling/mobs/bloodling_mob.dm
@@ -87,6 +87,9 @@
 	// All evolutions over 2 (3,4,5) are spess proof
 	if(evolution_level > 2)
 		ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
+		src.bodytemp_cold_damage_limit = -1
+		src.pressure_resistance = 200
+		src.habitable_atmos = null
 
 /mob/living/basic/bloodling/proper/adjust_health(amount, updating_health = TRUE, forced = FALSE)
 	. = amount
@@ -317,7 +320,7 @@
 	maptext_height = 64
 	maptext_width = 64
 	mob_size = MOB_SIZE_HUGE
-	
+
 	evolution_level = 7
 	initial_powers = list(
 		/datum/action/cooldown/bloodling/absorb,


### PR DESCRIPTION

## About The Pull Request
Fixes bloodlings space proofing and makes them properly space proof over level 2(The comment "// All evolutions over 2 (3,4,5) are spess proof" implies they are meant to be but they only get the spacewalk trait and nothing else)

Bloodling changeling thralls can no longer use the hivemind while dead

## Why It's Good For The Game
Fixes two bloodling related bugs

## Testing
Yes tested both, both work properly now

## Changelog

:cl:
fix: bloodling hivemind no longer works while dead
fix: bloodlings become properly space proof over level 2
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

