### PR TITLE
Bunch of fixes and improvements to deathmatches

### DIFF
--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -16,9 +16,25 @@
 		CRASH("A deathmatch controller already exists.")
 	GLOB.deathmatch_game = src
 
+	var/max_players = /datum/lazy_template/deathmatch::min_players // MONKESTATION EDIT ADDITION
 	for (var/datum/lazy_template/deathmatch/template as anything in subtypesof(/datum/lazy_template/deathmatch))
+		/* MONKESTATION EDIT OLD START
 		var/map_name = initial(template.name)
 		maps[map_name] = new template
+		MONKESTATION EDIT OLD END */
+	// MONKESTATION EDIT NEW START
+		template = new template()
+		maps[template.name] = template
+		if(length(template.allowed_loadouts) > 1)
+			template.allowed_loadouts.Insert(1, /datum/outfit/deathmatch_loadout/naked/random)
+		if(max_players < template.max_players)
+			max_players = template.max_players
+	var/datum/lazy_template/deathmatch/random_template = maps[/datum/lazy_template/deathmatch/random::name]
+	if(random_template)
+		random_template.max_players = max_players
+	else
+		message_admins("Random deathmatch template not found in deathmatch templates, report dis to coders")
+	// MONKESTATION EDIT NEW END
 	loadouts = subtypesof(/datum/outfit/deathmatch_loadout)
 	modifiers = sortTim(init_subtypes_w_path_keys(/datum/deathmatch_modifier), GLOBAL_PROC_REF(cmp_deathmatch_mods), associative = TRUE)
 

--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -26,7 +26,7 @@
 		template = new template()
 		maps[template.name] = template
 		if(length(template.allowed_loadouts) > 1)
-			template.allowed_loadouts.Insert(1, /datum/outfit/deathmatch_loadout/naked/random)
+			template.allowed_loadouts.Insert(1, /datum/outfit/deathmatch_loadout/random)
 		if(max_players < template.max_players)
 			max_players = template.max_players
 	var/datum/lazy_template/deathmatch/random_template = maps[/datum/lazy_template/deathmatch/random::name]

--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -16,25 +16,21 @@
 		CRASH("A deathmatch controller already exists.")
 	GLOB.deathmatch_game = src
 
-	var/max_players = /datum/lazy_template/deathmatch::min_players // MONKESTATION EDIT ADDITION
+	var/max_players = /datum/lazy_template/deathmatch::min_players
 	for (var/datum/lazy_template/deathmatch/template as anything in subtypesof(/datum/lazy_template/deathmatch))
-		/* MONKESTATION EDIT OLD START
-		var/map_name = initial(template.name)
-		maps[map_name] = new template
-		MONKESTATION EDIT OLD END */
-	// MONKESTATION EDIT NEW START
 		template = new template()
 		maps[template.name] = template
 		if(length(template.allowed_loadouts) > 1)
 			template.allowed_loadouts.Insert(1, /datum/outfit/deathmatch_loadout/random)
 		if(max_players < template.max_players)
 			max_players = template.max_players
+
 	var/datum/lazy_template/deathmatch/random_template = maps[/datum/lazy_template/deathmatch/random::name]
 	if(random_template)
 		random_template.max_players = max_players
 	else
 		message_admins("Random deathmatch template not found in deathmatch templates, report dis to coders")
-	// MONKESTATION EDIT NEW END
+
 	loadouts = subtypesof(/datum/outfit/deathmatch_loadout)
 	modifiers = sortTim(init_subtypes_w_path_keys(/datum/deathmatch_modifier), GLOBAL_PROC_REF(cmp_deathmatch_mods), associative = TRUE)
 

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -29,6 +29,12 @@
 	desc = "Naked man craves for bloodshed."
 	shoes = null
 
+// MONKESTATION EDIT ADDITION START
+/datum/outfit/deathmatch_loadout/naked/random
+	name = "Deathmatch: Random"
+	display_name = "Random"
+	desc = "A randomly selected loadout, how daring."
+// MONKESTATION EDIT ADDITION END
 /datum/outfit/deathmatch_loadout/assistant
 	name = "Deathmatch: Assistant loadout"
 	display_name = "Assistant"

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -23,18 +23,19 @@
 		var/datum/action/new_ability = new act(user)
 		new_ability.Grant(user)
 
+// MONKESTATION EDIT ADDITION START
+/datum/outfit/deathmatch_loadout/random
+	name = "Deathmatch: Random"
+	display_name = "Random"
+	desc = "A randomly selected loadout, how daring."
+// MONKESTATION EDIT ADDITION END
+
 /datum/outfit/deathmatch_loadout/naked
 	name = "Deathmatch: Naked"
 	display_name = "Unarmed, Butt-naked"
 	desc = "Naked man craves for bloodshed."
 	shoes = null
 
-// MONKESTATION EDIT ADDITION START
-/datum/outfit/deathmatch_loadout/naked/random
-	name = "Deathmatch: Random"
-	display_name = "Random"
-	desc = "A randomly selected loadout, how daring."
-// MONKESTATION EDIT ADDITION END
 /datum/outfit/deathmatch_loadout/assistant
 	name = "Deathmatch: Assistant loadout"
 	display_name = "Assistant"

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -23,12 +23,11 @@
 		var/datum/action/new_ability = new act(user)
 		new_ability.Grant(user)
 
-// MONKESTATION EDIT ADDITION START
 /datum/outfit/deathmatch_loadout/random
 	name = "Deathmatch: Random"
 	display_name = "Random"
 	desc = "A randomly selected loadout, how daring."
-// MONKESTATION EDIT ADDITION END
+
 /datum/outfit/deathmatch_loadout/naked
 	name = "Deathmatch: Naked"
 	display_name = "Unarmed, Butt-naked"

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -29,7 +29,6 @@
 	display_name = "Random"
 	desc = "A randomly selected loadout, how daring."
 // MONKESTATION EDIT ADDITION END
-
 /datum/outfit/deathmatch_loadout/naked
 	name = "Deathmatch: Naked"
 	display_name = "Unarmed, Butt-naked"

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -56,6 +56,18 @@
 /datum/deathmatch_lobby/proc/start_game()
 	if (playing)
 		return
+	// MONKESTATION EDIT ADDITION START
+	if(map.type == /datum/lazy_template/deathmatch/random)
+		var/list/available_maps = list()
+		for(var/key in GLOB.deathmatch_game.maps)
+			var/datum/lazy_template/deathmatch/map = GLOB.deathmatch_game.maps[key]
+			if(map.min_players <= length(players) && map.max_players >= length(players))
+				available_maps += map
+		if(length(available_maps))
+			change_map(pick(available_maps))
+		else
+			change_map(GLOB.deathmatch_game.maps[pick(GLOB.deathmatch_game.maps)])
+	// MONKESTATION EDIT ADDITION END
 	if(map.template_in_use)
 		to_chat(get_mob_by_ckey(host), span_warning("This map is currently loading for another lobby. Please wait until that other map finishes loading. It would be a disaster if these two mixed up."))
 		return
@@ -132,6 +144,13 @@
 	var/datum/outfit/deathmatch_loadout/loadout = players_info["loadout"]
 	if (!(loadout in loadouts))
 		loadout = loadouts[1]
+	// MONKESTATION EDIT NEW START
+	if(loadout == /datum/outfit/deathmatch_loadout/naked/random)
+		if(length(loadouts) > 1)
+			loadout = pick(loadouts - /datum/outfit/deathmatch_loadout/naked/random)
+		else
+			loadout = pick(GLOB.deathmatch_game.loadouts)
+	// MONKESTATION EDIT NEW END
 
 	var/mob/living/carbon/human/new_player = new(loc)
 	observer.client?.prefs.safe_transfer_prefs_to(new_player)
@@ -349,7 +368,8 @@
 	.["host"] = is_host
 	.["admin"] = is_admin
 	.["playing"] = playing
-	.["loadouts"] = list("Randomize")
+	// .["loadouts"] = list("Randomize") MONKESTATION EDIT OLD
+	.["loadouts"] = list() // MONKESTATION EDIT NEW -- Randomize got moved into an actual loadout
 	for (var/datum/outfit/deathmatch_loadout/loadout as anything in loadouts)
 		.["loadouts"] += initial(loadout.display_name)
 	.["map"] = list()
@@ -426,9 +446,11 @@
 				return FALSE
 			if (params["player"] != usr.ckey && host != usr.ckey)
 				return FALSE
+			/* MONKESTATION EDIT REMOVAL START -- Randomize got moved into an actual loadout
 			if (params["loadout"] == "Randomize")
 				players[params["player"]]["loadout"] = pick(loadouts)
 				return TRUE
+			MONKESTATION EDIT REMOVAL END */
 			for (var/datum/outfit/deathmatch_loadout/possible_loadout as anything in loadouts)
 				if (params["loadout"] != initial(possible_loadout.display_name))
 					continue

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -145,9 +145,9 @@
 	if (!(loadout in loadouts))
 		loadout = loadouts[1]
 	// MONKESTATION EDIT NEW START
-	if(loadout == /datum/outfit/deathmatch_loadout/naked/random)
+	if(loadout == /datum/outfit/deathmatch_loadout/random)
 		if(length(loadouts) > 1)
-			loadout = pick(loadouts - /datum/outfit/deathmatch_loadout/naked/random)
+			loadout = pick(loadouts - /datum/outfit/deathmatch_loadout/random)
 		else
 			loadout = pick(GLOB.deathmatch_game.loadouts)
 	// MONKESTATION EDIT NEW END

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -56,7 +56,7 @@
 /datum/deathmatch_lobby/proc/start_game()
 	if (playing)
 		return
-	// MONKESTATION EDIT ADDITION START
+
 	if(map.type == /datum/lazy_template/deathmatch/random)
 		var/list/available_maps = list()
 		for(var/key in GLOB.deathmatch_game.maps)
@@ -67,7 +67,7 @@
 			change_map(pick(available_maps))
 		else
 			change_map(pick(GLOB.deathmatch_game.maps))
-	// MONKESTATION EDIT ADDITION END
+
 	if(map.template_in_use)
 		to_chat(get_mob_by_ckey(host), span_warning("This map is currently loading for another lobby. Please wait until that other map finishes loading. It would be a disaster if these two mixed up."))
 		return
@@ -144,13 +144,12 @@
 	var/datum/outfit/deathmatch_loadout/loadout = players_info["loadout"]
 	if (!(loadout in loadouts))
 		loadout = loadouts[1]
-	// MONKESTATION EDIT NEW START
+
 	if(loadout == /datum/outfit/deathmatch_loadout/random)
 		if(length(loadouts) > 1)
 			loadout = pick(loadouts - /datum/outfit/deathmatch_loadout/random)
 		else
 			loadout = pick(GLOB.deathmatch_game.loadouts)
-	// MONKESTATION EDIT NEW END
 
 	var/mob/living/carbon/human/new_player = new(loc)
 	observer.client?.prefs.safe_transfer_prefs_to(new_player)
@@ -368,8 +367,7 @@
 	.["host"] = is_host
 	.["admin"] = is_admin
 	.["playing"] = playing
-	// .["loadouts"] = list("Randomize") MONKESTATION EDIT OLD
-	.["loadouts"] = list() // MONKESTATION EDIT NEW -- Randomize got moved into an actual loadout
+	.["loadouts"] = list()
 	for (var/datum/outfit/deathmatch_loadout/loadout as anything in loadouts)
 		.["loadouts"] += initial(loadout.display_name)
 	.["map"] = list()
@@ -446,11 +444,6 @@
 				return FALSE
 			if (params["player"] != usr.ckey && host != usr.ckey)
 				return FALSE
-			/* MONKESTATION EDIT REMOVAL START -- Randomize got moved into an actual loadout
-			if (params["loadout"] == "Randomize")
-				players[params["player"]]["loadout"] = pick(loadouts)
-				return TRUE
-			MONKESTATION EDIT REMOVAL END */
 			for (var/datum/outfit/deathmatch_loadout/possible_loadout as anything in loadouts)
 				if (params["loadout"] != initial(possible_loadout.display_name))
 					continue

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -62,11 +62,11 @@
 		for(var/key in GLOB.deathmatch_game.maps)
 			var/datum/lazy_template/deathmatch/map = GLOB.deathmatch_game.maps[key]
 			if(map.min_players <= length(players) && map.max_players >= length(players))
-				available_maps += map
+				available_maps += key
 		if(length(available_maps))
 			change_map(pick(available_maps))
 		else
-			change_map(GLOB.deathmatch_game.maps[pick(GLOB.deathmatch_game.maps)])
+			change_map(pick(GLOB.deathmatch_game.maps))
 	// MONKESTATION EDIT ADDITION END
 	if(map.template_in_use)
 		to_chat(get_mob_by_ckey(host), span_warning("This map is currently loading for another lobby. Please wait until that other map finishes loading. It would be a disaster if these two mixed up."))

--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -16,6 +16,14 @@
 	/// whether we are currently being loaded by a lobby
 	var/template_in_use = FALSE
 
+// MONKESTATION EDIT NEW START
+/datum/lazy_template/deathmatch/random // Not an actual template, but close enough
+	name = "Random"
+	desc = "Lets go gambling! (selects a random map, except for those that would force observers)"
+	allowed_loadouts = list(/datum/outfit/deathmatch_loadout/naked/random)
+	map_name = "ragecage"
+	key = "random"
+// MONKESTATION EDIT NEW END
 /datum/lazy_template/deathmatch/ragecage
 	name = "Ragecage"
 	desc = "Fun for the whole family, the classic ragecage."
@@ -39,7 +47,7 @@
 	max_players = 10
 	allowed_loadouts = list(/datum/outfit/deathmatch_loadout/assistant)
 	map_name = "OSHA_violator"
-	key = "OSHA_Violator"
+	key = "OSHA_violator"
 
 /datum/lazy_template/deathmatch/the_brig
 	name = "The Brig"

--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -20,7 +20,7 @@
 /datum/lazy_template/deathmatch/random // Not an actual template, but close enough
 	name = "Random"
 	desc = "Lets go gambling! (selects a random map, except for those that would force observers)"
-	allowed_loadouts = list(/datum/outfit/deathmatch_loadout/naked/random)
+	allowed_loadouts = list(/datum/outfit/deathmatch_loadout/random)
 	map_name = "ragecage"
 	key = "random"
 // MONKESTATION EDIT NEW END

--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -46,8 +46,10 @@
 	desc = "What would Engineering be without an overly complicated engine, with conveyor belts, emitters and shield generators sprinkled about? That's right, not Engineering."
 	max_players = 10
 	allowed_loadouts = list(/datum/outfit/deathmatch_loadout/assistant)
-	map_name = "OSHA_violator"
-	key = "OSHA_violator"
+	//map_name = "OSHA_Violator" MONKESTATION EDIT OLD
+	//key = "OSHA_Violator" MONKESTATION EDIT OLD
+	map_name = "OSHA_Violator" // MONKESTATION EDIT NEW
+	key = "OSHA_Violator" // MONKESTATION EDIT NEW
 
 /datum/lazy_template/deathmatch/the_brig
 	name = "The Brig"

--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -16,14 +16,13 @@
 	/// whether we are currently being loaded by a lobby
 	var/template_in_use = FALSE
 
-// MONKESTATION EDIT NEW START
 /datum/lazy_template/deathmatch/random // Not an actual template, but close enough
 	name = "Random"
 	desc = "Lets go gambling! (selects a random map, except for those that would force observers)"
 	allowed_loadouts = list(/datum/outfit/deathmatch_loadout/random)
 	map_name = "ragecage"
 	key = "random"
-// MONKESTATION EDIT NEW END
+
 /datum/lazy_template/deathmatch/ragecage
 	name = "Ragecage"
 	desc = "Fun for the whole family, the classic ragecage."
@@ -46,10 +45,8 @@
 	desc = "What would Engineering be without an overly complicated engine, with conveyor belts, emitters and shield generators sprinkled about? That's right, not Engineering."
 	max_players = 10
 	allowed_loadouts = list(/datum/outfit/deathmatch_loadout/assistant)
-	//map_name = "OSHA_Violator" MONKESTATION EDIT OLD
-	//key = "OSHA_Violator" MONKESTATION EDIT OLD
-	map_name = "OSHA_Violator" // MONKESTATION EDIT NEW
-	key = "OSHA_Violator" // MONKESTATION EDIT NEW
+	map_name = "OSHA_Violator"
+	key = "OSHA_Violator"
 
 /datum/lazy_template/deathmatch/the_brig
 	name = "The Brig"

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -411,7 +411,7 @@
 			modifiers_pool -= modpath
 
 	///Pick global modifiers at random.
-	for(var/iteration in rand(3, 5))
+	for(var/iteration in 1 to rand(3, 5))
 		var/datum/deathmatch_modifier/modifier = GLOB.deathmatch_game.modifiers[pick_n_take(modifiers_pool)]
 		modifier.on_select(lobby)
 		modifier.on_start_game(lobby)

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -47,6 +47,15 @@
 /datum/deathmatch_modifier/proc/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
 	return
 
+// MONKESTATION EDIT NEW START
+/datum/deathmatch_modifier/random_loadouts
+	name = "Forced random loadouts"
+	description = "Randomizes everyone's loadouts"
+
+/datum/deathmatch_modifier/random_loadouts/on_start_game(datum/deathmatch_lobby/lobby)
+	for(var/key in lobby.players)
+		lobby.players[key]["loadout"] = lobby.loadouts[1]
+// MONKESTATION EDIT NEW END
 /datum/deathmatch_modifier/health
 	name = "Double-Health"
 	description = "Doubles your starting health"

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -417,6 +417,8 @@
 		modifier.on_start_game(lobby)
 		lobby += modifier.type
 		modifiers_pool -= modifier.blacklisted_modifiers
+		if(!length(modifiers_pool))
+			return
 
 /datum/deathmatch_modifier/any_loadout
 	name = "Any Loadout Allowed"

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -415,7 +415,7 @@
 		var/datum/deathmatch_modifier/modifier = GLOB.deathmatch_game.modifiers[pick_n_take(modifiers_pool)]
 		modifier.on_select(lobby)
 		modifier.on_start_game(lobby)
-		lobby += modifier.type
+		lobby.modifiers += modifier.type
 		modifiers_pool -= modifier.blacklisted_modifiers
 		if(!length(modifiers_pool))
 			return

--- a/code/modules/deathmatch/deathmatch_modifier.dm
+++ b/code/modules/deathmatch/deathmatch_modifier.dm
@@ -47,15 +47,6 @@
 /datum/deathmatch_modifier/proc/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
 	return
 
-// MONKESTATION EDIT NEW START
-/datum/deathmatch_modifier/random_loadouts
-	name = "Forced random loadouts"
-	description = "Randomizes everyone's loadouts"
-
-/datum/deathmatch_modifier/random_loadouts/on_start_game(datum/deathmatch_lobby/lobby)
-	for(var/key in lobby.players)
-		lobby.players[key]["loadout"] = lobby.loadouts[1]
-// MONKESTATION EDIT NEW END
 /datum/deathmatch_modifier/health
 	name = "Double-Health"
 	description = "Doubles your starting health"
@@ -380,6 +371,14 @@
 			continue
 		var/mine_path = pick(mines)
 		new mine_path (target_turf)
+
+/datum/deathmatch_modifier/random_loadouts
+	name = "Forced random loadouts"
+	description = "Randomizes everyone's loadouts"
+
+/datum/deathmatch_modifier/random_loadouts/on_start_game(datum/deathmatch_lobby/lobby)
+	for(var/key in lobby.players)
+		lobby.players[key]["loadout"] = lobby.loadouts[1]
 
 /datum/deathmatch_modifier/random
 	name = "Random Modifiers"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -575,7 +575,7 @@
 
 /datum/chemical_reaction/corgium/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i in rand(1, created_volume) to created_volume) // More lulz.
+	for(var/i in 1 to rand(1, created_volume)) // More lulz.
 		new /mob/living/basic/pet/dog/corgi(location)
 	..()
 
@@ -614,7 +614,7 @@
 
 /datum/chemical_reaction/butterflium/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i in rand(1, created_volume) to created_volume)
+	for(var/i in 1 to rand(1, created_volume))
 		new /mob/living/basic/butterfly(location)
 	..()
 //scream powder
@@ -963,7 +963,7 @@
 
 /datum/chemical_reaction/ant_slurry/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i in rand(1, created_volume) to created_volume)
+	for(var/i in 1 to rand(1, created_volume))
 		new /mob/living/basic/ant(location)
 	..()
 


### PR DESCRIPTION

## About The Pull Request

- Fixed the OSHA violator map not working since the start (it had a typo)
- Fixed Random modifiers not working since the start
- "Random" Loadout no longer shows up if there's only 1 loadout to pick from
- Made the "Random" Loadout option randomize on-spawn instead of in the menu
- Added an option to randomize the map
- Added a modifier to force everyone's loadouts to randomize
- By default, your loadout will now randomize instead of being the 1st one

Ports 2 lines of code that were missed from
- https://github.com/tgstation/tgstation/pull/82223

Ports dis to fix random modifiers
- https://github.com/tgstation/tgstation/pull/87795

(I assume they meant the OSHA map)
fixes #7484

## Why It's Good For The Game

> Fixed the OSHA violator map not working since the start (it had a typo)
- More maps more good, less bugs also more good
> Fixed Random modifiers not working since the start
> "Random" Loadout no longer shows up if there's only 1 loadout to pick from
- Yeah
> Made the "Random" Loadout option randomize on-spawn instead of in the menu
- Its so lame to go "I randomized into X" when nobody can tell you're randomizing. Now they will
> Added an option to randomize the map
> Added a modifier to force everyone's loadouts to randomize
- Lets go gambling! (gambling is fun, tis why)
> By default, your loadout will now randomize instead of being the 1st one
- The 1st option is used as the default in 2 cases with unarmed butt-naked as alt, but not in 2 others so i think its fine to randomize em by default. Might be somewhat of a noob-trap but eh

## Testing

I forgot DM starts lists with index 1 instead of 0, this caused many issues locally. God dammit C#

<img width="657" height="482" alt="image" src="https://github.com/user-attachments/assets/c17a24ba-621a-45cc-a68d-d09d5572e295" />

## Changelog

:cl:
add: "Random" is now the default option for deathmatch loadouts
add: "Random" now randomizes your deathmatch loadout on-spawn instead of in-lobby
add: Added an option to pick a random map in deathmatch
add: Added a modifier to randomize everyone's loadouts in deathmatch
qol: "Random" loadout no longer shows up in deathmatches with only 1 loadout
fix: OSHA Violator map now works in deathmatch
fix: Random modifiers now work in deathmatch
/:cl:

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
