### PR TITLE
gets rid of two drains ontop of eachother in tramstation medical

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -30724,7 +30724,6 @@
 /obj/structure/curtain,
 /obj/machinery/shower/directional/north,
 /obj/structure/drain,
-/obj/structure/drain,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "iBx" = (


### PR DESCRIPTION

## About The Pull Request
removes a duplicate drain
## Why It's Good For The Game
not intended
## Testing
i didn't
## Changelog
:cl: Cujo
del: Removes a duplicate shower drain in Tramstation Medical
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
