### PR TITLE
Fixes runtimes in relevations

### DIFF
--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -8,6 +8,7 @@
 	program_flags = PROGRAM_ON_SYNDINET_STORE
 	tgui_id = "NtosRevelation"
 	program_icon = "magnet"
+	///Boolean on whether the PDA app is currently armed or not.
 	var/armed = FALSE
 
 /datum/computer_file/program/revelation/on_start(mob/living/user)
@@ -35,7 +36,7 @@
 
 	if(cached_computer.internal_cell && prob(25))
 		QDEL_NULL(cached_computer.internal_cell)
-		cached_computer.visible_message(span_notice("\The [cached_computer]'s battery explodes in rain of sparks."))
+		cached_computer.visible_message(span_warning("\The [cached_computer]'s battery explodes in rain of sparks."))
 		var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
 		spark_system.start()
 
@@ -54,7 +55,6 @@
 			filedesc = newname
 			return TRUE
 
-
 /datum/computer_file/program/revelation/clone()
 	var/datum/computer_file/program/revelation/temp = ..()
 	temp.armed = armed
@@ -63,6 +63,7 @@
 /datum/computer_file/program/revelation/ui_data(mob/user)
 	var/list/data = list()
 
+	data["filedesc"] = filedesc
 	data["armed"] = armed
 
 	return data

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -8,34 +8,36 @@
 	program_flags = PROGRAM_ON_SYNDINET_STORE
 	tgui_id = "NtosRevelation"
 	program_icon = "magnet"
-	var/armed = 0
+	var/armed = FALSE
 
 /datum/computer_file/program/revelation/on_start(mob/living/user)
-	. = ..(user)
+	. = ..()
+	if(!.)
+		return .
 	if(armed)
 		activate()
 
 /datum/computer_file/program/revelation/proc/activate()
-	if(computer)
-		if(istype(computer, /obj/item/modular_computer/pda/silicon)) //If this is a borg's integrated tablet
-			var/obj/item/modular_computer/pda/silicon/modularInterface = computer
-			to_chat(modularInterface.silicon_owner,span_userdanger("SYSTEM PURGE DETECTED/"))
-			addtimer(CALLBACK(modularInterface.silicon_owner, TYPE_PROC_REF(/mob/living/silicon/robot/, death)), 2 SECONDS, TIMER_UNIQUE)
-			return
+	if(!computer)
+		return
+	if(istype(computer, /obj/item/modular_computer/pda/silicon)) //If this is a borg's integrated tablet
+		var/obj/item/modular_computer/pda/silicon/modularInterface = computer
+		to_chat(modularInterface.silicon_owner, span_userdanger("SYSTEM PURGE DETECTED/"))
+		addtimer(CALLBACK(modularInterface.silicon_owner, TYPE_PROC_REF(/mob/living/silicon, death)), 2 SECONDS, TIMER_UNIQUE)
+		return
 
-		computer.visible_message(span_notice("\The [computer]'s screen brightly flashes and loud electrical buzzing is heard."))
-		computer.enabled = FALSE
-		computer.update_appearance()
+	var/obj/item/modular_computer/cached_computer = computer //this becomes null
+	computer.take_damage(25, BRUTE, 0, 0)
+	computer.visible_message(span_warning("\The [computer]'s screen brightly flashes and loud electrical buzzing is heard."))
+	for(var/datum/computer_file/file as anything in computer.stored_files)
+		computer.remove_file(file)
+	cached_computer.shutdown_computer(loud = FALSE)
 
-		QDEL_LIST(computer.stored_files)
-
-		computer.take_damage(25, BRUTE, 0, 0)
-
-		if(computer.internal_cell && prob(25))
-			QDEL_NULL(computer.internal_cell)
-			computer.visible_message(span_notice("\The [computer]'s battery explodes in rain of sparks."))
-			var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
-			spark_system.start()
+	if(cached_computer.internal_cell && prob(25))
+		QDEL_NULL(cached_computer.internal_cell)
+		cached_computer.visible_message(span_notice("\The [cached_computer]'s battery explodes in rain of sparks."))
+		var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
+		spark_system.start()
 
 /datum/computer_file/program/revelation/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -82,8 +82,6 @@
 	viewing_messages_of = null
 
 /datum/computer_file/program/messenger/Destroy(force)
-	if(!QDELETED(computer))
-		stack_trace("Attempted to qdel messenger of [computer] without qdeling computer, this will cause problems later")
 	remove_messenger(src)
 	return ..()
 

--- a/tgui/packages/tgui/interfaces/NtosRevelation.tsx
+++ b/tgui/packages/tgui/interfaces/NtosRevelation.tsx
@@ -5,20 +5,22 @@ import { useBackend } from '../backend';
 import { NtosWindow } from '../layouts';
 
 type Data = {
+  filedesc: string;
   armed: BooleanLike;
 };
 
-export const NtosRevelation = (props) => {
+export const NtosRevelation = () => {
   const { act, data } = useBackend<Data>();
-  const { armed } = data;
+  const { filedesc, armed } = data;
 
   return (
-    <NtosWindow width={400} height={250}>
+    <NtosWindow width={400} height={180}>
       <NtosWindow.Content>
         <Section>
           <Button.Input
             fluid
-            buttonText="Obfuscate Name..."
+            value={filedesc}
+            buttonText="Set Program Name..."
             onCommit={(value) =>
               act('PRG_obfuscate', {
                 new_name: value,
@@ -31,22 +33,24 @@ export const NtosRevelation = (props) => {
               label="Payload Status"
               buttons={
                 <Button
-                  content={armed ? 'ARMED' : 'DISARMED'}
                   color={armed ? 'bad' : 'average'}
                   onClick={() => act('PRG_arm')}
-                />
+                >{armed ? 'ARMED' : 'DISARMED'}</Button>
               }
             />
           </LabeledList>
-          <Button
+          <Button.Confirm
             fluid
+            my={1}
             bold
-            content="ACTIVATE"
+            tooltip="This will set off the bomb without needing to re-open the app"
             textAlign="center"
             color="bad"
             disabled={!armed}
-            onClick={() => act('PRG_activate')}
-          />
+            confirmColor="good"
+            onClick={() => act('PRG_activate')}>
+              ACTIVATE
+          </Button.Confirm>
         </Section>
       </NtosWindow.Content>
     </NtosWindow>


### PR DESCRIPTION
## About The Pull Request

Fixes Revelations runtiming and not properly closing your PDA.
Also makes it not run if the pda doesn't actually open the app (ex: if you already hit your program limit)
Improves the UI a bit, making "Activate" a confirm button with a tooltip explaining what it does, extra space between buttons, and a better description for app name obfuscation.


## Changelog

:cl:
fix: Revelations now works as intended
/:cl: