### PR TITLE
Having over required living minutes lets you skip interview

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -916,7 +916,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			if(string)
 				string += ", "
 			string += "Mobile Hostspot IP"
-	if(failed && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src) && required_living_minutes >= living_minutes)
+	if(failed && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src) && required_living_minutes < living_minutes)
 		message_admins(span_adminnotice("Proxy Detection: [key_name_admin(src)] Overwatch detected this is a [string]"))
 		interviewee = TRUE
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -898,6 +898,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 /client/proc/check_overwatch()
 	var/failed = FALSE
+	var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
+	var/living_minutes = client.get_exp_living(TRUE)
 	SSoverwatch.CollectClientData(src)
 	failed = SSoverwatch.HandleClientAccessCheck(src)
 	SSoverwatch.HandleASNbanCheck(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -595,7 +595,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(!tooltips)
 		tooltips = new /datum/tooltip(src)
 
-	if(((player_age != -1) && player_age < CONFIG_GET(number/minimum_age)) && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src))
+	var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
+	var/living_minutes = get_exp_living(TRUE)
+
+	if(((player_age != -1) && living_minutes < required_living_minutes && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src)))
 		interviewee = TRUE
 		register_for_interview()
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -914,7 +914,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			if(string)
 				string += ", "
 			string += "Mobile Hostspot IP"
-	if(failed && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src))
+	if(failed && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src) && living_minutes >= required_living_minutes)
 		message_admins(span_adminnotice("Proxy Detection: [key_name_admin(src)] Overwatch detected this is a [string]"))
 		interviewee = TRUE
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -916,11 +916,11 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			if(string)
 				string += ", "
 			string += "Mobile Hostspot IP"
-	if(failed && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src) && living_minutes >= required_living_minutes)
+	if(failed && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src) && required_living_minutes >= living_minutes)
 		message_admins(span_adminnotice("Proxy Detection: [key_name_admin(src)] Overwatch detected this is a [string]"))
 		interviewee = TRUE
 
-	if(ckey in GLOB.interviews.approved_ckeys)
+	if(ckey in GLOB.interviews.approved_ckeys || living_minutes >= required_living_minutes)
 		return FALSE
 
 	return failed

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -920,7 +920,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		message_admins(span_adminnotice("Proxy Detection: [key_name_admin(src)] Overwatch detected this is a [string]"))
 		interviewee = TRUE
 
-	if(ckey in GLOB.interviews.approved_ckeys || living_minutes >= required_living_minutes)
+	if((ckey in GLOB.interviews.approved_ckeys) || living_minutes >= required_living_minutes)
 		return FALSE
 
 	return failed

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -916,7 +916,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			if(string)
 				string += ", "
 			string += "Mobile Hostspot IP"
-	if(failed && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src) && required_living_minutes < living_minutes)
+	if(failed && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src) && living_minutes < required_living_minutes)
 		message_admins(span_adminnotice("Proxy Detection: [key_name_admin(src)] Overwatch detected this is a [string]"))
 		interviewee = TRUE
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -899,7 +899,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 /client/proc/check_overwatch()
 	var/failed = FALSE
 	var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
-	var/living_minutes = client.get_exp_living(TRUE)
+	var/living_minutes = get_exp_living(TRUE)
 	SSoverwatch.CollectClientData(src)
 	failed = SSoverwatch.HandleClientAccessCheck(src)
 	SSoverwatch.HandleASNbanCheck(src)

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -17,7 +17,7 @@
 	var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
 	var/living_minutes = client.get_exp_living(TRUE)
 
-	if(living_minutes < required_living_minutes && !(ckey in GLOB.interviews.approved_ckeys))
+	if(((client.player_age != -1) && living_minutes < required_living_minutes && !(ckey in GLOB.interviews.approved_ckeys) && !is_mentor(src) && !is_admin(src)))
 		client.interviewee = TRUE
 
 	. = ..()

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -17,7 +17,7 @@
 	var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
 	var/living_minutes = client.get_exp_living(TRUE)
 
-	if(living_minutes >= required_living_minutes && !(ckey in GLOB.interviews.approved_ckeys))
+	if(living_minutes < required_living_minutes && !(ckey in GLOB.interviews.approved_ckeys))
 		client.interviewee = TRUE
 
 	. = ..()

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -14,19 +14,11 @@
 		mind.active = TRUE
 		mind.set_current(src)
 
-	if((client.player_age != -1) && client.player_age <= CONFIG_GET(number/minimum_age) && !(client.ckey in GLOB.interviews.approved_ckeys))
-		client.interviewee = TRUE
+	var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
+	var/living_minutes = client.get_exp_living(TRUE)
 
-	// Check if user should be added to interview queue
-	if(!client.holder && CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))
-		var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
-		var/living_minutes = client.get_exp_living(TRUE)
-		if(!CONFIG_GET(flag/minimum_account_age))
-			if(required_living_minutes >= living_minutes)
-				client.interviewee = FALSE
-		else
-			if(client.account_age <= CONFIG_GET(number/minimum_age))
-				client.interviewee = TRUE
+	if(living_minutes >= required_living_minutes && !(ckey in GLOB.interviews.approved_ckeys))
+		client.interviewee = TRUE
 
 	. = ..()
 	if(!. || !client)

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -18,12 +18,12 @@
 		client.interviewee = TRUE
 
 	// Check if user should be added to interview queue
-	if (!client.holder && CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))
+	if(!client.holder && CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))
 		var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
 		var/living_minutes = client.get_exp_living(TRUE)
 		if(!CONFIG_GET(flag/minimum_account_age))
-			if (required_living_minutes >= living_minutes)
-				client.interviewee = TRUE
+			if(required_living_minutes >= living_minutes)
+				client.interviewee = FALSE
 		else
 			if(client.account_age <= CONFIG_GET(number/minimum_age))
 				client.interviewee = TRUE


### PR DESCRIPTION

## About The Pull Request
Having over the required amount of living minutes, set in config, lets you skip the interview and VPN interview

## Why It's Good For The Game
Headmin request, deleting all other interview stuff was also by their request due to monke just always having interviews anyways.

people who filled out interview, got accepted, played some, shouldn't have to do another interview next round, and people allowed in with vpns

## Testing
Tested by siro, loaded up with under required hours got interview loaded up with over required hours no interview

## Changelog

:cl:
admin: Having over required living minutes lets you skip interviews and VPN interview
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

