### PR TITLE
Fixes the makeshift pulse pack getting glued to your back

### DIFF
--- a/monkestation/code/modules/machining/machining_exclusives.dm
+++ b/monkestation/code/modules/machining/machining_exclusives.dm
@@ -30,6 +30,7 @@
 	gun = new(src)
 	battery = new(src)
 	START_PROCESSING(SSobj, src)
+	AddElement(/datum/element/drag_pickup)
 
 /obj/item/pulsepack/Destroy()
 	//we do this check as a precaution (read: pass checks) since the backpack itself should have already deleted this


### PR DESCRIPTION

## About The Pull Request
The makeshift pulse pack borrowed code from the laser minigun, but it forgot to take the element with it in the divorce, thus making it so you couldnt actually take it off.
## Why It's Good For The Game
Bugfix good
## Testing
Spawned pulse pack, put it on, took it off, removed drag_pickup element, couldnt do it, good enough
## Changelog
:cl:
fix: the Makeshift Pulse Pack can now be taken off of your back by click-dragging it.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
