### PR TITLE
AI Toggle Download verb is now a project

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized/projects/firewall.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/firewall.dm
@@ -15,3 +15,22 @@
 /datum/ai_project/firewall/stop()
 	ai.downloadSpeedModifier *= 2
 	..()
+
+/datum/ai_project/blockade
+	name = "Download Blockade"
+	description = "By converting old tools from online archives to fit your systems, you should be able to halt any attempts to download your consciousness."
+	research_cost = 3000
+	ram_required = 6
+	research_requirements = list(/datum/ai_project/firewall)
+	category = AI_PROJECT_MISC
+
+/datum/ai_project/blockade/run_project(force_run = FALSE)
+	. = ..(force_run)
+	if(!.)
+		return .
+	ai.can_download = FALSE
+
+/datum/ai_project/blockade/stop()
+	ai.can_download = TRUE
+	..()
+

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/firewall.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/firewall.dm
@@ -20,7 +20,7 @@
 	name = "Download Blockade"
 	description = "By converting old tools from online archives to fit your systems, you should be able to halt any attempts to download your consciousness."
 	research_cost = 3000
-	ram_required = 6
+	ram_required = 3
 	research_requirements = list(/datum/ai_project/firewall)
 	category = AI_PROJECT_MISC
 

--- a/code/modules/mob/living/silicon/ai/decentralized_ai.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized_ai.dm
@@ -11,17 +11,6 @@
 		return FALSE
 	return new_data_core
 
-/mob/living/silicon/ai/verb/toggle_download()
-	set category = "AI Commands"
-	set name = "Toggle Download"
-	set desc = "Allow or disallow carbon lifeforms to download you from an AI control console."
-
-	if(incapacitated())
-		return //won't work if dead
-	var/mob/living/silicon/ai/A = usr
-	A.can_download = !A.can_download
-	to_chat(A, span_warning("You [A.can_download ? "enable" : "disable"] read/write permission to your memorybanks! You [A.can_download ? "CAN" : "CANNOT"] be downloaded!"))
-
 /mob/living/silicon/ai/proc/relocate(silent = FALSE, kill_otherwise = TRUE)
 	if(is_dying)
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
There is a project to slow down downloads by 50%, however, this is Utterly Pointless. as you can just go to AI Commands and press Toggle Download and have the job done even better as it stops download entirely!

Removes the verb and puts its function into a AI project as Download Blockade for 3000 points, behind Download Firewall as a requirement.
## Why It's Good For The Game
There is literally no use to the Download Firewall program when it is surpassed by a stock function. This should hopefully add reasons to develop it, and extra reason to get upgraded servers.
## Testing
turned on download blockade during a download and it stopped the download.
## Changelog
:cl:
balance: AIs must research Download Blockade (3000 points, Download Firewall prerequisite) to disable downloading, instead of having a button to do it immediately.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
