### PR TITLE
[FIX] Fixes a bug where damage slowdown would not properly update your movespeed.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -977,9 +977,9 @@
 	var/stamina_deficiency = stamina?.loss
 	var/highest_deficiency = max(lethal_deficiency, stamina_deficiency)
 	if(lethal_deficiency >= 40 || stamina_deficiency >= 60)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, update = FALSE, multiplicative_slowdown = highest_deficiency / 75)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, multiplicative_slowdown = highest_deficiency / 75)
 	else if(LAZYACCESS(movespeed_modification, "[/datum/movespeed_modifier/damage_slowdown]"))
-		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, update = FALSE)
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 
 /mob/living/carbon/human/pre_stamina_change(diff as num, forced)
 	. = ..()

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -20,7 +20,7 @@
 	multiplicative_slowdown = 0.75
 
 /datum/movespeed_modifier/damage_slowdown
-	blacklisted_movetypes = FLOATING|FLYING
+	blacklisted_movetypes = FLOATING
 	variable = TRUE
 
 /// Movespeed modifier applied by worn equipment.


### PR DESCRIPTION

## About The Pull Request

Fixes a bug where updating or removing damage slowdown would update the relevant modifier but not _actually_ update your movespeed on its own. This is most noticeable when regenning stamina out of damage slowdown (which is what caused me to find it) but I'm sure it had effects in other places too.

I have NO clue how this bug flew under the radar because it's pretty major and I only started noticing it recently. Which leads me to believe something else was calling update_movespeed() more often than it was supposed to, and that was probably fixed which exposed this issue. Just a theory though. In any case, now your movespeed should properly update every time your damage slowdown is updated. 

UPDATE: Yep, I found the PR that broke this. It was included in the heretic rework port, believe it or not. https://github.com/Monkestation/Monkestation2.0/pull/11198. This heretic rework PR also ported this other tg PR, but the code isn't exactly the same, which is the source of the issue: https://github.com/tgstation/tgstation/pull/91710. 

The PR removed the additional damage movespeed modification for 'flying' damage slowdown, but on monke, only that additional damage movespeed modification had update set to TRUE, whereas the regular damage slowdown had it set to FALSE. So that removed proc is what was actually updating movespeed. 

A good lesson for why we should atomize our PRs, because that would have made this much easier to spot.

In light of this im also gonna update the current regular damage slowdown to apply to flying as well, which is part of the /tg/ PR that was seemingly just not ported.

## Why It's Good For The Game

Major bug fix good. 

## Testing

Tested on localhost - movespeed changes dynamically as stamina is damaged or regens, and when above 40 the slowdown goes away on its own immediately as intended. Tested with lethal damage too, seemed to work as intended also.

## Changelog
:cl:
fix: Fixed a bug where damage slowdown would not properly update player move speed when it was supposed to. 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
