### PR TITLE
Showers also apply chemicals via VAPOR method

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -244,7 +244,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/shower, (-16))
 
 /obj/machinery/shower/proc/wash_atom(atom/target)
 	target.wash(CLEAN_RAD | CLEAN_WASH)
-	reagents.expose(target, (TOUCH), SHOWER_EXPOSURE_MULTIPLIER * SHOWER_SPRAY_VOLUME / max(reagents.total_volume, SHOWER_SPRAY_VOLUME))
+	reagents.expose(target, TOUCH|VAPOR, SHOWER_EXPOSURE_MULTIPLIER * SHOWER_SPRAY_VOLUME / max(reagents.total_volume, SHOWER_SPRAY_VOLUME))
 	if(isitem(target))
 		var/obj/item/item = target
 		if(length(item.viruses))


### PR DESCRIPTION

## About The Pull Request
Showers now expose targets through both the `TOUCH` and `VAPOR` methods.
## Why It's Good For The Game
Intuitive, the shower even makes a vapor effect. ~~I spent all around trying to make a hercuri shower only for it to NOT WORK?!~~
## Testing
## Changelog
:cl:
balance: showers now also apply chems using vapor
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
