### PR TITLE
Cyborg Apparatus Bugfixes & Alike

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -352,13 +352,9 @@
 					L.put_in_hands(I)
 					. = TRUE
 			else
-				if(iscyborg(L))
-					var/mob/living/silicon/robot/borg = L
-					if(istype(borg.module_active, /obj/item/borg/apparatus/circuit))
-						var/obj/item/borg/apparatus/circuit/robo_hand = borg.module_active
-						I = robo_hand.stored
-				else
-					I = L.get_active_held_item()
+				I = L.get_active_held_item()
+				if(I)
+					I = I.get_proxy_attacker_for(holder, L) // Get the actual item that we want to use (e.g. borg apparatus's stored item).
 				if(isassembly(I))
 					var/obj/item/assembly/A = I
 					if(A.attachable)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -131,11 +131,6 @@
 				playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 				deconstruct(src)
 
-		if(istype(attacking_item, /obj/item/borg/apparatus/circuit))
-			var/obj/item/borg/apparatus/circuit/robo_hand = attacking_item
-			if(robo_hand.stored == null)
-				return attack_hand(user)
-
 		update_appearance()
 		return
 

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -42,11 +42,6 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/cell_charger/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(attacking_item, /obj/item/borg/apparatus/circuit) && !panel_open)
-		var/obj/item/borg/apparatus/circuit/robo_hand = attacking_item
-		if(robo_hand.stored == null)
-			return attack_hand(user)
-
 	if(istype(attacking_item, /obj/item/stock_parts/power_store) && !panel_open)
 		if(machine_stat & BROKEN)
 			to_chat(user, span_warning("[src] is broken!"))

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -223,10 +223,6 @@
 		SStgui.update_uis(src)
 		return TRUE
 
-	if(istype(attacking_item, /obj/item/borg/apparatus/circuit) && panel_open)
-		var/obj/item/borg/apparatus/circuit/robo_hand = attacking_item
-		if(robo_hand.stored == null)
-			return attack_hand(user)
 	return ..()
 
 /obj/machinery/space_heater/attack_hand_secondary(mob/user, list/modifiers)

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -6,46 +6,36 @@
 	/// The item stored inside of this apparatus
 	var/obj/item/stored
 	/// Whitelist of types (and its subtypes) that are allowed in this apparatus.
-	var/list/storable = list()
+	var/list/whitelist_storables = list()
 	/// Blacklist of types (and its subtypes) that are not allowed in this apparatus.
 	var/list/blacklisted_storables = list()
+	/// Can this interact with various electronics?
+	var/allow_electronics_interaction = FALSE
 
 /obj/item/borg/apparatus/Initialize(mapload)
-	RegisterSignal(loc.loc, COMSIG_BORG_SAFE_DECONSTRUCT, PROC_REF(safedecon))
-	return ..()
+	. = ..()
+	if(!iscyborg(loc))
+		return INITIALIZE_HINT_QDEL
+	RegisterSignal(loc, COMSIG_BORG_SAFE_DECONSTRUCT, PROC_REF(safe_deconstruct))
 
 /obj/item/borg/apparatus/Destroy()
-	QDEL_NULL(stored)
+	if(!isnull(stored))
+		QDEL_NULL(stored)
 	return ..()
 
-///If we're safely deconstructed, we put the item neatly onto the ground, rather than deleting it.
-/obj/item/borg/apparatus/proc/safedecon()
-	SIGNAL_HANDLER
-
-	if(stored)
-		stored.forceMove(get_turf(src))
-		stored = null
-
 /obj/item/borg/apparatus/Exited(atom/movable/gone, direction)
-	if(gone == stored) //sanity check
+	if(gone == stored) // Sanity check.
 		UnregisterSignal(stored, COMSIG_ATOM_UPDATED_ICON)
 		stored = null
 	update_appearance()
 	return ..()
 
-///A right-click verb, for those not using hotkey mode.
-/obj/item/borg/apparatus/verb/verb_dropHeld()
-	set category = "Object"
-	set name = "Drop"
+/obj/item/borg/apparatus/examine(mob/user)
+	. = ..()
+	if(stored)
+		. += span_notice("[EXAMINE_HINT("Alt-click")] to drop your stored item.")
 
-	if(usr != loc || !stored)
-		return
-	stored.forceMove(get_turf(usr))
-	return
-
-/**
-* Attack_self will pass for the stored item.
-*/
+// Attack_self will pass for the stored item.
 /obj/item/borg/apparatus/attack_self(mob/living/silicon/robot/user)
 	if(!stored || !issilicon(user))
 		return ..()
@@ -56,7 +46,7 @@
 		return ..()
 	stored.attack_self_secondary(user)
 
-//Alt click drops the stored item.
+// Alt-click drops the stored item.
 /obj/item/borg/apparatus/click_alt(mob/living/silicon/robot/user)
 	if(!stored || !issilicon(user))
 		return CLICK_ACTION_BLOCKING
@@ -66,14 +56,90 @@
 /obj/item/borg/apparatus/get_proxy_attacker_for(atom/target, mob/user)
 	if(stored)
 		return stored
-	else
-		return ..()
+	return ..()
+
+/obj/item/borg/apparatus/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!allow_electronics_interaction)
+		return NONE
+	// Mimicking a hand interaction with certain atoms to pull out batteries.
+	// Closed machines:
+	if(istype(interacting_with, /obj/machinery/cell_charger))
+		var/obj/machinery/cell_charger/charger_machinery = interacting_with
+		if(stored != null || charger_machinery.panel_open)
+			return ITEM_INTERACT_BLOCKING
+		charger_machinery.attack_hand(user)
+		return ITEM_INTERACT_SUCCESS
+	if(istype(interacting_with, /obj/machinery/cell_charger_multi))
+		var/obj/machinery/cell_charger_multi/charger_multi_machinery = interacting_with
+		if(stored != null || charger_multi_machinery.panel_open)
+			return ITEM_INTERACT_BLOCKING
+		charger_multi_machinery.attack_hand(user)
+		return ITEM_INTERACT_SUCCESS
+	// Opened machines:
+	if(istype(interacting_with, /obj/machinery/button))
+		var/obj/machinery/button/button_machinery = interacting_with
+		if(stored != null || !button_machinery.panel_open)
+			return ITEM_INTERACT_BLOCKING
+		button_machinery.attack_hand(user)
+		return ITEM_INTERACT_SUCCESS
+	if(istype(interacting_with, /obj/machinery/space_heater))
+		var/obj/machinery/space_heater/heater_machinery = interacting_with
+		if(stored != null || !heater_machinery.panel_open)
+			return ITEM_INTERACT_BLOCKING
+		heater_machinery.attack_hand(user)
+		return ITEM_INTERACT_SUCCESS
+	if(isapc(interacting_with))
+		var/obj/machinery/power/apc/apc_machinery = interacting_with
+		if(stored != null || !apc_machinery.opened || !apc_machinery.cell)
+			return ITEM_INTERACT_BLOCKING
+		var/obj/item/stock_parts/power_store/cell/removed_cell = apc_machinery.cell
+		user.visible_message(span_notice("[user] removes [removed_cell] from [src]!"))
+		balloon_alert(user, "cell removed")
+		removed_cell.update_appearance()
+		user.put_in_hands(removed_cell)
+		apc_machinery.cell = null
+		apc_machinery.charging = APC_NOT_CHARGING
+		apc_machinery.update_appearance()
+		return ITEM_INTERACT_SUCCESS
+	// Cyborgs:
+	if(iscyborg(interacting_with) && interacting_with != user)
+		var/mob/living/silicon/robot/touched_cyborg = interacting_with
+		if(stored != null || !touched_cyborg.cell || !touched_cyborg.opened || touched_cyborg.wiresexposed)
+			return ITEM_INTERACT_BLOCKING
+		var/obj/item/stock_parts/power_store/cell/removed_cell = touched_cyborg.cell
+		to_chat(user, span_notice("You remove \the [removed_cell]."))
+		removed_cell.update_appearance()
+		removed_cell.add_fingerprint(user)
+		user.put_in_hands(removed_cell)
+		touched_cyborg.update_icons()
+		touched_cyborg.diag_hud_set_borgcell()
+		return ITEM_INTERACT_SUCCESS
+	return NONE
+
+/obj/item/borg/apparatus/pre_attack(atom/target, mob/living/user, list/modifiers, list/attack_modifiers)
+	if(put_in_apparatus(target, user))
+		return TRUE
+	return ..()
+
+// Eject containers from machines and inserts it into the apparatus.
+/obj/item/borg/apparatus/pre_attack_secondary(atom/target, mob/living/user, list/modifiers, list/attack_modifiers)
+	for(var/atom/atom_content in target.contents)
+		if(!is_acceptable_storable(atom_content))
+			continue
+		return target.attack_hand_secondary(user, modifiers)
+	return ..()
+
+/obj/item/borg/apparatus/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	if(stored)
+		attacking_item.melee_attack_chain(user, stored, modifiers, attack_modifiers)
+		return TRUE
+	return ..()
 
 /// Checks if the item is allowed to be inside of the apparatus.
-/obj/item/borg/apparatus/proc/itemcheck(atom/atom)
-	if(is_type_in_list(atom, blacklisted_storables))
+/obj/item/borg/apparatus/proc/is_acceptable_storable(atom/target)
+	if(is_type_in_list(target, blacklisted_storables))
 		return FALSE
-	return is_type_in_list(atom, storable)
+	return is_type_in_list(target, whitelist_storables)
 
 /// Attempts to put the item into the apparatus.
 /obj/item/borg/apparatus/proc/put_in_apparatus(obj/item/storing_item, mob/user)
@@ -82,29 +148,26 @@
 	if(!istype(storing_item))
 		return FALSE
 	if(HAS_TRAIT(storing_item, TRAIT_NODROP))
-		return
-	if(storing_item == user)
-		if(istype(storing_item.loc, /mob/living/silicon/robot))
-			return FALSE
-		else if(istype(storing_item.loc, /obj/item/robot_model))
-			return FALSE
-	if(!itemcheck(storing_item))
 		return FALSE
-	var/obj/item/item = storing_item
-	item.forceMove(src)
-	stored = item
+	if(istype(storing_item.loc, /obj/item/robot_model)) // Taking stuff from our inventory.
+		return FALSE
+	if(iscyborg(storing_item.loc) && user == storing_item.loc) // Taking stuff from our active module slots.
+		return FALSE
+	if(!is_acceptable_storable(storing_item))
+		return FALSE
+	storing_item.forceMove(src)
+	stored = storing_item
 	RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
 	update_appearance()
 	return TRUE
 
-/obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
-	if(LAZYACCESS(params, RIGHT_CLICK))
-		for(var/atom/atom_content in atom.contents)
-			if(itemcheck(atom_content))
-				return atom.attack_hand_secondary(user, params)
-	if(put_in_apparatus(atom, user))
+/// If we're safely deconstructed, we put the item neatly onto the ground, rather than deleting it.
+/obj/item/borg/apparatus/proc/safe_deconstruct()
+	SIGNAL_HANDLER
+	if(!stored)
 		return
-	return ..()
+	stored.forceMove(get_turf(src))
+	stored = null
 
 /**
  * Updates the appearance of the apparatus when the stored object's icon gets updated.
@@ -117,20 +180,25 @@
 	update_appearance()
 	return NONE
 
-/obj/item/borg/apparatus/attackby(obj/item/item, mob/user, params)
-	if(stored)
-		item.melee_attack_chain(user, stored, params)
+/// A right-click verb, for those not using hotkey mode.
+/obj/item/borg/apparatus/verb/verb_drop_stored_item()
+	set category = "Object"
+	set name = "Drop"
+
+	if(usr != loc || !stored)
 		return
-	return ..()
+	stored.forceMove(get_turf(usr))
 
 /obj/item/borg/apparatus/beaker
 	name = "beaker storage apparatus"
 	desc = "A special apparatus for carrying beakers without spilling the contents."
 	icon_state = "borg_beaker_apparatus"
-	storable = list(/obj/item/reagent_containers/cup/beaker,
-					/obj/item/reagent_containers/cup/tube,
-					/obj/item/weapon/virusdish,
-					/obj/item/reagent_containers/cup/bottle,)
+	whitelist_storables = list(
+		/obj/item/reagent_containers/cup/beaker,
+		/obj/item/reagent_containers/cup/bottle,
+		/obj/item/reagent_containers/cup/tube,
+		/obj/item/weapon/virusdish
+	)
 
 /obj/item/borg/apparatus/beaker/Initialize(mapload)
 	add_glass()
@@ -146,13 +214,6 @@
 		var/obj/item/reagent_containers/reagent_container = stored
 		reagent_container.SplashReagents(get_turf(src))
 	QDEL_NULL(stored)
-	return ..()
-
-/obj/item/borg/apparatus/beaker/examine(mob/user)
-	if(stored)
-		to_chat(user, span_nicegreen(" <i>Alt-click</i> will drop the currently stored beaker."))
-		to_chat(user, span_nicegreen(" <i>Right-clicking</i> will splash the beaker on the ground."))
-		return stored.examine(user)
 	return ..()
 
 /obj/item/borg/apparatus/beaker/update_overlays()
@@ -188,11 +249,13 @@
 	name = "beverage storage apparatus"
 	desc = "A special apparatus for carrying drinks without spilling the contents. Will resynthesize any drinks you pour out!"
 	icon_state = "borg_beaker_apparatus"
-	storable = list(/obj/item/reagent_containers/cup/beaker,
-					/obj/item/reagent_containers/cup/bottle,
-					/obj/item/reagent_containers/cup/glass,
-					/obj/item/reagent_containers/condiment,
-					/obj/item/reagent_containers/cup/coffeepot)
+	whitelist_storables = list(
+		/obj/item/reagent_containers/cup/beaker,
+		/obj/item/reagent_containers/cup/bottle,
+		/obj/item/reagent_containers/cup/glass,
+		/obj/item/reagent_containers/condiment,
+		/obj/item/reagent_containers/cup/coffeepot
+	)
 
 /obj/item/borg/apparatus/beaker/service/add_glass()
 	stored = new /obj/item/reagent_containers/cup/glass/drinkingglass(src)
@@ -220,14 +283,10 @@
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "evidenceobj"
 	item_flags = SURGICAL_TOOL
-	storable = list(/obj/item/organ,
-					/obj/item/bodypart)
-
-/obj/item/borg/apparatus/organ_storage/examine(mob/user)
-	if(stored)
-		to_chat(user, span_nicegreen(" <i>Alt-click</i> will drop the currently stored organ."))
-		return stored.examine(user)
-	return ..()
+	whitelist_storables = list(
+		/obj/item/organ,
+		/obj/item/bodypart
+	)
 
 /obj/item/borg/apparatus/organ_storage/update_overlays()
 	. = ..()
@@ -259,22 +318,25 @@
 /obj/item/borg/apparatus/organ_storage/monster
 	name = "core storage bag"
 	desc = "A container for holding and application of various monster organs."
-	storable = list(/obj/item/organ/internal/monster_core)
+	whitelist_storables = list(/obj/item/organ/internal/monster_core)
 
 /obj/item/borg/apparatus/organ_storage/limb
 	name = "limb storage bag"
 	desc = "A container for holding limbs."
-	storable = list(/obj/item/bodypart)
+	whitelist_storables = list(/obj/item/bodypart)
 
 ///Apparatus to allow Engineering/Sabo borgs to manipulate any material sheets.
 /obj/item/borg/apparatus/sheet_manipulator
 	name = "material manipulation apparatus"
 	desc = "An apparatus for carrying, deploying, and manipulating sheets of material. The device can also carry custom floor tiles."
 	icon_state = "borg_stack_apparatus"
-	storable = list(/obj/item/stack/sheet,
-					/obj/item/stack/rods,
-					/obj/item/stack/ore/bluespace_crystal,
-					/obj/item/stack/tile)
+	whitelist_storables = list(
+		/obj/item/stack/sheet,
+		/obj/item/stack/rods,
+		/obj/item/stack/ore/bluespace_crystal,
+		/obj/item/stack/tile,
+		/obj/item/flatpacked_machine
+	)
 
 /obj/item/borg/apparatus/sheet_manipulator/Initialize(mapload)
 	update_appearance()
@@ -296,12 +358,6 @@
 		. += stored_copy
 	. += arm
 
-/obj/item/borg/apparatus/sheet_manipulator/examine(mob/user)
-	if(stored)
-		to_chat(user, span_nicegreen(" <i>Alt-click</i> will drop the currently stored sheets."))
-		return stored.examine(user)
-	return ..()
-
 /obj/item/borg/apparatus/sheet_manipulator/extra
 	name = "secondary material manipulation apparatus"
 	desc = "A supplementary apparatus for carrying, deploying, and manipulating sheets of material. The device can also carry custom floor tiles."
@@ -311,10 +367,14 @@
 	name = "electronics manipulation apparatus"
 	desc = "A special apparatus for carrying and manipulating electronics like circuit boards, cells, stock parts, signalers and etc."
 	icon_state = "borg_hardware_apparatus"
-	storable = list(/obj/item/circuitboard,
-				/obj/item/electronics,
-				/obj/item/stock_parts,
-				/obj/item/assembly)
+	whitelist_storables = list(
+		/obj/item/circuitboard,
+		/obj/item/electronics,
+		/obj/item/stock_parts,
+		/obj/item/assembly,
+		/obj/item/flatpacked_machine
+	)
+	allow_electronics_interaction = TRUE
 
 /obj/item/borg/apparatus/circuit/Initialize(mapload)
 	update_appearance()
@@ -334,12 +394,6 @@
 		. += stored_copy
 	. += arm
 
-/obj/item/borg/apparatus/circuit/examine(mob/user)
-	if(stored)
-		to_chat(user, span_nicegreen(" <i>Alt-click</i> will drop the currently stored circuit."))
-		return stored.examine(user)
-	return ..()
-
 /obj/item/borg/apparatus/circuit/pre_attack(atom/atom, mob/living/user, params)
 	if(istype(atom, /obj/item/ai_module) && !stored) //If an admin wants a borg to upload laws, who am I to stop them? Otherwise, we can hint that it fails
 		to_chat(user, span_warning("This circuit board doesn't seem to have standard robot apparatus pin holes. You're unable to pick it up."))
@@ -348,7 +402,7 @@
 /obj/item/borg/apparatus/circuit/science
 	name = "science manipulation apparatus"
 	desc = "A special apparatus for carrying various stock parts, disks, assemblies, and even artifacts!"
-	storable = list(
+	whitelist_storables = list(
 		/obj/item/stock_parts,
 		/obj/item/assembly,
 		/obj/item/disk,
@@ -369,7 +423,7 @@
 	name = "service storage apparatus"
 	desc = "A special apparatus for carrying food, bowls, plates, oven trays, soup pots and paper."
 	icon_state = "borg_service_apparatus"
-	storable = list(
+	whitelist_storables = list(
 		/obj/item/food,
 		/obj/item/paper,
 		/obj/item/plate,
@@ -378,18 +432,12 @@
 		/obj/item/seeds,
 		/obj/item/stack/biocube,
 		/obj/item/folder,
-		/obj/item/clipboard,
+		/obj/item/clipboard
 	)
 
 /obj/item/borg/apparatus/cooking/Initialize(mapload)
 	RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
 	update_appearance()
-	return ..()
-
-/obj/item/borg/apparatus/cooking/examine(mob/user)
-	if(stored)
-		to_chat(user, span_nicegreen(" <i>Alt-click</i> will drop the currently stored item."))
-		return stored.examine(user)
 	return ..()
 
 /obj/item/borg/apparatus/cooking/update_overlays()

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -14,9 +14,8 @@
 
 /obj/item/borg/apparatus/Initialize(mapload)
 	. = ..()
-	if(!iscyborg(loc))
-		return INITIALIZE_HINT_QDEL
-	RegisterSignal(loc, COMSIG_BORG_SAFE_DECONSTRUCT, PROC_REF(safe_deconstruct))
+	if(iscyborg(loc))
+		RegisterSignal(loc, COMSIG_BORG_SAFE_DECONSTRUCT, PROC_REF(safe_deconstruct))
 
 /obj/item/borg/apparatus/Destroy()
 	if(!isnull(stored))

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -978,7 +978,7 @@
 	if(!length(storables_to_add))
 		to_chat(user, span_warning("This upgrade doesn't seem to do anything!"))
 		return FALSE
-	apparatus.storable |= storables_to_add
+	apparatus.whitelist_storables |= storables_to_add
 
 /obj/item/borg/upgrade/science_apparatus_improvement/deactivate(mob/living/silicon/robot/borg, user = usr)
 	. = ..()
@@ -989,7 +989,7 @@
 		return FALSE
 	if(!length(storables_to_add))
 		return FALSE
-	apparatus.storable -= storables_to_add
+	apparatus.whitelist_storables -= storables_to_add
 
 /obj/item/borg/upgrade/science_apparatus_improvement/robotics
 	name = "science robotics upgrade"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -216,11 +216,12 @@
 	if(QDELETED(I))
 		return FALSE
 
-	// try to put it in a borg apparatus
-	if(istype(src, /mob/living/silicon/robot))
-		for(var/obj/item/borg/apparatus/apparatus in src)
-			if(apparatus.put_in_apparatus(I, src))
-				return TRUE
+	// Cyborg's apparatus is their hand.
+	if(iscyborg(src))
+		var/mob/living/silicon/robot/cyborg_owner = src
+		var/obj/item/borg/apparatus/cyborg_apparatus = cyborg_owner.get_active_held_item()
+		if(istype(cyborg_apparatus) && cyborg_apparatus.put_in_apparatus(I, cyborg_owner))
+			return TRUE
 
 	// If the item is a stack and we're already holding a stack then merge
 	if (isstack(I))

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -149,17 +149,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		add_to_upgrades(U, user)
 		return
 
-	if(istype(attacking_item, /obj/item/borg/apparatus/circuit) && user != src && cell && opened && !wiresexposed)
-		var/obj/item/borg/apparatus/circuit/robo_hand = attacking_item
-		if(robo_hand.stored == null)
-			to_chat(user, span_notice("You remove [cell]."))
-			cell.update_appearance()
-			cell.add_fingerprint(user)
-			user.put_in_hands(cell)
-			update_icons()
-			diag_hud_set_borgcell()
-			return
-
 	if(istype(attacking_item, /obj/item/toner))
 		if(toner >= tonermax)
 			to_chat(user, span_warning("The toner level of [src] is at its highest level possible!"))

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -19,19 +19,6 @@
 				cell.use(cell.charge)
 			return
 
-	if(istype(attacking_object, /obj/item/borg/apparatus/circuit) && opened)
-		var/obj/item/borg/apparatus/circuit/robo_hand = attacking_object
-		if(robo_hand.stored == null)
-			if(cell)
-				user.visible_message(span_notice("[user] removes [cell] from [src]!"))
-				balloon_alert(user, "cell removed")
-				cell.update_appearance()
-				user.put_in_hands(cell)
-				cell = null
-				charging = APC_NOT_CHARGING
-				update_appearance()
-				return
-
 	if(issilicon(user) && get_dist(src,user) > 1)
 		return attack_hand(user)
 

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -260,9 +260,10 @@
 		if(cell)
 			user.visible_message(span_notice("[user] removes \the [cell] from [src]!"))
 			balloon_alert(user, "cell removed")
-			user.put_in_hands(cell)
-			cell.update_appearance()
-			cell = null
+			var/obj/item/stock_parts/power_store/removed_cell = cell
+			user.put_in_hands(removed_cell) // Taking out the cell makes cell null. Thus the variable above.
+			removed_cell.update_appearance()
+			removed_cell = null
 			charging = APC_NOT_CHARGING
 			update_appearance()
 		return

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -261,9 +261,8 @@
 			user.visible_message(span_notice("[user] removes \the [cell] from [src]!"))
 			balloon_alert(user, "cell removed")
 			var/obj/item/stock_parts/power_store/removed_cell = cell
-			user.put_in_hands(removed_cell) // Taking out the cell makes cell null. Thus the variable above.
+			user.put_in_hands(removed_cell) // Makes cell null. Thus the variable above.
 			removed_cell.update_appearance()
-			removed_cell = null
 			charging = APC_NOT_CHARGING
 			update_appearance()
 		return

--- a/monkestation/code/modules/blueshift/appliances/multi_charger.dm
+++ b/monkestation/code/modules/blueshift/appliances/multi_charger.dm
@@ -54,11 +54,6 @@
 	. += span_notice("Right click it to remove all the cells at once!")
 
 /obj/machinery/cell_charger_multi/attackby(obj/item/tool, mob/user, params)
-	if(istype(tool, /obj/item/borg/apparatus/circuit) && !panel_open)
-		var/obj/item/borg/apparatus/circuit/robo_hand = tool
-		if(robo_hand.stored == null)
-			return attack_hand(user)
-
 	if(istype(tool, /obj/item/stock_parts/power_store/cell) && !panel_open)
 		if(machine_stat & BROKEN)
 			to_chat(user, span_warning("[src] is broken!"))

--- a/monkestation/code/modules/blueshift/structures/flatpacker.dm
+++ b/monkestation/code/modules/blueshift/structures/flatpacker.dm
@@ -106,15 +106,6 @@
 /obj/item/flatpacked_machine/proc/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
 
-/obj/item/borg/apparatus/sheet_manipulator/Initialize(mapload)
-	. = ..()
-	storable += /obj/item/flatpacked_machine
-
-/obj/item/borg/apparatus/circuit/Initialize(mapload)
-	. = ..()
-	storable += /obj/item/flatpacked_machine
-
-
 /obj/item/flatpacked_machine/generic
 	name = "generic flat-packed machine"
 	skips_deployable_component = TRUE


### PR DESCRIPTION

## About The Pull Request
All machine/cyborg interactions via the electronics manipulation apparatus and its subtypes are now dealt with inside of `interact_with_atom` instead of by each machine/cyborg's `attackby`.

Fixes cyborg apparatus grabbing a cyborg's module while it was in their inventory or was an active module.
Closes https://github.com/Monkestation/Monkestation2.0/issues/2880
Closes https://github.com/Monkestation/Monkestation2.0/issues/6881
Closes https://github.com/Monkestation/Monkestation2.0/issues/11919

The examination hint that they can drop their stored item via alt-click has been added to all cyborg apparatus, changed from a select few.

The storable flatpacked machine for cyborg apparatus is now in the initial list rather than added through initialization.

Renamed some variables / procs regarding the cyborg apparatus to be more accurate about what they do.
Shuffled around some cyborg apparatus' procs to be in a specific order.

Adds some documentation explaining some code that was confusing to me that other people added because it isn't obvious what it does.

Fixes a runtime where it tries to update the appearance of a null cell when you remove it from an APC.

## Why It's Good For The Game
Bugfixes and improvements to code.

## Testing
Can still remove cells from APCs & Cyborgs.
<img width="321" height="236" alt="wawawaa" src="https://github.com/user-attachments/assets/41ef7c17-2fa3-440e-bdc4-d2246316cb59" />

Unable to pick up metal/glass from active module / inventory.
<img width="263" height="186" alt="waaa2" src="https://github.com/user-attachments/assets/c55d4571-77ba-4d7d-aeae-2aaa1ab464e6" />
## Changelog
:cl:
qol: Examining any cyborg apparatus will tell you that you can drop the stored item via alt-click.
fix: Cyborg apparatus can no longer take items that are inside of a cyborg's inventory.
fix: Removing an APC's powercell with your hand no longer causes a runtime.
code: The electronics manipulation apparatus now handles its interactions with machinery/cyborgs within interact_with_atom.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
