### PR TITLE
Swaps infiltrator and Bloodred mod armor values, Small chameleon vest nerf

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1070,14 +1070,14 @@
 	)
 
 /datum/armor/mod_theme_syndicate
-	melee = 40
+	melee = 50
 	bullet = 50
-	laser = 30
-	energy = 30
-	bomb = 35
+	laser = 40
+	energy = 50
+	bomb = 40
 	bio = 100
-	fire = 50
-	acid = 90
+	fire = 100
+	acid = 100
 	wound = 25
 
 /datum/mod_theme/elite
@@ -1205,13 +1205,13 @@
 	)
 
 /datum/armor/mod_theme_infiltrator
-	melee = 50
+	melee = 40
 	bullet = 50
-	laser = 40
-	energy = 50
-	bomb = 40
-	fire = 100
-	acid = 100
+	laser = 30
+	energy = 30
+	bomb = 35
+	fire = 50
+	acid = 90
 	wound = 25
 
 /datum/mod_theme/interdyne


### PR DESCRIPTION

## About The Pull Request
Swaps infiltrator and syndicate modsuit armor values apart from bio protection, bloodred retains it bioprotection and infil continues to lack it.

Infiltrator new values
	melee = 40
	bullet = 50
	laser = 30
	energy = 30
	bomb = 35
	fire = 50
	acid = 90
	wound = 25

Bloodred new armor values
	melee = 50
	bullet = 50
	laser = 40
	energy = 50
	bomb = 40
	bio = 100
	fire = 100
	acid = 100
	wound = 25


Syndicate chameleon body armor shares infils armor values so it also follows their new ones

## Why It's Good For The Game
Currently bloodred is just kinda really bad. It cost more at 6 tc, has a slowdown, and less armor, meanwhile infil modsuit is kinda insane at only 5 tc no slowdown, better armor values. 

The only reason to ever buy a blood red is if you want to go into space which is a little niche and you can buy a 2 tc syndicate space suit with the same armor values, its baggable, space proof, and really only lacks the benefit of a few modules.

Overall its just not great right now, and it doesn't make sense for a space proof, heavy, more expensive modsuit, to have less armor than a lightweight infiltrator speed modsuit non space proof? This hopefully makes it a little less niche and gives some solid actual reason to buy it and makes the infil suit a little more reasonable in general as its insanely strong for a 5 tc item.

## Testing
Yes tested armor properly updated

## Changelog

:cl:
balance: swaps infiltrator and bloodreds mod protections
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

