### PR TITLE
Fixes AI exosuits trapping the AI

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
@@ -61,7 +61,7 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 
 /obj/machinery/ai/data_core/on_deconstruction()
 	. = ..()
-	integrated_battery.forceMove(drop_location())
+	integrated_battery?.forceMove(drop_location())
 
 /obj/machinery/ai/data_core/JoinPlayerHere(mob/M, buckle)
 	return
@@ -174,6 +174,9 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 		return ..()
 	if(!valid_data_core() || !valid_holder())
 		balloon_alert(user, "not a valid core!")
+		return ..()
+	if(user.controlled_equipment)
+		balloon_alert(user, "controlling equipment!")
 		return ..()
 	if(user.nuking)
 		var/confirmation_alert = tgui_alert(user, "Shunting will disable the doomsday device, are you sure you wish to do this?", "Really shunt?", list("Shunt", "Cancel"))

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -135,10 +135,17 @@
 			AI.remote_control = null
 			mob_container = AI
 			newloc = null
-			if(AI.relocate(silent = TRUE, kill_otherwise = FALSE))
+			if(AI.last_used_data_core && !QDELETED(AI.last_used_data_core))
+				if(AI.last_used_data_core.can_transfer_ai())
+					AI.last_used_data_core.transfer_AI(AI)
+					moved_already = TRUE
+			else if(AI.relocate(silent = TRUE, kill_otherwise = FALSE))
 				moved_already = TRUE
 			else
-				to_chat(AI, span_userdanger("No cores available. Core code corrupted."))
+				to_chat(AI, span_userdanger("No cores available. Enabling controls."))
+				AI.controlled_equipment = src
+				AI.remote_control = src
+				return FALSE
 	else
 		return ..()
 	var/mob/living/ejector = M


### PR DESCRIPTION

## About The Pull Request
Maybe its a bit scuffed. but it works. i like that better than getting a player stuck until theyre given mercy via annihilation
adds in some extra handling for if an AI fails to eject, giving them back control
makes the handling for ejecting an AI even worse
fixes a potential runtime on data core deconstruction
fixes an issue where you could get stuck unable to act in a data core by shunting whilst in a mech
## Why It's Good For The Game
bug fix good, players being unable to move bad
## Testing
loaded into mech, ejected, worked
loaded into mech, ejected on centcom, worked
loaded into mech, destroyed the last core, shunted to secondary core
loaded into mech, destroyed all cores, ejected, failed to eject and kept controls
## Changelog
:cl:
fix: AIs assuming controls of exosuits should be less likely to have a horrible catastrophe occur when ejecting.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
