### PR TITLE
FIxed custom vendors not differentiating between DNA Activators

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -13,7 +13,7 @@
 	contraband = list()
 	premium = list()
 */
-
+#define ITEM_HASH(item)(sanitize_css_class_name("[item.name][item.custom_price][item.type]"))
 #define MAX_VENDING_INPUT_AMOUNT 30
 /**
  * # vending record datum
@@ -1037,10 +1037,12 @@
 			LAZYADD(product_datum.returned_products, inserted_item)
 			return
 
-	if(vending_machine_input[inserted_item.type])
-		vending_machine_input[inserted_item.type]++
+	var/itemhash = ITEM_HASH(inserted_item)
+	if(vending_machine_input[itemhash])
+		vending_machine_input[itemhash]++
 	else
-		vending_machine_input[inserted_item.type] = 1
+		vending_machine_input[itemhash] = 1
+		update_static_data_for_all_viewers()
 	loaded_items++
 
 /obj/machinery/vending/unbuckle_mob(mob/living/buckled_mob, force = FALSE, can_fall = TRUE)
@@ -1575,12 +1577,14 @@
 	. = ..()
 	.["access"] = compartmentLoadAccessCheck(user)
 	.["vending_machine_input"] = list()
-	for (var/obj/item/stocked_item as anything in vending_machine_input)
+	for (var/stocked_item as anything in vending_machine_input)
 		if(vending_machine_input[stocked_item] > 0)
 			var/base64
 			var/price = 0
-			for(var/obj/item/stored_item in contents)
-				if(stored_item.type == stocked_item)
+			var/itemname
+			for(var/obj/item/stored_item in contents - component_parts)
+				if(ITEM_HASH(stored_item) == stocked_item)
+					itemname = stored_item.name
 					price = stored_item.custom_price
 					if(!base64) //generate an icon of the item to use in UI
 						if(base64_cache[stored_item.type])
@@ -1590,8 +1594,8 @@
 							base64_cache[stored_item.type] = base64
 					break
 			var/list/data = list(
-				path = stocked_item,
-				name = initial(stocked_item.name),
+				path = stocked_item, //list key is named "path", but actual value is of type "text" from calling ITEM_HASH(). I'm afraid to rename for fear of causing issues
+				name = itemname,
 				price = price,
 				img = base64,
 				amount = vending_machine_input[stocked_item],
@@ -1649,7 +1653,7 @@
 /obj/machinery/vending/custom/proc/vend_act(mob/living/user, list/params)
 	if(!vend_ready)
 		return
-	var/obj/item/choice = text2path(params["item"]) // typepath is a string coming from javascript, we need to convert it back
+	var/choice = params["item"]
 	var/obj/item/dispensed_item
 	var/obj/item/card/id/id_card = user.get_idcard(TRUE)
 	vend_ready = FALSE
@@ -1658,8 +1662,8 @@
 		flick(icon_deny, src)
 		return TRUE
 	var/datum/bank_account/payee = id_card.registered_account
-	for(var/obj/item/stock in contents)
-		if(istype(stock, choice))
+	for(var/obj/item/stock in contents - component_parts)
+		if(choice == ITEM_HASH(stock))
 			dispensed_item = stock
 			break
 	if(!dispensed_item)
@@ -1687,6 +1691,8 @@
 	loaded_items--
 	use_energy(active_power_usage)
 	vending_machine_input[choice] = max(vending_machine_input[choice] - 1, 0)
+	if (vending_machine_input[choice] == 0)
+		vending_machine_input -= list(choice)
 	if(user.CanReach(src) && user.put_in_hands(dispensed_item))
 		to_chat(user, span_notice("You take [dispensed_item.name] out of the slot."))
 	else

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1577,7 +1577,7 @@
 	. = ..()
 	.["access"] = compartmentLoadAccessCheck(user)
 	.["vending_machine_input"] = list()
-	for (var/stocked_item as anything in vending_machine_input)
+	for (var/stocked_item in vending_machine_input)
 		if(vending_machine_input[stocked_item] > 0)
 			var/base64
 			var/price = 0


### PR DESCRIPTION

## About The Pull Request

Made custom vendor's vending_machine_input list use keys containing more info about the item (name,path,price) instead of just path. All usages of vending_machine_input reflect this and a proc/verb (not familiar with the terminology yet), ITEM_HASH - a one line verb/proc/whatever it is - has been copied from tgstation to make code more readable when forming these keys.

The vendor ui is force-refreshed when adding an item with a new combo of name+path+price just in case (a safety copy from the tg code, since i think sometimes during testing i had to close/reopen the ui to load new items, though this was pre me figuring out how the ui/backend link worked, so i mightve broken it early in my work and fixed it later unknowingly even without this line) 

Leftover vending_machine_input keys should now cleaned up (i.e. when an item is fully removed ("itemkey" = 0 in the list), vending_machine_input removes it from the list) as a very minor 'optimization' in case large numbers of unique keys are added and then removed from a custom vendor and would waste time in iterations through vending_machine_input.

The value passed for the "path" key for the UI in vending/custom/ui_data() has been replaced with the new info key as it was originally just used as a unique identifying key for items rather than an actual path at most usage points (the exception to this - in vending/custom/ui_data - has been handled with an extra temp variable) and this new name+path+price key is more uniquely identifying than just item path. 

Custom vendor sold items now also display their current name rather than initial name, allowing things like dna injectors to reflect their current state (i.e Radproof, insulated, rather than always being shown as "DNA activator")

component parts are now skipped over when looking at vending contents for for-sale items
## Why It's Good For The Game

Allows more freedom in custom vendor usage, notably geneticists can now put dna activators/mutators in a custom vending machine and customers can actually see what they're buying instead of a mystery "DNA activator". 

Also allows for differentiation in prices between insertions of different instances of the same item without compromising the sale-ability of the item. For example, I think if you put in 3 of the same item, one priced at 10, the next at 10000, and the last at 10, the old system would have the first one costing 10 sold first, then lock the other 10 cost one behind someone removing the one priced at 10000. The new system separates them into 2 stacks, ones at 10 and ones at 10000 so you can keep one basically not-for-sale as a display of potentially refreshable stock if the customer comes back later.
## Testing

Every testing instance had me spawn a custom vendor with the spawn panel, smack my ID on it to gain ownership, price tag items with the transformed universal scanner, and then insert them into the machine with left click and my ID equipped.

Minor preamble: during initial testing I originally tried passing around of name as a separate variable alongside the type for item comparisons in ui and vending logic and found some items failed the comparison even though they looked the same due to invisible nonsense characters, i would add them to the custom vendor the normal way and then not be able to retrieve them because the name passed in as a param didnt match the item's actual name (no idea why???) but that issue got fixed with the usage of sanitize_css_class_name(). I only figured this out after I did the ITEM_HASH thing from tg, and in hindsight if I'd just used sanitize_css_class_name with the name passing that probably would've worked too. Anyway those special name case issues are fixed. 

Main test, the specific items aren't important, what i believe important is that you have 2 different items, then 2 different mutators

1. Set up (spawn vendor, own vendor, tag soon-to-be-mentioned items with price tagger, and shove a human/monkey into a dna scanner and print 2 of 1 mutation and 2 of a different mutation )
2. Insert Debug Surgery Disk at 1cr (1cr price not relevant, just default)
3. Insert Ambu Bag at 1cr
4. Insert DNA Mutator A at 1cr (usually ended up being monkified but again, not relevant)
5. Insert DNA Mutator B at 1cr 
6. Insert DNA Mutator A at 2cr
7. Insert DNA Mutator B at 1cr
This shows you can add different mutators and not stack them on the UI, add differently priced mutators and not stack them, and add an item of the same type/price/name and add it to a previous stack with those values
<img width="620" height="322" alt="Screenshot 2026-06-15 001958" src="https://github.com/user-attachments/assets/71c02fef-0d8d-45cc-958f-3de3bbc33365" />

8. buy the ambu bag
<img width="663" height="273" alt="image" src="https://github.com/user-attachments/assets/295bdda9-3420-495a-a224-882e3e2d4060" />

this is just to show theres no pesky UI bug like the one i posted about in discord where it would duplicate vending rows when multiple of the same item type were in separate stacks later in the display (some type-related issue, cleared by using the item,type,price combo)
9. Buy mutator A at 2cr (because its later in the list, if it didnt consider price when trying to vend then the 1cr one would be taken out since its earlier in the contents list)
<img width="1410" height="208" alt="image" src="https://github.com/user-attachments/assets/f4364654-586d-45aa-99e3-b0aa84d724c5" />
10. Buy mutator B (shows you can buy from a stack and have it update on the UI correctly)
<img width="1437" height="244" alt="image" src="https://github.com/user-attachments/assets/9075af33-6bf2-4f8c-ae48-cdb08b64091d" />

11. buy B again just for the hell of it
<img width="1462" height="259" alt="image" src="https://github.com/user-attachments/assets/7bbb700e-b3a4-4ce7-b502-1a5e0f8266e1" />

Yay! Everything functioned as it should! woohoo!
## Changelog

:cl:
fix: Displays the current names of items in custom vendors instead of initial names
qol: Added distinction in custom vendor ui for item instances with the same path but different names or prices
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
