### PR TITLE
holy water counters labyrinth pages

### DIFF
--- a/code/modules/antagonists/heretic/items/labyrinth_handbook.dm
+++ b/code/modules/antagonists/heretic/items/labyrinth_handbook.dm
@@ -2,6 +2,7 @@
 	name = "labyrinth pages"
 	desc = "A field of papers flying in the air, repulsing heathens with impossible force."
 	icon_state = "lintel"
+	antimagic_flags = MAGIC_RESISTANCE_HOLY
 	initial_duration = 15 SECONDS
 
 /obj/effect/forcefield/wizard/heretic/CanAllowThrough(atom/movable/mover, border_dir)


### PR DESCRIPTION

## About The Pull Request
labyrinth  pages can be passed through if the person has TRAIT_HOLY which holy water gives.

alternative to https://github.com/Monkestation/Monkestation2.0/pull/11825

## Why It's Good For The Game
some counter for being boxxed in by the fornite spell.

## Changelog

:cl:
balance: labyrinth  pages can be passed through if the person has TRAIT_HOLY which holy water gives.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

