### PR TITLE
Nerfs DNR a bit

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -90,6 +90,9 @@ DEFINE_BITFIELD(status_flags, list(
 #define HEALTH_THRESHOLD_FULLCRIT -30
 #define HEALTH_THRESHOLD_DEAD -100
 
+///DNR quirk will subtract this from the health needed to enter fullcrit.
+#define HEALTH_THRESHOLD_DNR_FULLCRIT_MODIFIER 20
+
 #define HEALTH_THRESHOLD_NEARDEATH -90 //Not used mechanically, but to determine if someone is so close to death they hear the other side
 
 //Actual combat defines

--- a/monkestation/code/datums/quirks/negative_quirks/dnr.dm
+++ b/monkestation/code/datums/quirks/negative_quirks/dnr.dm
@@ -13,17 +13,17 @@
 	quirk_holder.mind.add_traits(list(TRAIT_DEFIB_BLACKLISTED, TRAIT_NO_SPECIAL_REVIVAL), QUIRK_TRAIT)
 
 	//can survive a bit longer
-	quirk_holder.hardcrit_threshold -= (MAX_LIVING_HEALTH / 2)
+	quirk_holder.hardcrit_threshold -= HEALTH_THRESHOLD_DNR_FULLCRIT_MODIFIER
 	quirk_holder.dead_threshold -= MAX_LIVING_HEALTH
 	var/obj/item/organ/internal/brain/target_brain = quirk_holder.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(target_brain)
-		target_brain.maxHealth += BRAIN_DAMAGE_SEVERE
+		target_brain.maxHealth += (BRAIN_DAMAGE_MILD * 2)
 
 /datum/quirk/dnr/remove()
 	quirk_holder.mind.remove_traits(list(TRAIT_DEFIB_BLACKLISTED, TRAIT_NO_SPECIAL_REVIVAL), QUIRK_TRAIT)
-	quirk_holder.hardcrit_threshold += (MAX_LIVING_HEALTH / 2)
+	quirk_holder.hardcrit_threshold += HEALTH_THRESHOLD_DNR_FULLCRIT_MODIFIER
 	quirk_holder.dead_threshold += MAX_LIVING_HEALTH
 	var/obj/item/organ/internal/brain/target_brain = quirk_holder.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(target_brain)
-		target_brain.maxHealth -= BRAIN_DAMAGE_SEVERE
+		target_brain.maxHealth -= (BRAIN_DAMAGE_MILD * 2)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Hardcrit threshold moved from -80 to -50
Brain maxhp now increases by 40 instead of 100

## Why It's Good For The Game

DNR quirk has been too good for too long.

## Changelog

:cl:
balance: DNR quirk falls in hardcrit and dies from brain damage a little faster.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
