### PR TITLE
Updates the deforest specialty bag storages

### DIFF
--- a/monkestation/code/modules/blueshift/items/deforest.dm
+++ b/monkestation/code/modules/blueshift/items/deforest.dm
@@ -552,6 +552,7 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/bodybag,
+		/obj/item/breathing_bag,
 	))
 
 /obj/item/storage/backpack/deforest_medkit/stocked
@@ -654,6 +655,8 @@
 		/obj/item/wrench/medical,
 		/obj/item/emergency_bed,
 		/obj/item/bodybag,
+		/obj/item/breathing_bag,
+		/obj/item/autopsy_scanner,
 	))
 
 /obj/item/storage/backpack/deforest_surgical/stocked


### PR DESCRIPTION

## About the Pull Request
Updates the whitelist on the deforest surgery bag to hold ambu bags and autopsy scanners, and the deforest orange satchel to hold ambu bags.
## Why It's Good For The Game
Updates the medical themed bags to hold medical items
## Testing
Yep, both fit within their weight limits.
## Changelog
:cl:
balance: deforest surgery bag can now hold ambu bags and autopsy scanners, and the deforest orange satchel hold ambu bags.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
