### PR TITLE
Fixes the AI overclocking console not having a board.

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -457,6 +457,11 @@
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/ai_server_console
 
+/obj/item/circuitboard/computer/ai_overclocking
+	name = "AI Overclocking Workstation Console"
+	greyscale_colors = CIRCUIT_COLOR_SCIENCE
+	build_path = /obj/machinery/computer/ai_overclocking
+
 /obj/item/circuitboard/computer/ai_resource_distribution
 	name = "AI Resource Distribution Console"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE

--- a/code/modules/mob/living/silicon/ai/decentralized/systech/overclocking.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/systech/overclocking.dm
@@ -7,7 +7,7 @@
 	icon_keyboard = "tech_key"
 	icon_screen = "ai-fixer"
 	light_color = LIGHT_COLOR_PINK
-	circuit = /obj/item/circuitboard/computer/ai_server_overview
+	circuit = /obj/item/circuitboard/computer/ai_overclocking
 
 	var/obj/item/ai_cpu/inserted_cpu = null
 	var/overclocking = FALSE

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -389,6 +389,16 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_NETMIN
 
+/datum/design/board/ai_overclocking
+	name = "AI Overclocking Workstation Console Board"
+	desc = "Allows for the construction of circuit boards used to build an AI Overclocking Workstation."
+	id = "ai_overclocking"
+	build_path = /obj/item/circuitboard/computer/ai_overclocking
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_RESEARCH
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_NETMIN
+
 /datum/design/board/ai_resource_distribution
 	name = "AI Resource Distribution Console Board"
 	desc = "Allows for the construction of circuit boards used to build an AI Resource Distribution console."

--- a/code/modules/research/techweb/robo_nodes.dm
+++ b/code/modules/research/techweb/robo_nodes.dm
@@ -72,6 +72,7 @@
 		"ai_data_core",
 		"ai_core_display",
 		"ai_server_overview",
+		"ai_overclocking",
 		"ram1",
 		"basic_ai_cpu",
 		"ai_resource_distribution",


### PR DESCRIPTION

## About The Pull Request
Creates a board for the overclocking console
Adds the board to the AI techweb node.
## Why It's Good For The Game
I dont wanna adminhelp when i have my overclock console deconned.
## Testing
Dismantled overclock console, repaired it, still an overclock console
Couldnt test the techweb node bc TGUI was broken bc i was also playing at the same time i made this.
## Changelog
:cl:
fix: AI overclocking workstation now has a board of its own, letting it be repaired.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
