### PR TITLE
cyborg light replacer recharging is now more performant

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -16,7 +16,7 @@
 // HOW TO REFILL THE DEVICE
 //
 // It will need to be manually refilled with lights.
-// If it's part of a robot module, it will charge when the Robot is inside a Recharge Station.
+// If it's part of a robot model, it will charge when the Robot is inside a Recharge Station.
 //
 // EMAGGED FEATURES
 //

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -16,7 +16,7 @@
 // HOW TO REFILL THE DEVICE
 //
 // It will need to be manually refilled with lights.
-// If it's part of a robot model, it will charge when the Robot is inside a Recharge Station.
+// If it's part of a robot module, it will charge when the Robot is inside a Recharge Station.
 //
 // EMAGGED FEATURES
 //
@@ -50,6 +50,8 @@
 	var/uses = 10
 	/// The maximum number of lights this replacer can hold
 	var/max_uses = 20
+	/// The light replacer's charge increment (used for adding to cyborg light replacers)
+	var/charge = 1
 
 	/// Eating used bulbs gives us bulb shards. Requires BULB_SHARDS_MAXIMUM to produce a new light.
 	var/bulb_shards = 0

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -246,22 +246,21 @@
 /obj/item/lightreplacer/proc/add_uses(amount = 1)
 	uses = clamp(uses + amount, 0, max_uses)
 
+/**
+ * Increases the amount of bulb shards and converts excess bulb shards into blubs.
+ *
+ * Only provides feedback if an user is provided.
+ */
 /obj/item/lightreplacer/proc/add_shards(amount = 1, user)
 	bulb_shards += amount
 	var/new_bulbs = round(bulb_shards / BULB_SHARDS_REQUIRED)
 	if(new_bulbs > 0)
 		add_uses(new_bulbs)
 	bulb_shards = bulb_shards % BULB_SHARDS_REQUIRED
-	if(new_bulbs != 0)
+	if(new_bulbs != 0 && user)
 		to_chat(user, span_notice("\The [src] fabricates a new bulb from the broken glass it has stored. It now has [uses] uses."))
 		playsound(src.loc, 'sound/machines/ding.ogg', 50, TRUE)
 	return new_bulbs
-
-/obj/item/lightreplacer/proc/Charge(mob/user)
-	charge += 1
-	if(charge > 3)
-		add_uses(1)
-		charge = 1
 
 /obj/item/lightreplacer/proc/replace_light(obj/machinery/light/target, mob/living/user)
 	//Confirm that it's a light we're testing, because afterattack runs this for everything on a given turf and will runtime

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -49,8 +49,6 @@
 	var/uses = 10
 	/// The maximum number of lights this replacer can hold
 	var/max_uses = 20
-	/// The light replacer's charge increment (used for adding to cyborg light replacers)
-	var/charge = 1
 
 	/// Eating used bulbs gives us bulb shards. Requires BULB_SHARDS_MAXIMUM to produce a new light.
 	var/bulb_shards = 0

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -30,6 +30,7 @@
 #define GLASS_SHEET_USES 5
 #define LIGHTBULB_COST 1
 #define BULB_SHARDS_REQUIRED 4
+#define LIGHT_CHARGE_COEFF 3
 
 /obj/item/lightreplacer
 	name = "light replacer"
@@ -244,21 +245,23 @@
 /obj/item/lightreplacer/proc/add_uses(amount = 1)
 	uses = clamp(uses + amount, 0, max_uses)
 
-/**
- * Increases the amount of bulb shards and converts excess bulb shards into blubs.
- *
- * Only provides feedback if an user is provided.
- */
 /obj/item/lightreplacer/proc/add_shards(amount = 1, user)
 	bulb_shards += amount
 	var/new_bulbs = round(bulb_shards / BULB_SHARDS_REQUIRED)
 	if(new_bulbs > 0)
 		add_uses(new_bulbs)
 	bulb_shards = bulb_shards % BULB_SHARDS_REQUIRED
-	if(new_bulbs != 0 && user)
+	if(new_bulbs != 0)
 		to_chat(user, span_notice("\The [src] fabricates a new bulb from the broken glass it has stored. It now has [uses] uses."))
 		playsound(src.loc, 'sound/machines/ding.ogg', 50, TRUE)
 	return new_bulbs
+
+/// Increases the amount of charge and converts the excess into additional uses.
+/obj/item/lightreplacer/proc/charge(mob/user, coeff)
+	charge += coeff
+	if(charge > LIGHT_CHARGE_COEFF)
+		add_uses(floor(charge / LIGHT_CHARGE_COEFF))
+		charge = charge % LIGHT_CHARGE_COEFF
 
 /obj/item/lightreplacer/proc/replace_light(obj/machinery/light/target, mob/living/user)
 	//Confirm that it's a light we're testing, because afterattack runs this for everything on a given turf and will runtime
@@ -310,3 +313,4 @@
 #undef GLASS_SHEET_USES
 #undef LIGHTBULB_COST
 #undef BULB_SHARDS_REQUIRED
+#undef LIGHT_CHARGE_COEFF

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -420,9 +420,7 @@
 /obj/item/robot_model/engineering/respawn_consumable(mob/living/silicon/robot/cyborg, coeff = 1)
 	..()
 	var/obj/item/lightreplacer/light_replacer = locate(/obj/item/lightreplacer) in basic_modules
-	if(light_replacer)
-		for(var/charge in 1 to coeff)
-			light_replacer.Charge(cyborg)
+	light_replacer?.add_shards(coeff)
 
 /obj/item/robot_model/engineering/be_transformed_to(obj/item/robot_model/old_model, forced = FALSE)
 	var/datum/action/cooldown/borg_sight_vision/sight_vision_meson = new(loc)
@@ -738,9 +736,7 @@
 /obj/item/robot_model/janitor/respawn_consumable(mob/living/silicon/robot/cyborg, coeff = 1)
 	..()
 	var/obj/item/lightreplacer/light_replacer = locate(/obj/item/lightreplacer) in basic_modules
-	if(light_replacer)
-		for(var/charge in 1 to coeff)
-			light_replacer.Charge(cyborg)
+	light_replacer?.add_shards(coeff)
 
 	var/obj/item/reagent_containers/spray/cyborg_drying/drying_agent = locate(/obj/item/reagent_containers/spray/cyborg_drying) in basic_modules
 	if(drying_agent)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -420,7 +420,7 @@
 /obj/item/robot_model/engineering/respawn_consumable(mob/living/silicon/robot/cyborg, coeff = 1)
 	..()
 	var/obj/item/lightreplacer/light_replacer = locate(/obj/item/lightreplacer) in basic_modules
-	light_replacer?.add_shards(coeff)
+	light_replacer?.charge(cyborg, coeff)
 
 /obj/item/robot_model/engineering/be_transformed_to(obj/item/robot_model/old_model, forced = FALSE)
 	var/datum/action/cooldown/borg_sight_vision/sight_vision_meson = new(loc)
@@ -736,7 +736,7 @@
 /obj/item/robot_model/janitor/respawn_consumable(mob/living/silicon/robot/cyborg, coeff = 1)
 	..()
 	var/obj/item/lightreplacer/light_replacer = locate(/obj/item/lightreplacer) in basic_modules
-	light_replacer?.add_shards(coeff)
+	light_replacer?.charge(cyborg, coeff)
 
 	var/obj/item/reagent_containers/spray/cyborg_drying/drying_agent = locate(/obj/item/reagent_containers/spray/cyborg_drying) in basic_modules
 	if(drying_agent)


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/83624

Changes the way cyborg light replacers restore their charge when recharging.

## Why It's Good For The Game
More performant to do some math and determine how much charges are left over and how many uses to add.

## Testing
None.

## Changelog
:cl: Runian, Majkl-J
code: The way cyborgs restore uses for their light replacer via recharging is more performant.
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
