### PR TITLE
Reduces range to overhear cyborg radios

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -577,6 +577,7 @@
 	subspace_transmission = TRUE
 	subspace_switchable = TRUE
 	dog_fashion = null
+	canhear_range = 0
 
 /obj/item/radio/borg/resetChannels()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/79453

Cyborg radios now only can be heard if you're right ontop of them, just like normal radio headsets.

## Why It's Good For The Game
Bugfix. No reason for cyborgs to have a station bounced radio in them when headsets exist.

## Testing
None.

## Changelog
:cl:
fix: Cyborg radios now have the same hearing range as radio headsets.
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
