### PR TITLE
Medical PR: Sleeper.

### DIFF
--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -23,33 +23,95 @@
 	///Message sent when a user enters the machine.
 	var/enter_message = span_boldnotice("You feel cool air surround you. You go numb as your senses turn inward.")
 
+	///Сurrent dose
+	var/inject_amount = 5
+	///Available dose options
+	var/list/available_amounts = list(1, 2, 3, 5, 10, 15, 20)
 	///List of currently available chems.
 	var/list/available_chems = list()
 	///Used when emagged to scramble which chem is used, eg: mutadone -> morphine
 	var/list/chem_buttons
+
+	/// Is the synthesis of custom chemicals enabled?
+	var/synthesis_active = FALSE
+	/// Chemical for accelerated synthesis (null = random)
+	var/forced_synthesis_chem
+	/// Synthesis rate (depends on the capacity)
+	var/synthesis_rate = 0.25
+
+	/// Maximum capacity for each custom chemical (depends on matter_bin)
+	var/max_custom_storage = 50
+	/// Storage of custom chemicals: reagent path -> quantity
+	var/list/custom_chem_storage = list()
+
 	///All chems this sleeper will get, depending on the parts inside.
 	var/list/possible_chems = list(
 		list(
-			/datum/reagent/medicine/epinephrine,
-			/datum/reagent/medicine/painkiller/morphine,
-			/datum/reagent/medicine/c2/convermol,
-			/datum/reagent/medicine/c2/libital,
+			/datum/reagent/medicine/c2/libital, // line 1
 			/datum/reagent/medicine/c2/aiuri,
+			/datum/reagent/medicine/c2/multiver,
+			/datum/reagent/medicine/salbutamol,
+			/datum/reagent/medicine/epinephrine, // line 2
+			/datum/reagent/medicine/painkiller/morphine,
 		),
 		list(
 			/datum/reagent/medicine/oculine,
 			/datum/reagent/medicine/inacusiate,
+			/datum/reagent/medicine/salglu_solution,  // line 3
+			/datum/reagent/medicine/antipathogenic/spaceacillin,
+			/datum/reagent/medicine/potass_iodide,
 		),
 		list(
-			/datum/reagent/medicine/c2/multiver,
+			/datum/reagent/toxin/formaldehyde,
+			/datum/reagent/medicine/pen_acid, // line 4
 			/datum/reagent/medicine/mutadone,
 			/datum/reagent/medicine/mannitol,
-			/datum/reagent/medicine/salbutamol,
-			/datum/reagent/medicine/pen_acid,
 		),
 		list(
-			/datum/reagent/medicine/omnizine,
+			/datum/reagent/medicine/diphenhydramine,
+			/datum/reagent/medicine/omnizine, // line 5
+			/datum/reagent/medicine/nanopaste,
+			/datum/reagent/medicine/coagulant,
+			/datum/reagent/toxin/radiomagnetic_disruptor,
 		),
+	)
+
+	/// List of custom chemicals available for addition. >>> ORDER IS IMPORTANT <<<
+	var/list/available_custom_chems = list(
+		// First, declare categories and subtypes
+		/datum/reagent/medicine = TRUE,
+		/datum/reagent/toxin = FALSE,
+		/datum/reagent/consumable = TRUE,
+
+		// Second, declare direct names
+		/datum/reagent/iron = TRUE,
+		/datum/reagent/water = TRUE,
+
+		// Third, we declare exceptions from categories that will overwrite the value.
+		/datum/reagent/toxin/mutagen = TRUE,
+		/datum/reagent/toxin/plasma = TRUE,
+		/datum/reagent/toxin/lipolicide = TRUE,
+	)
+
+	/// Emergency chemicals (can be administered in any condition, including the dead)
+	var/list/emergency_chems = list(
+		/datum/reagent/medicine/epinephrine,
+		/datum/reagent/medicine/atropine,
+		/datum/reagent/medicine/salbutamol,
+		/datum/reagent/medicine/coagulant,
+		/datum/reagent/medicine/rezadone,
+		/datum/reagent/medicine/c2/synthflesh,
+		/datum/reagent/toxin/formaldehyde,
+	)
+	/// Adds a special set of chemicals when using E-mag
+	var/list/emag_chems_to_add = list(
+		/datum/reagent/toxin/cyanide,
+		/datum/reagent/toxin/acid/fluacid,
+		/datum/reagent/toxin/heparin,
+		/datum/reagent/toxin/lexorin,
+		/datum/reagent/toxin/mutetoxin,
+		/datum/reagent/toxin/sodium_thiopental,
+		/datum/reagent/toxin/mutagen,
 	)
 
 /obj/machinery/sleeper/Initialize(mapload)
@@ -60,15 +122,36 @@
 
 /obj/machinery/sleeper/RefreshParts()
 	. = ..()
-	var/matterbin_rating
+	// Matterbin — maximum injection limit, volume of synthesis capacity, minimum acceptable health for work
+	var/matterbin_rating = 0
 	for(var/datum/stock_part/matter_bin/matterbins in component_parts)
 		matterbin_rating += matterbins.tier
-	efficiency = initial(efficiency) * matterbin_rating
-	min_health = initial(min_health) * matterbin_rating
 
-	available_chems.Cut()
+	efficiency = initial(efficiency) * max(matterbin_rating, 1)
+	min_health = initial(min_health) * max(matterbin_rating, 1)
+	max_custom_storage = initial(max_custom_storage) * max(matterbin_rating, 1)
+
+	// Capacitor — synthesis rate
+	var/capacitor_rating = 0
+	for(var/datum/stock_part/capacitor/capacitors in component_parts)
+		capacitor_rating += capacitors.tier
+	switch(capacitor_rating)
+		if(2)
+			synthesis_rate = 0.05	// 0.25u / 10sec
+		if(3)
+			synthesis_rate = 0.1	// 0.5u / 10sec
+		if(4)
+			synthesis_rate = 0.2	// 1u / 10sec
+		else
+			synthesis_rate = 0
+
+	// Manipulator — open standard chemicals
+	var/manipulator_rating = 0
 	for(var/datum/stock_part/manipulator/manipulators in component_parts)
-		for(var/i in 1 to manipulators.tier)
+		manipulator_rating += manipulators.tier
+	available_chems.Cut()
+	for(var/i in 1 to manipulator_rating)
+		if(i <= possible_chems.len)
 			available_chems |= possible_chems[i]
 
 	reset_chem_buttons()
@@ -76,6 +159,58 @@
 /obj/machinery/sleeper/update_icon_state()
 	icon_state = "[base_icon_state][state_open ? "-open" : null]"
 	return ..()
+
+/obj/machinery/sleeper/attackby(obj/item/weapon, mob/user, params)
+	if(is_reagent_container(weapon) && weapon.is_open_container())
+		var/obj/item/reagent_containers/container = weapon
+		if(!length(container.reagents.reagent_list))
+			balloon_alert(user, "container is empty!")
+			return
+
+		var/added_any = FALSE
+
+		// It eat all reagents in 1 beaker
+		for(var/datum/reagent/reagent in container.reagents.reagent_list)
+			var/chem_path = reagent.type
+
+			if(!is_chem_allowed(chem_path))
+				continue
+
+			var/current = custom_chem_storage[chem_path] || 0
+			var/space_left = max_custom_storage - current
+
+			if(space_left <= 0)
+				continue
+
+			var/to_add = min(reagent.volume, space_left)
+			container.reagents.remove_reagent(chem_path, to_add)
+			custom_chem_storage[chem_path] = current + to_add
+			added_any = TRUE
+
+		user.do_attack_animation(src)
+		if(added_any)
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			update_appearance()
+			balloon_alert(user, "chemicals added!")
+		else
+			balloon_alert(user, "no compatible chemicals!")
+		return
+
+	return ..()
+
+// Can u add custom chem?
+/obj/machinery/sleeper/proc/is_chem_allowed(chem_path)
+	// Direct name and exceptions
+	for(var/key in available_custom_chems)
+		if(chem_path == key)
+			return available_custom_chems[key]
+
+	// Category
+	for(var/key in available_custom_chems)
+		if(ispath(chem_path, key))
+			return available_custom_chems[key]
+
+	return FALSE
 
 /obj/machinery/sleeper/container_resist_act(mob/living/user)
 	visible_message(span_notice("[occupant] emerges from [src]!"),
@@ -94,11 +229,13 @@
 /obj/machinery/sleeper/open_machine(drop = TRUE, density_to_set = FALSE)
 	if(!state_open && !panel_open)
 		flick("[initial(icon_state)]-anim", src)
+		playsound(src, 'sound/effects/servostep.ogg', 50, 0)
 	return ..()
 
 /obj/machinery/sleeper/close_machine(mob/user, density_to_set = TRUE)
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
 		flick("[initial(icon_state)]-anim", src)
+		playsound(src, 'sound/effects/servostep.ogg', 50, 0)
 		..()
 		var/mob/living/mob_occupant = occupant
 		if(mob_occupant && mob_occupant.stat != DEAD)
@@ -179,7 +316,50 @@
 	. += span_notice("Alt-click [src] to [state_open ? "close" : "open"] it.")
 
 /obj/machinery/sleeper/process()
-	use_energy(idle_power_usage)
+	if(synthesis_active)
+		use_energy(active_power_usage)
+	else
+		use_energy(idle_power_usage)
+
+	if(synthesis_active)
+		perform_synthesis()
+
+/obj/machinery/sleeper/proc/perform_synthesis()
+	if(!length(custom_chem_storage))
+		synthesis_active = FALSE
+		return
+
+	// Get list of incomplete chemicals
+	var/list/not_full_chems = list()
+	for(var/chem in custom_chem_storage)
+		var/current = custom_chem_storage[chem] || 0
+		if(current < max_custom_storage)
+			not_full_chems += chem
+
+	if(!length(not_full_chems))
+		synthesis_active = FALSE
+		return
+
+	// Choosing a chemical for synthesis
+	var/target_chem
+	if(forced_synthesis_chem && (forced_synthesis_chem in not_full_chems))
+		target_chem = forced_synthesis_chem
+	else if(forced_synthesis_chem && !(forced_synthesis_chem in not_full_chems))
+		// The forced chemical is full — we switch to a random one
+		forced_synthesis_chem = null
+		target_chem = pick(not_full_chems)
+	else
+		target_chem = pick(not_full_chems)
+
+	if(!target_chem)
+		return
+
+	var/current = custom_chem_storage[target_chem] || 0
+	var/to_add = min(synthesis_rate, max_custom_storage - current)
+	if(to_add <= 0)
+		return
+
+	custom_chem_storage[target_chem] = current + to_add
 
 /obj/machinery/sleeper/nap_violation(mob/violator)
 	. = ..()
@@ -189,15 +369,67 @@
 	var/list/data = list()
 	data["occupied"] = !!occupant
 	data["open"] = state_open
+	data["available_amounts"] = available_amounts
+	data["inject_amount"] = inject_amount
+	data["max_custom_storage"] = max_custom_storage
+	var/is_synthesizing = FALSE
+	if(synthesis_active)
+		for(var/chem in custom_chem_storage)
+			var/current = custom_chem_storage[chem] || 0
+			if(current < max_custom_storage)
+				is_synthesizing = TRUE
+				break
 
-	data["chems"] = list()
+	data["is_synthesizing"] = is_synthesizing
+	data["synthesis_active"] = synthesis_active
+	data["synthesis_rate"] = synthesis_rate
+	data["forced_synthesis_chem"] = forced_synthesis_chem ? "[forced_synthesis_chem]" : null
+
+	var/forced_name = null
+	if(forced_synthesis_chem)
+		var/datum/reagent/R = GLOB.chemical_reagents_list[forced_synthesis_chem]
+		if(R)
+			forced_name = R.name
+	data["forced_synthesis_name"] = forced_name
+
+	// --- STANDARD CHEMICALS (endless) ---
+	data["standard_chems"] = list()
 	for(var/chem in available_chems)
 		var/datum/reagent/R = GLOB.chemical_reagents_list[chem]
-		data["chems"] += list(
+		var/display_name = R.display_name_short ? R.display_name_short : R.name
+		data["standard_chems"] += list(
 			list(
-				"name" = R.name,
+				"name" = display_name,
+				"full_name" = R.name,
 				"id" = R.type,
 				"allowed" = chem_allowed(chem),
+				"description" = R.description,
+				"is_standard" = TRUE,
+			),
+		)
+
+	// --- CUSTOM CHEMICALS (finite) ---
+	data["custom_chems"] = list()
+	for(var/chem in custom_chem_storage)
+		var/datum/reagent/R = GLOB.chemical_reagents_list[chem]
+		if(!R)
+			continue
+		var/display_name = R.display_name_short ? R.display_name_short : R.name
+		var/stored = custom_chem_storage[chem] || 0
+		var/percent = round((stored / max_custom_storage) * 100)
+		var/is_empty = stored < inject_amount
+
+		data["custom_chems"] += list(
+			list(
+				"name" = display_name,
+				"full_name" = R.name,
+				"id" = R.type,
+				"allowed" = !is_empty && chem_allowed(chem),
+				"description" = R.description,
+				"storage" = stored,
+				"max_storage" = max_custom_storage,
+				"percent" = percent,
+				"is_empty" = is_empty,
 			),
 		)
 
@@ -227,6 +459,22 @@
 		data["occupant"]["fireLoss"] = mob_occupant.getFireLoss()
 		data["occupant"]["cloneLoss"] = mob_occupant.getCloneLoss()
 		data["occupant"]["brainLoss"] = mob_occupant.get_organ_loss(ORGAN_SLOT_BRAIN)
+		data["occupant"]["blood_volume"] = mob_occupant.blood_volume
+
+		// Chems in blood
+		var/list/blood_chems = list()
+		if(mob_occupant.reagents && length(mob_occupant.reagents.reagent_list))
+			for(var/datum/reagent/reagent in mob_occupant.reagents.reagent_list)
+				if(reagent.chemical_flags & REAGENT_INVISIBLE) //Don't show hidden chems on scanners
+					continue
+				var/display_volume = round(reagent.volume, 0.001)
+				blood_chems += list(list(
+					"name" = reagent.name,
+					"volume" = display_volume,
+					"overdosed" = reagent.overdosed
+				))
+		data["occupant"]["blood_chems"] = blood_chems
+
 		data["occupant"]["reagents"] = list()
 		if(mob_occupant.reagents && mob_occupant.reagents.reagent_list.len)
 			for(var/datum/reagent/R in mob_occupant.reagents.reagent_list)
@@ -245,7 +493,6 @@
 	. = ..()
 	if(.)
 		return
-	playsound(src, 'sound/items/hypospray.ogg', 50, TRUE, 2)
 
 	var/mob/living/mob_occupant = occupant
 	check_nap_violations()
@@ -256,43 +503,142 @@
 			else
 				open_machine()
 			. = TRUE
+
 		if("inject")
 			var/chem = text2path(params["chem"])
 			if(!is_operational || !mob_occupant || isnull(chem))
 				return
-			if(mob_occupant.health < min_health && !ispath(chem, /datum/reagent/medicine/epinephrine))
+
+			// Emergency chemicals can always be administered, the rest — only if the health is above the threshold.
+			if(!(chem in emergency_chems) && mob_occupant.health < min_health)
+				balloon_alert(usr, "patient too damaged!")
 				return
+
 			if(inject_chem(chem, usr))
+				playsound(src, 'sound/items/hypospray.ogg', 50, TRUE, 2)
 				. = TRUE
-				if((obj_flags & EMAGGED) && prob(5))
-					to_chat(usr, span_warning("Chemical system re-route detected, results may not be as expected!"))
+
+		if("toggle_synthesis")
+			if(!length(custom_chem_storage))
+				balloon_alert(usr, "no custom chemicals!")
+				return
+			synthesis_active = !synthesis_active
+			if(synthesis_active)
+				balloon_alert(usr, "synthesis started")
+			else
+				balloon_alert(usr, "synthesis stopped")
+			. = TRUE
+
+		if("force_synthesis")
+			var/chem = text2path(params["chem"])
+			if(!chem || !(chem in custom_chem_storage))
+				return
+			if(forced_synthesis_chem == chem)
+				forced_synthesis_chem = null
+				balloon_alert(usr, "synthesis: random")
+			else
+				forced_synthesis_chem = chem
+				balloon_alert(usr, "synthesis: [chem]")
+				if(!synthesis_active)
+					synthesis_active = TRUE
+			. = TRUE
+
+		if("inject_custom")
+			var/chem = text2path(params["chem"])
+			if(!is_operational || !mob_occupant || isnull(chem))
+				return
+			var/stored = custom_chem_storage[chem] || 0
+			if(stored < inject_amount)
+				balloon_alert(usr, "not enough!")
+				return
+			var/actual_amount = min(inject_amount, 20 * efficiency - mob_occupant.reagents.get_reagent_amount(chem))
+			if(actual_amount > 0)
+				mob_occupant.reagents.add_reagent(chem, actual_amount)
+				custom_chem_storage[chem] = stored - actual_amount
+				if(usr)
+					log_combat(usr, mob_occupant, "injected [actual_amount] units of custom [chem] into", addition = "via [src]")
+				playsound(src, 'sound/items/hypospray.ogg', 50, TRUE, 2)
+				. = TRUE
+
+		if("remove_custom_chem")
+			var/chem = text2path(params["chem"])
+			if(!chem || !(chem in custom_chem_storage))
+				return
+			if(forced_synthesis_chem == chem)
+				forced_synthesis_chem = null
+			custom_chem_storage -= chem
+			if(!length(custom_chem_storage))
+				synthesis_active = FALSE
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			. = TRUE
+
+		if("set_amount")
+			var/new_amount = text2num(params["amount"])
+			if(new_amount in available_amounts)
+				playsound(src, 'sound/effects/pop.ogg', 50, 0)
+				inject_amount = new_amount
+				. = TRUE
 
 /obj/machinery/sleeper/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
+		balloon_alert(user, "already emagged!")
+		return FALSE
+
+	var/choice = tgui_input_list(user, "Select emag function:", "Sleeper Emag", list(
+		"Scramble Buttons",
+		"Syndicate chemicals kit",
+		"Cancel"
+	))
+
+	if(!choice || choice == "Cancel")
 		return FALSE
 
 	balloon_alert(user, "interface scrambled")
 	obj_flags |= EMAGGED
 
-	var/list/av_chem = available_chems.Copy()
-	for(var/chem in av_chem)
-		chem_buttons[chem] = pick_n_take(av_chem) //no dupes, allow for random buttons to still be correct
+	switch(choice)
+		if("Scramble Buttons")
+			var/list/av_chem = available_chems.Copy()
+			for(var/chem in av_chem)
+				chem_buttons[chem] = pick_n_take(av_chem)
+			to_chat(user, span_warning("Chemical buttons scrambled!"))
+
+		if("Syndicate chemicals kit")
+			available_custom_chems[/datum/reagent/toxin] = TRUE
+
+			for(var/toxin in emag_chems_to_add)
+				if(!(toxin in custom_chem_storage))
+					custom_chem_storage[toxin] = 20
+
+			to_chat(user, span_warning("Toxic chemicals unlocked and added to synthesis data base!"))
 	return TRUE
 
 /obj/machinery/sleeper/proc/inject_chem(chem, mob/user)
 	if((chem in available_chems) && chem_allowed(chem))
-		occupant.reagents.add_reagent(chem_buttons[chem], 10) //emag effect kicks in here so that the "intended" chem is used for all checks, for extra FUUU
-		if(user)
-			log_combat(user, occupant, "injected [chem] into", addition = "via [src]")
-		return TRUE
+		//dosage of medications
+		var/actual_amount = min(inject_amount, 20 * efficiency - occupant.reagents.get_reagent_amount(chem))
+		if(actual_amount > 0)
+			occupant.reagents.add_reagent(chem_buttons[chem], actual_amount)
+			if(user)
+				log_combat(user, occupant, "injected [actual_amount] units of [chem] into", addition = "via [src]")
+			return TRUE
+	return FALSE
 
+// Can u inject chem?
 /obj/machinery/sleeper/proc/chem_allowed(chem)
 	var/mob/living/mob_occupant = occupant
 	if(!mob_occupant || !mob_occupant.reagents)
-		return
-	var/amount = mob_occupant.reagents.get_reagent_amount(chem) + 10 <= 20 * efficiency
-	var/occ_health = mob_occupant.health > min_health || chem == /datum/reagent/medicine/epinephrine
-	return amount && occ_health
+		return FALSE
+
+	var/amount = mob_occupant.reagents.get_reagent_amount(chem) + inject_amount <= 20 * efficiency
+	var/occ_health = (chem in emergency_chems) || mob_occupant.health > min_health
+
+	var/has_storage = TRUE
+	if(chem in custom_chem_storage)
+		var/stored = custom_chem_storage[chem] || 0
+		has_storage = stored >= inject_amount
+
+	return amount && occ_health && has_storage
 
 /obj/machinery/sleeper/proc/reset_chem_buttons()
 	obj_flags &= ~EMAGGED

--- a/tgui/packages/tgui/interfaces/Sleeper.jsx
+++ b/tgui/packages/tgui/interfaces/Sleeper.jsx
@@ -1,5 +1,13 @@
 import { useBackend } from '../backend';
-import { Box, Button, LabeledList, ProgressBar, Section } from '../components';
+import {
+  Box,
+  Button,
+  LabeledList,
+  ProgressBar,
+  Section,
+  Stack,
+  Tooltip,
+} from '../components';
 import { Window } from '../layouts';
 
 const damageTypes = [
@@ -23,99 +31,366 @@ const damageTypes = [
 
 export const Sleeper = (props) => {
   const { act, data } = useBackend();
-  const { open, occupant = {}, occupied } = data;
-  const preSortChems = data.chems || [];
-  const chems = preSortChems.sort((a, b) => {
-    const descA = a.name.toLowerCase();
-    const descB = b.name.toLowerCase();
-    if (descA < descB) {
-      return -1;
-    }
-    if (descA > descB) {
-      return 1;
-    }
-    return 0;
-  });
+  const {
+    open,
+    occupant = {},
+    occupied,
+    inject_amount,
+    available_amounts,
+    max_custom_storage,
+    standard_chems = [],
+    custom_chems = [],
+    synthesis_active,
+    synthesis_rate,
+    forced_synthesis_chem,
+    forced_synthesis_name,
+    is_synthesizing,
+  } = data;
+
+  const windowHeight = Math.min(
+    800,
+    Math.max(550, 550 + custom_chems.length * 28),
+  );
+
+  let synthesisTooltip = '';
+  if (synthesis_active && is_synthesizing && forced_synthesis_name) {
+    synthesisTooltip = `Forced: ${forced_synthesis_name} synthesis is ON (${synthesis_rate}u/2s)`;
+  } else if (synthesis_active && is_synthesizing) {
+    synthesisTooltip = `General synthesis is ON (${synthesis_rate}u/2s)`;
+  } else if (synthesis_active && !is_synthesizing) {
+    synthesisTooltip = 'Synthesis paused — all chemicals full';
+  } else {
+    synthesisTooltip = 'Synthesis is OFF — click to start';
+  }
+
+  let forcedText = '';
+  if (synthesis_active && is_synthesizing && forced_synthesis_name) {
+    forcedText = `Forced: ${forced_synthesis_name}`;
+  } else if (synthesis_active && is_synthesizing) {
+    forcedText = 'General synthesis';
+  } else if (synthesis_active && !is_synthesizing) {
+    forcedText = 'Paused (full)';
+  } else {
+    forcedText = 'Synthesis is OFF';
+  }
+
   return (
-    <Window width={310} height={465}>
+    <Window width={560} height={windowHeight}>
       <Window.Content>
-        <Section
-          title={occupant.name ? occupant.name : 'No Occupant'}
-          minHeight="210px"
-          buttons={
-            !!occupant.stat && (
-              <Box inline bold color={occupant.statstate}>
-                {occupant.stat}
-              </Box>
-            )
-          }
-        >
-          {!!occupied && (
-            <>
-              <ProgressBar
-                value={occupant.health}
-                minValue={occupant.minHealth}
-                maxValue={occupant.maxHealth}
-                ranges={{
-                  good: [50, Infinity],
-                  average: [0, 50],
-                  bad: [-Infinity, 0],
-                }}
-              />
-              <Box mt={1} />
-              <LabeledList>
-                {damageTypes.map((type) => (
-                  <LabeledList.Item key={type.type} label={type.label}>
-                    <ProgressBar
-                      value={occupant[type.type]}
-                      minValue={0}
-                      maxValue={occupant.maxHealth}
-                      color="bad"
-                    />
-                  </LabeledList.Item>
-                ))}
-                <LabeledList.Item
-                  label="Cells"
-                  color={occupant.cloneLoss ? 'bad' : 'good'}
+        <Stack fill vertical>
+          {/* THE UPPER HALF: patient and chems in blood */}
+          <Stack.Item grow={1}>
+            <Stack fill>
+              {/* THE LEFT COLUMN: PATIENT INFORMATION */}
+              <Stack.Item basis="50%">
+                <Section
+                  title={occupant.name ? occupant.name : 'No Occupant'}
+                  fill
+                  buttons={
+                    !!occupant.stat && (
+                      <Box inline bold color={occupant.statstate}>
+                        {occupant.stat}
+                      </Box>
+                    )
+                  }
                 >
-                  {occupant.cloneLoss ? 'Damaged' : 'Healthy'}
-                </LabeledList.Item>
-                <LabeledList.Item
-                  label="Brain"
-                  color={occupant.brainLoss ? 'bad' : 'good'}
-                >
-                  {occupant.brainLoss ? 'Abnormal' : 'Healthy'}
-                </LabeledList.Item>
-              </LabeledList>
-            </>
-          )}
-        </Section>
-        <Section
-          title="Medicines"
-          minHeight="205px"
-          buttons={
-            <Button
-              icon={open ? 'door-open' : 'door-closed'}
-              content={open ? 'Open' : 'Closed'}
-              onClick={() => act('door')}
-            />
-          }
-        >
-          {chems.map((chem) => (
-            <Button
-              key={chem.name}
-              icon="flask"
-              content={chem.name}
-              disabled={!occupied || !chem.allowed}
-              width="140px"
-              onClick={() =>
-                act('inject', {
-                  chem: chem.id,
-                })
+                  {!!occupied && (
+                    <>
+                      <ProgressBar
+                        value={occupant.health}
+                        minValue={occupant.minHealth}
+                        maxValue={occupant.maxHealth}
+                        ranges={{
+                          good: [50, Infinity],
+                          average: [0, 50],
+                          bad: [-Infinity, 0],
+                        }}
+                      />
+                      <Box mt={1} />
+                      <LabeledList>
+                        {damageTypes.map((type) => {
+                          const damageValue = occupant[type.type];
+                          return (
+                            <LabeledList.Item
+                              key={type.type}
+                              label={type.label}
+                            >
+                              <ProgressBar
+                                value={damageValue}
+                                minValue={0}
+                                maxValue={occupant.maxHealth}
+                                ranges={{
+                                  good: [-Infinity, 50],
+                                  average: [50, 100],
+                                  bad: [100, Infinity],
+                                }}
+                              />
+                            </LabeledList.Item>
+                          );
+                        })}
+                        <LabeledList.Item
+                          label="Cells"
+                          color={occupant.cloneLoss ? 'bad' : 'good'}
+                        >
+                          {occupant.cloneLoss ? 'Damaged' : 'Healthy'}
+                        </LabeledList.Item>
+                        <LabeledList.Item
+                          label="Brain"
+                          color={occupant.brainLoss ? 'bad' : 'good'}
+                        >
+                          {occupant.brainLoss ? 'Abnormal' : 'Healthy'}
+                        </LabeledList.Item>
+                        <LabeledList.Item label="Blood Volume">
+                          <ProgressBar
+                            value={occupant.blood_volume || 0}
+                            minValue={0}
+                            maxValue={560}
+                            ranges={{
+                              good: [448, 560],
+                              average: [280, 448],
+                              bad: [0, 280],
+                            }}
+                          />
+                        </LabeledList.Item>
+                      </LabeledList>
+                    </>
+                  )}
+                </Section>
+              </Stack.Item>
+
+              {/* THE RIGHT COLUMN: CHEMICALS IN THE BLOOD */}
+              <Stack.Item basis="50%">
+                <Section title="Blood Chemicals" fill>
+                  {!occupied ? (
+                    <Box color="grey" textAlign="center" mt={2}>
+                      No occupant
+                    </Box>
+                  ) : !occupant.blood_chems ||
+                    occupant.blood_chems.length === 0 ? (
+                    <Box color="grey" textAlign="center" mt={2}>
+                      No chemicals detected in blood
+                    </Box>
+                  ) : (
+                    <Box>
+                      {occupant.blood_chems.map((chem, index) => (
+                        <Box key={index} mb={1}>
+                          <Box color={chem.overdosed ? 'bad' : 'good'}>
+                            {Math.round(chem.volume * 10) / 10} units of{' '}
+                            {chem.name}
+                            {chem.overdosed ? ' - OVERDOSING' : ''}
+                          </Box>
+                        </Box>
+                      ))}
+                    </Box>
+                  )}
+                </Section>
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+
+          {/* THE LOWER HALF: medicines */}
+          <Stack.Item>
+            <Section
+              title="Medicines"
+              buttons={
+                <>
+                  <Button
+                    icon="cog"
+                    content={
+                      synthesis_active && is_synthesizing
+                        ? 'Synthesis: ON'
+                        : 'Synthesis: OFF'
+                    }
+                    color={
+                      synthesis_active && is_synthesizing ? 'green' : 'default'
+                    }
+                    tooltip={synthesisTooltip}
+                    onClick={() => act('toggle_synthesis')}
+                  />
+                  <Button
+                    icon={open ? 'door-open' : 'door-closed'}
+                    content={open ? 'Open' : 'Closed'}
+                    onClick={() => act('door')}
+                  />
+                </>
               }
-            />
-          ))}
-        </Section>
+            >
+              {/* SETTING THE DOSAGE */}
+              <Box mb={2}>
+                <Box mb={1} fontSize="12px" color="label">
+                  Injection Amount:
+                </Box>
+                <Stack spacing={1}>
+                  {available_amounts?.map((amount) => (
+                    <Stack.Item key={amount}>
+                      <Button
+                        content={`${amount} units`}
+                        selected={inject_amount === amount}
+                        color={inject_amount === amount ? 'green' : 'default'}
+                        onClick={() => act('set_amount', { amount: amount })}
+                      />
+                    </Stack.Item>
+                  ))}
+                </Stack>
+              </Box>
+
+              {/* STANDARD CHEMICALS */}
+              <Box mb={2}>
+                <Box mb={0.5} fontSize="12px" color="label">
+                  Standard Chemicals:
+                </Box>
+                <Box display="flex" flexWrap="wrap" gap="4px">
+                  {standard_chems.map((chem) => (
+                    <Tooltip
+                      key={chem.id}
+                      content={
+                        <Box backgroundColor="#1a1a1a" p={1}>
+                          <Box color="green" bold>
+                            {chem.full_name}
+                          </Box>
+                          <Box color="label" mt={0.5}>
+                            {chem.description}
+                          </Box>
+                          <Box color="good" mt={0.5}>
+                            ♾️ Unlimited
+                          </Box>
+                        </Box>
+                      }
+                      position="top"
+                    >
+                      <Button
+                        icon="flask"
+                        content={chem.name}
+                        disabled={!occupied || !chem.allowed}
+                        width="130px"
+                        onClick={() =>
+                          act('inject', {
+                            chem: chem.id,
+                          })
+                        }
+                      />
+                    </Tooltip>
+                  ))}
+                </Box>
+              </Box>
+
+              {/* CUSTOM CHEMICALS */}
+              <Box>
+                <Box mb={0.5} fontSize="12px" color="label">
+                  Custom Chemicals:
+                  <Box
+                    inline
+                    color={
+                      synthesis_active && is_synthesizing ? 'green' : 'default'
+                    }
+                    ml={1}
+                  >
+                    ({forcedText})
+                  </Box>
+                </Box>
+                {custom_chems.length === 0 ? (
+                  <Box color="grey" textAlign="center" mt={1}>
+                    You can add custom chemicals manually.
+                  </Box>
+                ) : (
+                  <Box display="flex" flexDirection="column" gap="4px">
+                    {custom_chems.map((chem) => {
+                      const isForced = chem.id === forced_synthesis_chem;
+                      return (
+                        <Box
+                          key={chem.id}
+                          display="flex"
+                          alignItems="center"
+                          gap="4px"
+                          flexWrap="nowrap"
+                        >
+                          {/* The injection button */}
+                          <Tooltip
+                            content={
+                              <Box backgroundColor="#1a1a1a" p={1}>
+                                <Box color="green" bold>
+                                  {chem.full_name}
+                                </Box>
+                                <Box color="label" mt={0.5}>
+                                  {chem.description}
+                                </Box>
+                                <Box
+                                  color={chem.is_empty ? 'bad' : 'good'}
+                                  mt={0.5}
+                                >
+                                  {chem.is_empty
+                                    ? '⚠ EMPTY'
+                                    : `${chem.storage}u available`}
+                                </Box>
+                              </Box>
+                            }
+                            position="top"
+                          >
+                            <Button
+                              icon="flask"
+                              content={chem.name}
+                              disabled={!occupied || !chem.allowed}
+                              width="130px"
+                              onClick={() =>
+                                act('inject_custom', { chem: chem.id })
+                              }
+                            />
+                          </Tooltip>
+
+                          {/* Stock scale */}
+                          <ProgressBar
+                            value={chem.storage}
+                            maxValue={chem.max_storage}
+                            ranges={{
+                              good: [chem.max_storage * 0.5, Infinity],
+                              average: [
+                                chem.max_storage * 0.25,
+                                chem.max_storage * 0.5,
+                              ],
+                              bad: [0, chem.max_storage * 0.25],
+                            }}
+                            width="264px"
+                          >
+                            {`${chem.storage}u / ${chem.max_storage}u (${chem.percent}%)`}
+                          </ProgressBar>
+
+                          {/* Chemical Synthesis button */}
+                          <Button
+                            icon="bolt"
+                            content="Synthesis"
+                            color={
+                              isForced && synthesis_active ? 'green' : 'default'
+                            }
+                            width="108px"
+                            tooltip={
+                              isForced && synthesis_active
+                                ? 'Forcing synthesis'
+                                : 'Click to force synthesis for this chem. Greatly increases energy consumption.'
+                            }
+                            onClick={() =>
+                              act('force_synthesis', { chem: chem.id })
+                            }
+                          />
+
+                          {/* Line deletion button */}
+                          <Button
+                            icon="times"
+                            color="bad"
+                            width="22px"
+                            tooltip={`Remove ${chem.full_name}`}
+                            onClick={() =>
+                              act('remove_custom_chem', { chem: chem.id })
+                            }
+                          />
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                )}
+              </Box>
+            </Section>
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );


### PR DESCRIPTION
## Medical PR: Sleeper
Elo, This PR is a remodulation of my other PR https://github.com/Monkestation/Monkestation2.0/pull/11818. 
`This PR must be taken SECOND for the operation of the PR sleeper and hypospray. PR with the rod of Asclepius can be accepted regardless of the others.`
In this element introduced:
* Sleeper
 
I apologize in advance for any possible illiteracy, this is not my native language.
Contact information:

* Discord: felinemistress
* Byond: felinemistress

## Description (a copy of the previous PR with added changes)

1) The sleeper's functionality has been expanded, the graphic panel has become bigger and more informative
	* now it shows the blood level and all chemicals in the patient's blood
	* Reports about overdose. 
	* Added the ability to select the dosage (1, 5, 10, 15, 20)
	* Added a description hint
	* There are more chemicals, T2 chemicals have appeared, and some chemicals are available with more affordable components. 
		* Tier 1:
			+ Convermol - deleted
			+ Multiver - moved T3 -> T1
			+ Salbutamol - moved T3 -> T1
		* Tier 2:
			+ Saline-Glucose - added
			+ Spaceacillin - added
			+ Potassium Iodide - added
		
		* Tier 3:
			+ Formaldehyde  - added
		
		* Tier 4:
			+ Diphenhydramine - added
			+ Nanopaste (new chem) - added
			+ Sanguirite (coagulant) - added
			+ R-disruptor - added
2) Now you can add custom chemicals to the sleeper using chemical glasses. These chemicals can also be injected by sleeper, but they are finite and can be deleted.

3) Custom chemicals can be synthesized with a sleeper, but very-vary-vary slowly and it consumes 10 times more energy. You can force a specific chemical for synthesis or turn on general synthesis and each tick will be replenished with a random chemical from the available ones. The synthesizer has the functionality of black and white lists - by default, all medicines, everything edible, some basic elements are unblocked, toxins are prohibited with some exceptions (E-mag can unblock toxins).
The synthesis rate depends on the new component - the capacitor, now it required to create the machine:
	* T1 cant synthesis,
	* T2 - 0.05u / 2 sec (0.25u / 10 sec)
	* T3 - 0.1u / 2 sec (0.5u / 10 sec)
	* T4 - 0.2u / 2 sec (1u / 10 sec)
The maximum capacity of the each custom chems depends on the matter bin:
	* T1 - 50u
	* T2 - 100u
	* T3 - 150u
	* T4 - 200u

4) With the E-mag, there is now a choice:
	* Mix up the chemical input buttons (this was the default function)
	* Unlock the input of toxins and synthesis of chemicals. It also instantly synthesizes 20u of each of these chemicals:
		/datum/reagent/toxin/cyanide,
		/datum/reagent/toxin/acid/fluacid,
		/datum/reagent/toxin/heparin,
		/datum/reagent/toxin/lexorin,
		/datum/reagent/toxin/mutetoxin,
		/datum/reagent/toxin/sodium_thiopental,
		/datum/reagent/toxin/mutagen,

Attachments:
some outdated but
<img width="668" height="604" alt="2026-06-05_22-29-53" src="https://github.com/user-attachments/assets/ff6b9bb5-38da-466c-a51f-5e1cf48d4ff7" />
level 4 sleeper without additional chemicals divided into ranks:
<img width="672" height="659" alt="2026-06-27_22-35-23" src="https://github.com/user-attachments/assets/c67f778c-b5a2-4a2f-a15f-98371c88dccd" />
A sleeper loaded with chemicals
<img width="670" height="918" alt="2026-06-27_22-38-43" src="https://github.com/user-attachments/assets/856fdb8b-f422-467f-910b-82b31dbfe342" />
The E-mag menu
<img width="387" height="395" alt="2026-06-27_22-39-32" src="https://github.com/user-attachments/assets/c9083051-cdcb-4e55-9935-e5107c4e686c" />
chemicals added by E-mag
<img width="672" height="884" alt="2026-06-27_22-39-47" src="https://github.com/user-attachments/assets/ff63ad9b-0810-4b09-9874-4ec6aca312fc" />

## Testing
* i hope i dont lost nothing when transfer it all
* This PR will not compile without accepting PR https://github.com/Monkestation/Monkestation2.0/pull/12000 He needs chemicals.


## Changelog
:cl:
add: The sleeper's functionality has been expanded, the graphic panel has become bigger and more informative. New chems.
qol: IV, sleepers
sound: Sleeper
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
