### PR TITLE
Adds black dimensional gloves as a tot item

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -64,7 +64,7 @@
 	var/refund_amount = 0
 	/// Whether this item is refundable or not.
 	var/refundable = FALSE
-	// Chance of being included in the surplus crate.
+	/// Chance of being included in the surplus crate.
 	var/surplus = 100
 	/// Whether this can be discounted or not
 	var/cant_discount = FALSE

--- a/code/modules/uplink/uplink_items/utility_clothing.dm
+++ b/code/modules/uplink/uplink_items/utility_clothing.dm
@@ -165,3 +165,10 @@
 	item = /obj/item/storage/backpack/duffelbag/syndie
 	cost = 1
 	surplus = 50
+
+/datum/uplink_item/utility_clothing/dimensional_gloves
+	name = "Black Dimensional Gloves"
+	desc = "A pair of sleak black gloves that functions as a weapon storage using bluespace compression technology. Holds up to six weapons."
+	item = /obj/item/clothing/gloves/color/black/dimensional
+	cost = 10
+	surplus = 30

--- a/monkestation/code/modules/clothing/gloves/gloves.dm
+++ b/monkestation/code/modules/clothing/gloves/gloves.dm
@@ -36,7 +36,7 @@
 		user_active_arm.unarmed_damage_high += 0.1
 
 /obj/item/clothing/gloves/latex/surgical
-	name = "Black Latex gloves"
+	name = "black latex gloves"
 	desc = "Pricy sterile gloves that are thinner than latex. The lining allows for the person to operate \
 					quicker along with the faster use time of various chemical related items"
 	icon = 'monkestation/icons/obj/clothing/gloves.dmi'
@@ -61,3 +61,46 @@
 	worn_icon = 'monkestation/icons/mob/clothing/gloves.dmi'
 	icon = 'monkestation/icons/obj/clothing/gloves.dmi'
 	alternate_worn_layer = ABOVE_SUIT_LAYER
+
+/obj/item/clothing/gloves/color/black/dimensional
+	desc = "These gloves function as a dimensonal weapon storage using bluespace compression technology. It doesn't muffle surrounding sound; why would it?"
+
+/obj/item/clothing/gloves/color/black/dimensional/Initialize(mapload)
+	. = ..()
+	create_storage(storage_type = /datum/storage/dimensional_gloves)
+
+/datum/storage/dimensional_gloves
+	max_specific_storage = WEIGHT_CLASS_GIGANTIC
+	max_total_storage = WEIGHT_CLASS_GIGANTIC * 6
+	max_slots = 6
+
+/datum/storage/dimensional_gloves/New(atom/parent, max_slots, max_specific_storage, max_total_storage, numerical_stacking, allow_quick_gather, allow_quick_empty, collection_mode, attack_hand_interact)
+	. = ..()
+	set_holdable(can_hold_list = list(
+		/obj/item/ammo_box,
+		/obj/item/ammo_casing,
+		/obj/item/gun,
+		/obj/item/knife,
+		/obj/item/melee,
+		/obj/item/nullrod,
+		/obj/item/energy_katana,
+		/obj/item/throwing_star,
+		/obj/item/shield,
+		/obj/item/spear,
+		/obj/item/dualsaber,
+		/obj/item/fireaxe,
+		/obj/item/flamethrower,
+		/obj/item/chainsaw,
+		/obj/item/pitchfork,
+		/obj/item/pneumatic_cannon,
+		/obj/item/soulscythe,
+		/obj/item/claymore,
+		/obj/item/katana,
+		/obj/item/switchblade,
+		/obj/item/cane,
+		/obj/item/highfrequencyblade,), \
+
+		cant_hold_list = list(
+			/obj/item/gun/magic, // no magic
+		)
+	)

--- a/monkestation/code/modules/clothing/gloves/gloves.dm
+++ b/monkestation/code/modules/clothing/gloves/gloves.dm
@@ -76,30 +76,31 @@
 
 /datum/storage/dimensional_gloves/New(atom/parent, max_slots, max_specific_storage, max_total_storage, numerical_stacking, allow_quick_gather, allow_quick_empty, collection_mode, attack_hand_interact)
 	. = ..()
-	set_holdable(can_hold_list = list(
-		/obj/item/ammo_box,
-		/obj/item/ammo_casing,
-		/obj/item/gun,
-		/obj/item/knife,
-		/obj/item/melee,
-		/obj/item/nullrod,
-		/obj/item/energy_katana,
-		/obj/item/throwing_star,
-		/obj/item/shield,
-		/obj/item/spear,
-		/obj/item/dualsaber,
-		/obj/item/fireaxe,
-		/obj/item/flamethrower,
-		/obj/item/chainsaw,
-		/obj/item/pitchfork,
-		/obj/item/pneumatic_cannon,
-		/obj/item/soulscythe,
-		/obj/item/claymore,
-		/obj/item/katana,
-		/obj/item/switchblade,
-		/obj/item/cane,
-		/obj/item/highfrequencyblade,), \
-
+	set_holdable(
+		can_hold_list = list(
+			/obj/item/ammo_box,
+			/obj/item/ammo_casing,
+			/obj/item/gun,
+			/obj/item/knife,
+			/obj/item/melee,
+			/obj/item/nullrod,
+			/obj/item/energy_katana,
+			/obj/item/throwing_star,
+			/obj/item/shield,
+			/obj/item/spear,
+			/obj/item/dualsaber,
+			/obj/item/fireaxe,
+			/obj/item/flamethrower,
+			/obj/item/chainsaw,
+			/obj/item/pitchfork,
+			/obj/item/pneumatic_cannon,
+			/obj/item/soulscythe,
+			/obj/item/claymore,
+			/obj/item/katana,
+			/obj/item/switchblade,
+			/obj/item/cane,
+			/obj/item/highfrequencyblade,
+		),
 		cant_hold_list = list(
 			/obj/item/gun/magic, // no magic
 		)

--- a/monkestation/code/modules/clothing/gloves/gloves.dm
+++ b/monkestation/code/modules/clothing/gloves/gloves.dm
@@ -63,7 +63,7 @@
 	alternate_worn_layer = ABOVE_SUIT_LAYER
 
 /obj/item/clothing/gloves/color/black/dimensional
-	desc = "These gloves function as a dimensonal weapon storage using bluespace compression technology. It doesn't muffle surrounding sound; why would it?"
+	desc = "These gloves function as a dimensional weapon storage using bluespace compression technology. It doesn't muffle surrounding sound; why would it?"
 
 /obj/item/clothing/gloves/color/black/dimensional/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/modules/clothing/gloves/gloves.dm
+++ b/monkestation/code/modules/clothing/gloves/gloves.dm
@@ -63,7 +63,7 @@
 	alternate_worn_layer = ABOVE_SUIT_LAYER
 
 /obj/item/clothing/gloves/color/black/dimensional
-	desc = "These gloves function as a dimensional weapon storage using bluespace compression technology. It doesn't muffle surrounding sound; why would it?"
+	desc = "These gloves function as a dimensional weapon storage using bluespace compression technology. They are as silent as a prayer for loving sorrow."
 
 /obj/item/clothing/gloves/color/black/dimensional/Initialize(mapload)
 	. = ..()
@@ -73,6 +73,9 @@
 	max_specific_storage = WEIGHT_CLASS_GIGANTIC
 	max_total_storage = WEIGHT_CLASS_GIGANTIC * 6
 	max_slots = 6
+	silent = TRUE
+	rustle_sound = FALSE
+	emp_shielded = TRUE
 
 /datum/storage/dimensional_gloves/New(atom/parent, max_slots, max_specific_storage, max_total_storage, numerical_stacking, allow_quick_gather, allow_quick_empty, collection_mode, attack_hand_interact)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Adds a syndicate utility clothing: **black dimensional gloves**. It's disguised as black gloves and acts as a bag of holding for any weapon or gun (except for wands). Costs 10 TC (prevents tots from also getting dual energy saber) and is available to all uplinks. Make a comment if I missed a weapon you want included.
## Why It's Good For The Game
More cool gadgets for syndicate to play with.  Highly versatile for anyone not using modsuits and with access to a lot of weaponry. There is absolutely zero affiliation with a certain man with a dead wife and anger management issues.
## Testing
<img width="1272" height="560" alt="image" src="https://github.com/user-attachments/assets/ac3fa022-36ac-4b34-8aaf-d796fc52cfee" />

## Changelog
:cl:
add: new utility syndicate clothing: black gloves which can store up to six bulky weapons
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
