### PR TITLE
Mythril now innately has its fantasy effects (soul pr)

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -414,7 +414,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	mineral_rarity = MATERIAL_RARITY_UNDISCOVERED //Doesn't naturally spawn on lavaland.
 	points_per_unit = 100 / SHEET_MATERIAL_AMOUNT
 
-/* monkestation edit: this is given anyways by [/datum/material_trait/magical]
+
 /datum/material/mythril/on_applied_obj(atom/source, amount, material_flags)
 	. = ..()
 	if(isitem(source))
@@ -426,7 +426,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	if(isitem(source))
 		REMOVE_TRAIT(source, TRAIT_INNATELY_FANTASTICAL_ITEM, REF(src)) // DO THIS FIRST OR WE WILL NEVER GET OUR BONUSES DELETED!!!
 		qdel(source.GetComponent(/datum/component/fantasy))
-monkestation end */
+
 
 /datum/material/mythril/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(20, BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -237,13 +237,13 @@
 	catalog_description = "Liquid plasma vents"
 	fish_table = list(
 		FISHING_DUD = 5,
-		/obj/item/fish/chasm_crab/ice = 15,
-		/obj/item/coin/plasma = 3,
-		/obj/item/stack/ore/plasma = 3,
-		/mob/living/basic/mining/lobstrosity = 1,
-		/obj/effect/decal/remains/plasma = 1,
-		/obj/item/stack/sheet/mineral/mythril = 1,
-		/obj/item/stack/sheet/mineral/adamantine = 1,
+		/obj/item/fish/chasm_crab/ice = 120,
+		/obj/item/coin/plasma = 24,
+		/obj/item/stack/ore/plasma = 24,
+		/mob/living/basic/mining/lobstrosity = 8,
+		/obj/effect/decal/remains/plasma = 8,
+		/obj/item/stack/sheet/mineral/mythril = 3,
+		/obj/item/stack/sheet/mineral/adamantine = 8,
 	)
 	fish_counts = list(
 		/obj/item/stack/sheet/mineral/adamantine = 3,


### PR DESCRIPTION
## About The Pull Request

mythril sheets and everything made out of mythril have their fantasy effects like they used to, mythril now has a 1.5% chance to be fished up from icemoon lava instead of 4%

## Why It's Good For The Game

mythril is fun, i actually dont know why it didnt have the effects before, this kinda seems like a bug. i did make it a bit rarer (from 4% to 1.5%) 

## Testing


## Changelog

:cl:
fix: Mythril now has it's fantasy effects, although it is slightly rarer to obtain from icemoon lava now.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
