### PR TITLE
fixes mask items worn on the neck not being obscured visually

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -309,6 +309,8 @@ There are several things that need to be remembered:
 		var/obj/item/worn_item = wear_neck
 		update_hud_neck(wear_neck)
 
+		if(worn_item.slot_flags & ITEM_SLOT_MASK)
+			CHECK_SHOULDNT_RENDER(worn_item, ITEM_SLOT_MASK)
 		CHECK_SHOULDNT_RENDER(worn_item, ITEM_SLOT_NECK) // monkestation edit: combine TRAIT_ALWAYS_RENDER + TRAIT_NO_WORN_ICON + obscure check into a single define
 
 		var/icon_file = 'icons/mob/clothing/neck.dmi'

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -357,6 +357,8 @@
 		update_inv_ears()
 	if(I.flags_inv & HIDEEYES || forced)
 		update_worn_glasses()
+	if(wear_neck)
+		update_worn_neck()
 	update_worn_head()
 
 /mob/living/carbon/proc/get_holding_bodypart_of_item(obj/item/I)


### PR DESCRIPTION

## About The Pull Request
if you wear mask item on your neck it gets covered as if it was a mask item worn on your mask slot.

## Why It's Good For The Game
bug fix

## Changelog

:cl:
fix: if you wear mask item on your neck it gets covered as if it was a mask item worn on your mask slot.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

