### PR TITLE
caps TEG power production at 100 MW

### DIFF
--- a/monkestation/code/modules/smithing/TEG/thermoelectric_generator.dm
+++ b/monkestation/code/modules/smithing/TEG/thermoelectric_generator.dm
@@ -144,7 +144,7 @@
 /obj/machinery/power/thermoelectric_generator/process()
 	//Setting this number higher just makes the change in power output slower, it doesnt actualy reduce power output cause **math**
 	var/power_output = round(lastgen / 10)
-	add_avail(power_output)
+	add_avail(min(power_output, 100 MW)) // caps at 100 MW
 	lastgenlev = power_output
 	lastgen -= power_output
 	process_engine()


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
currently TEGs are uncapped and you can easily get ridiculous power numbers with a good burn.

if you want the funny power numbers you gotta build more than one


## Changelog

:cl:
balance: capped TEG power production at 100 MW.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

