### PR TITLE
Adds gears to Oshan public mining

### DIFF
--- a/_maps/map_files/Mining/Oshan.dmm
+++ b/_maps/map_files/Mining/Oshan.dmm
@@ -427,7 +427,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/mine/maintenance/service)
 "tw" = (
-/obj/machinery/suit_storage_unit,
+/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/mine/production)
@@ -900,7 +900,7 @@
 /area/mine/production)
 "FS" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/suit_storage_unit,
+/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/mine/production)

--- a/_maps/map_files/Mining/Oshan.dmm
+++ b/_maps/map_files/Mining/Oshan.dmm
@@ -51,6 +51,27 @@
 /obj/structure/railing,
 /turf/open/floor/plating/ocean/rock,
 /area/ocean/dark)
+"dJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/pickaxe{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/pickaxe{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/pickaxe{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/pickaxe{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/production)
 "en" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -86,10 +107,38 @@
 "fd" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 9
+	},
+/obj/item/gps/mining{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/gps/mining{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/mining_scanner{
+	pixel_x = -4
+	},
+/obj/item/mining_scanner{
+	pixel_x = 4
+	},
+/obj/item/storage/bag/ore{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/storage/bag/ore{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = 4;
+	pixel_y = 6
 	},
 /turf/open/floor/iron,
 /area/mine/production)
@@ -408,6 +457,22 @@
 /area/mine/maintenance/service)
 "tZ" = (
 /obj/structure/cable,
+/obj/item/flashlight{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/flashlight{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/flashlight{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/flashlight{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/mine/production)
 "ul" = (
@@ -932,6 +997,22 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/mine/production)
 "HG" = (
@@ -1286,13 +1367,41 @@
 "Yf" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/structure/table,
-/obj/item/paper,
-/obj/item/pen,
 /obj/machinery/camera/autoname/directional/south{
 	network = list("mine")
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
+	},
+/obj/item/gps/mining{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/gps/mining{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/mining_scanner{
+	pixel_x = -4
+	},
+/obj/item/mining_scanner{
+	pixel_x = 4
+	},
+/obj/item/storage/bag/ore{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/storage/bag/ore{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = 4;
+	pixel_y = 6
 	},
 /turf/open/floor/iron,
 /area/mine/production)
@@ -19509,7 +19618,7 @@ wE
 qK
 fB
 fL
-ML
+dJ
 fd
 uT
 fG


### PR DESCRIPTION

## About The Pull Request

Adds flashlights, GPS, mining satchel, manual mining scanner, oxygen tank, pickaxes, meson scanners and EVA suits (why were there empty suit storages there) to Oshan public mining

## Why It's Good For The Game

Every public mining has these gears so far, I don't see why Oshan should be different

## Testing

Sadly, I played Oshan to test this and discovered there is nothing inside the suit storages.

## Changelog
:cl:
map: Oshan public mining now has proper gears. (Including EVA suits, pickaxes, oxygen tanks, mining satchels, pickaxes, meson scanners, GPS, manual mining scanners and flashlights)
/:cl:


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.