### PR TITLE
Hugs heals stamina damage & can take people out of stamina crit

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -517,13 +517,18 @@
 
 ///////////////////////// CLEAR STATUS /////////////////////////
 
+/// Reduces a multitude of status effects, heals some stamina damage, and can remove stamina stun.
 /mob/living/proc/adjust_status_effects_on_shake_up()
-	AdjustStun(-60)
-	AdjustKnockdown(-60)
-	AdjustUnconscious(-60)
-	AdjustSleeping(-100)
-	AdjustParalyzed(-60)
-	AdjustImmobilized(-60)
+	AdjustStun(-6 SECONDS)
+	AdjustKnockdown(-6 SECONDS)
+	AdjustUnconscious(-6 SECONDS)
+	AdjustSleeping(-10 SECONDS)
+	AdjustParalyzed(-6 SECONDS)
+	AdjustImmobilized(-6 SECONDS)
+	if(HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA))
+		stamina.adjust(5)
+		if(stamina.current > 15)
+			exit_stamina_stun()
 
 ///////////////////////////////// FROZEN /////////////////////////////////////
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -526,8 +526,8 @@
 	AdjustParalyzed(-6 SECONDS)
 	AdjustImmobilized(-6 SECONDS)
 	if(HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA))
-		stamina.adjust(5)
-		if(stamina.current >= 15)
+		stamina.adjust(6)
+		if(stamina.current > 15)
 			exit_stamina_stun()
 
 ///////////////////////////////// FROZEN /////////////////////////////////////

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -527,7 +527,7 @@
 	AdjustImmobilized(-6 SECONDS)
 	if(HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA))
 		stamina.adjust(5)
-		if(stamina.current > 15)
+		if(stamina.current >= 15)
 			exit_stamina_stun()
 
 ///////////////////////////////// FROZEN /////////////////////////////////////


### PR DESCRIPTION

## About The Pull Request
Idea from https://github.com/ParadiseSS13/Paradise/pull/18360

Hugging people who are in stamina critical will heal 6 stamina damage and get them out of stamina critical if they have more than 15 stamina (aka 2.5 hugs).

## Why It's Good For The Game
Stamina stuns are basically hard stuns. Many mechanics and items that remove hard stuns also restore stamina, but hugs haven't updated for stamina. So, hugs now heal stamina damage. Teamwork is good.

## Testing
Hugged a stamina critical person 4 times. They got out of critical.

## Changelog
:cl:
balance: Hugging people who are in stamina critical will heal 6 stamina.
balance: Hugging people who are in stamina critical will take them out of it if they have more than 15 stamina (2.5 hugs worth).
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
