### PR TITLE
tape recorder improvements

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -15,12 +15,12 @@
 	speech_span = SPAN_TAPE_RECORDER
 	drop_sound = 'sound/items/handling/taperecorder_drop.ogg'
 	pickup_sound = 'sound/items/handling/taperecorder_pickup.ogg'
+	desc_controls = "Alt-Click to toggle the radio filter."
 	var/recording = FALSE
 	var/playing = FALSE
 	var/playsleepseconds = 0
 	var/obj/item/tape/mytape
 	var/starting_tape_type = /obj/item/tape/random
-	var/open_panel = FALSE
 	var/canprint = TRUE
 	var/list/icons_available = list()
 	var/radial_icon_file = 'icons/hud/radial_taperecorder.dmi'
@@ -30,6 +30,8 @@
 	var/time_left_warning = 60 SECONDS
 	///Sound loop that plays when recording or playing back.
 	var/datum/looping_sound/tape_recorder_hiss/soundloop
+	///If we record stuff spoken on radio
+	var/radio_sensitive = FALSE
 
 /obj/item/taperecorder/Initialize(mapload)
 	. = ..()
@@ -37,7 +39,6 @@
 		mytape = new starting_tape_type(src)
 	soundloop = new(src)
 	update_appearance()
-	become_hearing_sensitive()
 
 /obj/item/taperecorder/Destroy()
 	QDEL_NULL(soundloop)
@@ -58,11 +59,13 @@
 /obj/item/taperecorder/examine(mob/user)
 	. = ..()
 	if(in_range(src, user) || isobserver(user))
-		. += span_notice("The wire panel is [open_panel ? "opened" : "closed"]. The display reads:")
+		. += span_notice("The radio filter is [radio_sensitive ? "off" : "on"].")
+		. += span_notice("The display reads:")
 		. += "[readout()]"
 
 /obj/item/taperecorder/click_alt(mob/user)
-	play()
+	radio_sensitive = !radio_sensitive
+	balloon_alert(user, "radio filter [radio_sensitive ? "off" : "on"]")
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/taperecorder/proc/update_available_icons()
@@ -111,8 +114,8 @@
 	update_appearance()
 
 /obj/item/taperecorder/fire_act(exposed_temperature, exposed_volume)
-	mytape.unspool() //Fires unspool the tape, which makes sense if you don't think about it
-	..()
+	mytape?.unspool() //Fires unspool the tape, which makes sense if you don't think about it
+	return ..()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/taperecorder/attack_hand(mob/user, list/modifiers)
@@ -137,7 +140,6 @@
 	if(!mytape)
 		balloon_alert(usr, "no tape!")
 		return
-
 	eject(usr)
 
 
@@ -157,9 +159,14 @@
 
 /obj/item/taperecorder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans, list/message_mods = list(), message_range)
 	. = ..()
-	if(mytape && recording)
-		mytape.timestamp += mytape.used_capacity
-		mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss")]\] [raw_message]"
+	if(!mytape || istype(speaker, /obj/item/taperecorder))
+		return
+
+	if(radio_freq && !radio_sensitive)
+		return
+
+	mytape.timestamp += mytape.used_capacity
+	mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss")]\] [speaker.GetVoice()]: [raw_message]"
 
 
 /obj/item/taperecorder/verb/record()
@@ -183,6 +190,7 @@
 
 	if(mytape.used_capacity < mytape.max_capacity)
 		recording = TRUE
+		become_hearing_sensitive()
 		balloon_alert(usr, "started recording")
 		update_sound()
 		update_appearance()
@@ -216,6 +224,7 @@
 		playsound(src, 'sound/items/taperecorder/taperecorder_stop.ogg', 50, FALSE)
 		balloon_alert(usr, "stopped recording")
 		recording = FALSE
+		lose_hearing_sensitivity()
 	else if(playing)
 		playsound(src, 'sound/items/taperecorder/taperecorder_stop.ogg', 50, FALSE)
 		balloon_alert(usr, "stopped playing")
@@ -265,7 +274,7 @@
 			playsleepseconds = 1
 			sleep(1 SECONDS)
 		else
-			playsleepseconds = mytape.timestamp[i + 1] - mytape.timestamp[i]
+			playsleepseconds = max(mytape.timestamp[i + 1] - mytape.timestamp[i], 1 SECONDS)
 		if(playsleepseconds > 14 SECONDS)
 			sleep(1 SECONDS)
 			say("Skipping [playsleepseconds/10] seconds of silence.")


### PR DESCRIPTION

## About The Pull Request
ports: https://github.com/tgstation/tgstation/pull/90206
ports: https://github.com/tgstation/tgstation/pull/86570

gives tape recorders a radio filter and they log the speaker of the message now.

## Why It's Good For The Game
easier to read the transcript and do interrogations

## Changelog

:cl: hack-wrench,  SirNightKnight, Ghommie
add: tape recorder now records speaker name.
qol: gave tape recorders a radio filter toggle.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

