### PR TITLE
fixes why roundstart dynamic threat-requiring rulesets were not working

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -135,7 +135,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/waittime_h = 1800
 
 	/// Maximum amount of threat allowed to generate.
-	var/max_threat_level = 0 //disables dynamic threat PLEASE DONT LET ME MERGE THIS
+	var/max_threat_level = 100
 
 	/// The extra chance multiplier that a heavy impact midround ruleset will run next time.
 	/// For example, if this is set to 50, then the next heavy roll will be about 50% more likely to happen.


### PR DESCRIPTION

## About The Pull Request
Changes the maximum threat level in dynamic from 0 to 100.

## Why It's Good For The Game
It stopped roundstart dynamic rulesets from activating. Not cool. Comments implies that it was unintentional.

## Testing
Before, readied as AI:
<img width="825" height="218" alt="image" src="https://github.com/user-attachments/assets/de7426af-64cd-449f-8f36-3b54d3c5d59f" />

After, readied as AI:
<img width="839" height="232" alt="image" src="https://github.com/user-attachments/assets/8dc81ce3-06b0-4d1c-8373-489035a55d42" />

## Changelog
:cl:
fix: The maximum threat level for dynamic have been reverted from 0 to 100. This means that any roundstart dynamic rulesets that require any amount of threat can now trigger again.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
