### PR TITLE
Sleepers now have a 1 second doafter on dragclick

### DIFF
--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -114,7 +114,11 @@
 /obj/machinery/sleeper/mouse_drop_receive(atom/target, mob/user, params)
 	if(!iscarbon(target))
 		return
-	do_after(user, 1 SECOND)
+	target.visible_message(span_warning("[user] starts buckling [target] to [src]!"),\
+			span_userdanger("[user] starts buckling you to [src]!"),\
+			span_hear("You hear metal clanking."))
+	if(!do_after(user, 1 SECONDS, target))
+		return FALSE
 	close_machine(target)
 
 /obj/machinery/sleeper/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -120,7 +120,7 @@
 		span_hear("You hear metal clanking."),
 	)
 	if(!do_after(user, 1 SECONDS, target))
-		return FALSE
+		return
 	close_machine(target)
 
 /obj/machinery/sleeper/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -114,6 +114,7 @@
 /obj/machinery/sleeper/mouse_drop_receive(atom/target, mob/user, params)
 	if(!iscarbon(target))
 		return
+	do_after(user, 1 SECOND)
 	close_machine(target)
 
 /obj/machinery/sleeper/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -114,9 +114,11 @@
 /obj/machinery/sleeper/mouse_drop_receive(atom/target, mob/user, params)
 	if(!iscarbon(target))
 		return
-	target.visible_message(span_warning("[user] starts buckling [target] to [src]!"),\
-			span_userdanger("[user] starts buckling you to [src]!"),\
-			span_hear("You hear metal clanking."))
+	target.visible_message(span_warning(
+		"[user] starts buckling [target] to [src]!"),
+		span_userdanger("[user] starts buckling you to [src]!"),
+		span_hear("You hear metal clanking."),
+	)
 	if(!do_after(user, 1 SECONDS, target))
 		return FALSE
 	close_machine(target)


### PR DESCRIPTION

## About The Pull Request
gives a 1 second do after to sleepers on drag click
## Why It's Good For The Game
you can instantly drag someone into a sleeper and if you are fast enough start spam injecting them with stuff. it should probably give a warning 

also gives some warnings to the person getting dragged and people around
## Testing
tested on local host it takes a second. 
## Changelog
:cl: Cujo
add: Sleepers now take a second to drag someone inside
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
