### PR TITLE
adds a mining foundry to kilostation

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2500,7 +2500,6 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/fore)
 "aLI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -4811,13 +4810,11 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "bAy" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "bAM" = (
@@ -7123,6 +7120,9 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
 "chT" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "chV" = (
@@ -12722,13 +12722,9 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "dVB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/shaft_miner,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/landmark/start/explorer,
 /turf/open/floor/iron,
-/area/station/cargo/miningoffice)
+/area/station/cargo/storage)
 "dVM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -21360,7 +21356,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "gIi" = (
-/obj/effect/landmark/start/explorer,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "gIo" = (
@@ -22566,8 +22565,8 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "hbC" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "hbE" = (
@@ -29049,7 +29048,8 @@
 /area/station/commons/fitness/recreation)
 "iRq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
+/obj/effect/landmark/start/explorer,
+/obj/item/clothing/suit/hooded/wintercoat/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "iRt" = (
@@ -47379,18 +47379,18 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/starboard)
 "oLI" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/item/gps/mining,
-/obj/structure/table,
-/obj/item/crowbar/red,
-/obj/item/hand_labeler,
 /obj/machinery/digital_clock/directional/north,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 4
+	},
+/obj/machinery/bouldertech/refinery/smelter,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "oLR" = (
@@ -50821,14 +50821,13 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/chapel/monastery)
 "pNY" = (
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display/evac/directional/east,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/item/gps/mining,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -54927,6 +54926,9 @@
 /area/station/commons/toilet/restrooms)
 "rcp" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wardrobe/miner,
+/obj/item/clothing/suit/hooded/wintercoat/miner,
+/obj/item/clothing/suit/hooded/wintercoat/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "rcB" = (
@@ -61001,7 +61003,14 @@
 /area/station/maintenance/disposal/incinerator)
 "sYB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/explorer,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 1
+	},
+/obj/machinery/brm,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "sYM" = (
@@ -61390,18 +61399,16 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "tfo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/miner,
-/obj/item/clothing/suit/hooded/wintercoat/miner,
-/obj/item/clothing/suit/hooded/wintercoat/miner,
-/obj/item/clothing/suit/hooded/wintercoat/miner,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "tfs" = (
@@ -61860,16 +61867,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "tmN" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/computer/security/mining,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "tmU" = (
 /obj/machinery/newscaster/directional/west,
@@ -63196,9 +63201,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "tME" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
@@ -63206,6 +63208,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 5
+	},
+/obj/machinery/bouldertech/refinery,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "tMG" = (
@@ -67184,7 +67191,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "uZZ" = (
@@ -119129,7 +119135,7 @@ wbj
 jgC
 lKq
 smd
-ncH
+dVB
 mYW
 bzY
 sTm
@@ -120673,7 +120679,7 @@ rZV
 tmN
 iRq
 aLI
-dVB
+uZY
 kyj
 qAR
 qJs

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -29049,7 +29049,6 @@
 "iRq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/explorer,
-/obj/item/clothing/suit/hooded/wintercoat/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "iRt" = (
@@ -47885,6 +47884,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"oUk" = (
+/obj/item/clothing/suit/hooded/wintercoat/miner,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard)
 "oUl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/red/directional/west,
@@ -119645,7 +119648,7 @@ shO
 dAQ
 eGD
 rcI
-lDu
+oUk
 xZL
 lKq
 lKq


### PR DESCRIPTION

## About The Pull Request
<img width="460" height="448" alt="image" src="https://github.com/user-attachments/assets/323c8518-c7a0-4ef6-ba57-24c1a252d598" />

adds a mining foundry near the shaft miners area. shuffles things around to allow for it.
the coat in the picture was moved to where it should be, i forgot that one since the explorer spawn happens to be there

## Why It's Good For The Game

kilostation doesn't have one. this addition has been requested in OOC

## Testing

loaded into local host, pulled the lever and turned on retrieval matrix.

## Changelog

:cl:
map: Revamped the kilostation mining area to add an ore foundry
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
