### PR TITLE
Reduces number of hyposprays in vending machines

### DIFF
--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -32,10 +32,10 @@
 			"name" = "Hyposprays",
 			"icon" = "syringe",
 			"products" = list(
-				/obj/item/hypospray = 5,
-				/obj/item/storage/medkit/hypospray = 3,
+				/obj/item/hypospray = 2,
+				/obj/item/storage/medkit/hypospray = 2,
 				/obj/item/storage/medkit/hypospray/advanced = 1,
-				/obj/item/storage/lockbox/vialbox = 5,
+				/obj/item/storage/lockbox/vialbox = 3,
 			),
 		))
 	contraband = list(

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -21,7 +21,6 @@
 		/obj/item/stack/medical/bone_gel = 2,
 		/obj/item/reagent_containers/medipen/deforest/robot_liquid_solder = 2,
 		/obj/item/reagent_containers/medipen/deforest/robot_system_cleaner = 4,
-		/obj/item/storage/medkit/hypospray = 3,
 			),
 		))
 	contraband = list(


### PR DESCRIPTION

## About The Pull Request
reduces number of hyposprays in medical vendor from 5 to 2
reduces number of hypospray kits in medical vendor from 3 to 2
reduces number of vial boxes in medical vendor from 5 to 3
removes hypospray kits from wall mount vendor
## Why It's Good For The Game
hyposprays are a tech locked item but as it stands there is 5 purchaseable in a vending machine, along with 3 kits (with hypos included) for a total of 8 roundstart. not to mention 3 more in every single wall vendor which some maps have 2-3 as well as some in security

tech lock items should be ideally locked behind tech and not entirely bypassable. it's nice to have a limited quantity available if you want to get your hands on one early but the entirety of medbay + anyone else shouldn't be able to get their hands on one too. 

the wallmount vendors seem to be meant to be a quick place to buy a patch or so, and an entire kit doesn't really make sense here. much more of a premium item for these convenience vendors. not sure why the gel cans are here either, could be made either more expensive or removed tbh

having items in limited quantity encourages cooperation and science is more impactful. less kits means it's harder to get chems so you have to either ask a chemist or doc to make some. more cooperation is good instead of just buying heals and healing yourself
## Testing
<img width="460" height="75" alt="image" src="https://github.com/user-attachments/assets/5b527b80-0e96-4a9c-b391-464ba82e7ac2" />

i lowkey dunno what this means but it probably wasn't me. just a numbers change anyways mostly kinda. otherwise compiled fine.
## Changelog
:cl: Cujo
balance: Reduces number of hyposprays in medical vendor (5->2)
balance: Reduces number of hypospray kits in medical vendor (3->2)
balance: Reduces number of vial boxes in medical vendor (5->3)
del: Removes hypospray kits from medical wall vendors
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
