### PR TITLE
Hosed quirk no longer prevents crit damage

### DIFF
--- a/monkestation/code/datums/quirks/positive_quirks/hosed.dm
+++ b/monkestation/code/datums/quirks/positive_quirks/hosed.dm
@@ -1,9 +1,9 @@
 /datum/quirk/cybernetics_quirk/hosed
 	name = "Hosed"
 	desc = "You've got a cybernetic breathing tube implant!"
-	value = 3
+	value = 2
 	gain_text = span_notice("You can breathe easier!")
 	lose_text = span_notice("Breathing feels normal again.")
 	medical_record_text = "Patient has been installed with a breathing tube implant."
 	icon = FA_ICON_LUNGS
-	cybernetic_type = /obj/item/organ/internal/cyberimp/mouth/breathing_tube
+	cybernetic_type = /obj/item/organ/internal/cyberimp/mouth/breathing_tube/simple

--- a/monkestation/code/modules/cybernetics/augments/internal_implants.dm
+++ b/monkestation/code/modules/cybernetics/augments/internal_implants.dm
@@ -178,6 +178,11 @@
 		to_chat(owner, span_warning("Your breathing tube suddenly closes!"))
 		owner.losebreath += 2
 
+/obj/item/organ/internal/cyberimp/mouth/breathing_tube/simple
+	name = "simple breathing tube implant"
+	desc = "This simple implant adds an internals connector to your back, allowing you to use internals without a mask."
+	organ_traits = list()
+
 //BOX O' IMPLANTS
 
 /obj/item/storage/box/cyber_implants


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes a simple variant of the breathing tube, does not recieve assisted breathing trait

hosed recieves simple variant of breathing trait

hosed quirk 2 points instead of 3
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A 3 point quirk entirely removing crit damage is a bit stupid and overly strong, additionally even though niche random people just being outright immune to choking/a few other things that checked for assisted breathing trait off roundstart is a bit crazy.

Was really strong for a cheap quirk meant to be mostly qol, bumped it down a bit since it is just solidified as a qol/cosmetic quirk just letting you wear mask that dont support internals with internals.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing
yes tested on local, quirk applies properly and users dont get the trait
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: hosed quirk no longer recieves assisted breathing trait, now only 2 points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
