### PR TITLE
Swat mask reskin ability

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -90,15 +90,20 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 
 /obj/item/clothing/mask/gas/sechailer/swat
 	name = "\improper SWAT mask"
-	desc = "A close-fitting tactical mask with an especially aggressive Compli-o-nator 3000."
+	desc = "A close-fitting tactical mask with an especially aggressive Compli-o-nator 3000. Also has adjustable lens and filters slots to fit on your face!"
 	actions_types = list(/datum/action/item_action/halt)
 	icon_state = "swat"
 	inhand_icon_state = "swat"
 	aggressiveness = AGGR_SHIT_COP
-	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDEEYES | HIDEEARS | HIDEHAIR | HIDESNOUT
+	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDEEYES | HIDEEARS | HIDESNOUT
 	visor_flags_inv = 0
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
+	unique_reskin = list(
+			"Hood" = "swat",
+			"Soviet" = "swat1",
+			"Pig" = "swat2"
+	)
 
 /obj/item/clothing/mask/gas/sechailer/swat/alt
 	name = "\improper SWAT gas mask"
@@ -116,6 +121,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	inhand_icon_state = "spacepol_mask"
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
+	uses_advanced_reskins = FALSE
 
 /obj/item/clothing/mask/gas/sechailer/cyborg
 	name = "security hailer"

--- a/monkestation/code/modules/ERT/equipment/ERT_misc_equipment.dm
+++ b/monkestation/code/modules/ERT/equipment/ERT_misc_equipment.dm
@@ -101,6 +101,7 @@
 	worn_icon = 'monkestation/icons/mob/clothing/mask.dmi'
 	icon_state = "ert"
 	aggressiveness = 1
+	unique_reskin = FALSE
 
 /obj/item/storage/box/survival/ert
 	name = "emergency response survival box"


### PR DESCRIPTION

## About The Pull Request
Lets the sec swat gas mask be reskinnable to all its styles, for more nerd drip options.
Also makes it show hair to make the alt styles work.
<img width="226" height="189" alt="image" src="https://github.com/user-attachments/assets/7abbb489-ad0b-4e94-9ee1-7ab94c1c55dc" />

<img width="204" height="85" alt="image" src="https://github.com/user-attachments/assets/30d34458-bfca-4811-b0ae-0d8f90d3347a" />

## Why It's Good For The Game
Customizations neat!
## Testing
<img width="416" height="209" alt="image" src="https://github.com/user-attachments/assets/a1e9ea3a-d78c-462e-84c1-e4e5ffa11792" />

<img width="491" height="584" alt="image" src="https://github.com/user-attachments/assets/fff9a106-9399-4ba5-8fab-0580fee8252d" />

## Changelog
:cl:
add: You can alt+click security swat masks for some nifty alt styles.
add: Swat mask shows hair now
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
