### PR TITLE
Ooze mobs now have a health doll and see their ability costs

### DIFF
--- a/code/_onclick/hud/ooze.dm
+++ b/code/_onclick/hud/ooze.dm
@@ -3,7 +3,7 @@
 	. = ..()
 
 	zone_select = new /atom/movable/screen/zone_sel(null, src)
-	zone_select.icon = ui_style
+	zone_select.icon = ui_style2icon(owner.client?.prefs?.read_preference(/datum/preference/choiced/ui_style))
 	zone_select.update_appearance()
 	static_inventory += zone_select
 

--- a/code/_onclick/hud/ooze.dm
+++ b/code/_onclick/hud/ooze.dm
@@ -1,5 +1,5 @@
 ///Hud type with targeting dol and a nutrition bar
-/datum/hud/ooze/New(mob/living/owner)
+/datum/hud/living/ooze/New(mob/living/owner)
 	. = ..()
 
 	zone_select = new /atom/movable/screen/zone_sel(null, src)

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -11,7 +11,7 @@
 	emote_see = list("jiggles", "bounces in place")
 	speak_emote = list("blorbles")
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	hud_type = /datum/hud/ooze
+	hud_type = /datum/hud/living/ooze
 	bodytemp_cold_damage_limit = 250
 	bodytemp_heat_damage_limit = INFINITY
 	faction = list(FACTION_SLIME)
@@ -300,7 +300,7 @@
 ///Ability that allows the owner to fire healing globules at mobs, targeting specific limbs.
 /datum/action/cooldown/globules
 	name = "Fire Mending globule"
-	desc = "Fires a mending globule at someone, healing a specific limb of theirs."
+	desc = "Fires a mending globule at someone, healing a specific limb of theirs. Costs 5 nutrition."
 	background_icon_state = "bg_hive"
 	overlay_icon_state = "bg_hive_border"
 	button_icon = 'icons/mob/actions/actions_slime.dmi'
@@ -310,10 +310,16 @@
 	click_to_activate = TRUE
 
 /datum/action/cooldown/globules/set_click_ability(mob/on_who)
+	var/mob/living/simple_animal/hostile/ooze/oozy_owner = owner
+	if(istype(oozy_owner))
+		if(oozy_owner.ooze_nutrition < 5)
+			to_chat(oozy_owner, span_warning("You need at least 5 nutrition to launch a mending globule."))
+			return
 	. = ..()
 	if(!.)
 		return
 
+	oozy_owner.adjust_ooze_nutrition(-5)
 	to_chat(on_who, span_notice("You prepare to launch a mending globule. <B>Left-click to fire at a target!</B>"))
 
 /datum/action/cooldown/globules/unset_click_ability(mob/on_who, refund_cooldown = TRUE)
@@ -322,20 +328,9 @@
 		return
 
 	if(refund_cooldown)
+		var/mob/living/simple_animal/hostile/ooze/oozy_owner = owner
+		oozy_owner.adjust_ooze_nutrition(5)
 		to_chat(on_who, span_notice("You stop preparing your mending globules."))
-
-/datum/action/cooldown/globules/Activate(atom/target)
-	. = ..()
-	if(!.)
-		return FALSE
-
-	var/mob/living/simple_animal/hostile/ooze/oozy_owner = owner
-	if(istype(oozy_owner))
-		if(oozy_owner.ooze_nutrition < 5)
-			to_chat(oozy_owner, span_warning("You need at least 5 nutrition to launch a mending globule."))
-			return FALSE
-
-	return TRUE
 
 /datum/action/cooldown/globules/InterceptClickOn(mob/living/user, params, atom/target)
 	. = ..()
@@ -404,7 +399,7 @@
 ///This action lets you put a mob inside of a cacoon that will inject it with some chemicals.
 /datum/action/cooldown/gel_cocoon
 	name = "Gel Cocoon"
-	desc = "Puts a mob inside of a cocoon, allowing it to slowly heal."
+	desc = "Puts a mob inside of a cocoon, allowing it to slowly heal. Costs 30 nutrition."
 	background_icon_state = "bg_hive"
 	overlay_icon_state = "bg_hive_border"
 	button_icon = 'icons/mob/actions/actions_slime.dmi'


### PR DESCRIPTION
## About The Pull Request

Fixes a bug where mending globule (ability of Sholean grapes) being able to be cust without nutrition. The abilities of sholean grapes now state their cost in their description.

All ooze mobs now also have a health doll and a damaged overlay.

<img width="1230" height="967" alt="image" src="https://github.com/user-attachments/assets/611f3a9d-60ef-479b-a545-0a8436a285b2" />

## Why It's Good For The Game

Not being able to see your health and ability costs is bad.

## Testing

Tested on a local server, they do in fact have an updated hud and can't cast mending globules without enough nutrition

## Changelog
:cl:
qol: Ooze mobs from cytology now have the same type of HUD as other mobs, allowing them to see their health
qol: The abilities of shoolean grapes now have their cost specified in their description
fix: The mending globule ability used by shoolean grapes no longer can be cast while there isn't enough nutrition to do so
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
