### PR TITLE
Remove moodlet from pride pins

### DIFF
--- a/monkestation/code/modules/clothing/under/accessories/badges.dm
+++ b/monkestation/code/modules/clothing/under/accessories/badges.dm
@@ -1,10 +1,3 @@
-/obj/item/clothing/accessory/pride/accessory_equipped(obj/item/clothing/under/clothes, mob/living/user)
-	if(HAS_TRAIT(user, TRAIT_PRIDE_PIN))
-		user.add_mood_event("pride_pin", /datum/mood_event/pride_pin)
-
-/obj/item/clothing/accessory/pride/accessory_dropped(obj/item/clothing/under/clothes, mob/living/user)
-	user.clear_mood_event("pride_pin")
-
 ///Actual "Badge" badges.
 /obj/item/clothing/accessory/badge
 	name = "badge"

--- a/monkestation/code/modules/datums/mood_events/generic_positive_events.dm
+++ b/monkestation/code/modules/datums/mood_events/generic_positive_events.dm
@@ -10,10 +10,6 @@
 	mood_change = 10
 	hidden = TRUE
 
-/datum/mood_event/pride_pin
-	description = "I love showing off my pride pin!"
-	mood_change = 1
-
 /datum/mood_event/jazzy
 	description = "Oooh, jazzy!"
 	mood_change = 2


### PR DESCRIPTION
## About The Pull Request

Removes the +1 moodlet from pride pins

## Why It's Good For The Game

It's a free 0 point +1 moodlet which gets powergamed especially with hypersensitive making it a +2 mood buff. Clown and mime pins give the same moodlet but they actually cost quirk points

## Testing
## Changelog
:cl:
balance: Pride pin no longer gives you a positive moodlet
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
