### PR TITLE
Removes screenshake from megafauna warning roar (ided)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -228,8 +228,6 @@
 
 /mob/living/simple_animal/hostile/megafauna/proc/warn_players(list/targets)
 	playsound(src, rawr_sound, 100, extrarange = 5, falloff_distance = (vision_range + 2))
-	for(var/mob/living/shake_target as anything in targets)
-		shake_camera(shake_target, 2 SECONDS)
 	if(prob(0.1))
 		visible_message(span_userdanger("[src] roars loudly, visibly being annoyed with your presence!"))
 		return


### PR DESCRIPTION

## About The Pull Request

Simply removes the screenshake from the warning roar that megafauna do, making it a bit easier to recover bodies

## Why It's Good For The Game

The screenshake helps to "warn" the user that a megafauna is about to aggro them, however it makes rescuing bodies near them a harder task than it already is. For some megafauna, it is easier to just lure them away, but some megafaunas are too destructive and might end up being harder to lure away.

When you want to rescue a dead body without taking aggro you have to:
- Only approach once every 20 seconds after initial roar, otherwise you get instantly aggro after the 5 seconds from the roar.
- You have to find the body underneath other items near the megafauna.
- You have to wait about 3 seconds for the screenshake to stop to actually be able to pull the body.
- Somehow leave the aggro range before the warning timer runs out.

There are far too many things to consider when trying to recover a body, this won't make it instantly easy and doable, but it makes it less reliable on the screenshake RNG and a lot less frustrating.

## Testing

Ran a private server, went near a megafauna, no screenshake.

## Changelog
:cl:
del: Removes screenshake from megafauna warning roars.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
