### PR TITLE
Adds bungo tree fruits and seeds to ashwalker place

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker2.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker2.dmm
@@ -1744,6 +1744,8 @@
 /obj/item/seeds/reishi,
 /obj/item/seeds/reishi,
 /obj/item/seeds/cannabis,
+/obj/item/seeds/cocoapod/bungotree,
+/obj/item/seeds/cocoapod/bungotree,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Ew" = (
@@ -1946,8 +1948,7 @@
 "IM" = (
 /obj/structure/rack/wooden,
 /obj/item/stack/medical/aloe{
-	pixel_x = -5;
-	pixel_y = 12
+	pixel_x = -10
 	},
 /obj/item/food/grown/aloe,
 /obj/item/food/grown/aloe{
@@ -1956,6 +1957,17 @@
 /obj/item/food/grown/aloe{
 	pixel_y = 0;
 	pixel_x = 10
+	},
+/obj/item/food/grown/bungofruit{
+	pixel_y = 9
+	},
+/obj/item/food/grown/bungofruit{
+	pixel_y = 9;
+	pixel_x = -5
+	},
+/obj/item/food/grown/bungofruit{
+	pixel_y = 9;
+	pixel_x = 5
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)


### PR DESCRIPTION

## About The Pull Request
Adds bungo fruits and seeds next to aloe plants and seeds in the Ashwalker place.
## Why It's Good For The Game
Ashwalkers have access to aloe and cellulose but are missing bungotoxin to make mourning poultices. It feels pretty thematic for ashwalkers to make poultices as a low-tech healing option.
## Testing
## Changelog
:cl:
add: ashwalkers now have access to bungo fruit
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
