### PR TITLE
[BALANCE] [SHOULD TESTMERGE] Nerfs void chill. 

### DIFF
--- a/code/modules/antagonists/heretic/magic/void_conduit.dm
+++ b/code/modules/antagonists/heretic/magic/void_conduit.dm
@@ -93,8 +93,6 @@
 
 			if(isliving(thing_to_affect))
 				var/mob/living/affected_mob = thing_to_affect
-				if(affected_mob.can_block_magic(MAGIC_RESISTANCE))
-					continue
 				if(IS_HERETIC_OR_MONSTER(affected_mob) || HAS_TRAIT(affected_mob, TRAIT_MANSUS_TOUCHED))
 					affected_mob.apply_status_effect(/datum/status_effect/void_conduit)
 				else

--- a/code/modules/antagonists/heretic/status_effects/void_chill.dm
+++ b/code/modules/antagonists/heretic/status_effects/void_chill.dm
@@ -4,7 +4,7 @@
  */
 /datum/status_effect/void_chill
 	id = "void_chill"
-	duration = 30 SECONDS
+	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/void_chill
 	status_type = STATUS_EFFECT_REFRESH //Custom code
 	on_remove_on_mob_delete = TRUE
@@ -15,6 +15,7 @@
 	var/stack_limit = 5
 	///icon for the overlay
 	var/image/stacks_overlay
+	COOLDOWN_DECLARE(chill_purge)
 
 /datum/status_effect/void_chill/on_creation(mob/living/new_owner, new_stacks, ...)
 	. = ..()
@@ -35,11 +36,21 @@
 	owner.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, COLOR_BLUE_LIGHT)
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/void_chill)
 	owner.remove_alt_appearance("heretic_status")
-	REMOVE_TRAIT(owner, TRAIT_HYPOTHERMIC, TRAIT_STATUS_EFFECT(id))
 	UnregisterSignal(owner, COMSIG_ATOM_UPDATE_OVERLAYS)
 
 /datum/status_effect/void_chill/tick(seconds_between_ticks)
-	owner.adjust_bodytemperature(-12 * stacks * seconds_between_ticks)
+	if(owner.has_reagent(/datum/reagent/water/holywater) || owner.can_block_magic())
+		//void chill is less effective
+		owner.adjust_bodytemperature(-3 KELVIN * stacks * seconds_between_ticks)
+		if(COOLDOWN_FINISHED(src, chill_purge))
+			COOLDOWN_START(src, chill_purge, 2 SECONDS)
+			to_chat(owner, span_notice("You feel holy protection warming you up."))
+			adjust_stacks(-1)
+	else
+		owner.adjust_bodytemperature(-6 KELVIN * stacks * seconds_between_ticks)
+
+	if (stacks == 0)
+		owner.remove_status_effect(/datum/status_effect/void_chill)
 
 /datum/status_effect/void_chill/refresh(mob/living/new_owner, new_stacks, forced = FALSE)
 	. = ..()
@@ -75,8 +86,6 @@
 /datum/status_effect/void_chill/proc/adjust_stacks(new_stacks)
 	stacks = max(0, min(stack_limit, stacks + new_stacks))
 	update_movespeed(stacks)
-	if(stacks >= 5)
-		ADD_TRAIT(owner, TRAIT_HYPOTHERMIC, TRAIT_STATUS_EFFECT(id))
 
 ///Updates the movespeed of owner based on the amount of stacks of the debuff
 /datum/status_effect/void_chill/proc/update_movespeed(stacks)
@@ -90,7 +99,7 @@
 
 /datum/movespeed_modifier/void_chill
 	variable = TRUE
-	multiplicative_slowdown = 0.1
+	multiplicative_slowdown = 0.5
 
 //---- Screen alert
 /atom/movable/screen/alert/status_effect/void_chill


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PR discussion thread: https://discord.com/channels/748354466335686736/1523767079423967232

Substantially nerfs void chill. Brings back some of the nerfs that were already implemented here (https://github.com/Monkestation/Monkestation2.0/pull/7253) before the heretic rework reverted them, however, they have been adjusted somewhat.

Duration of the status effect reduced from 30s -> 10s.
Body temp loss per stack, per second reduced from 12K to 6K. 
Holy water being in your system now once again reduces body temp loss to 3K and also allows you to purge 1 stack every 2 seconds. Anti-magic of any kind does the same thing. 
Slight buff to counteract: Anti-magic no longer fully protects you from void conduits.
Void chill no longer stops all body heating at 5 stacks. 

## Why It's Good For The Game

These changes are mainly aimed at 
1) Keeping void chill effective as an AOE, spammable slow effect, while reducing its extremely high and almost unavoidable lethality. I could consider increasing the actual direct slowdown caused in order to achieve this goal as well, but from my testing I don't immediately think that is necessary. 
2) Introducing some more counterplay back to the ability, as in its current state it is basically impossible to counter. Now, there are essentially 3 counters, which vary in both availability and effectiveness: 
- Warming drinks will probably be able to prevent taking lethal damage after the fact, depending on how long your exposure was, but are definitely not going to stop you getting severely slowed. 
- Leporazine will at least _work_ to somewhat control your body temperature and can shrug off a couple stacks on its own, although it will not stop the direct slowdown component. However, it substantially loses effectiveness past more than 2 stacks. 
- Holy water or anti-magic works as the strongest countermeasure, but they wont entirely negate its effects, and after fighting for a little while in constant or re-applied chill you will still start taking serious damage and slowdown. Will help protect you more against the direct application abilities if pre-dosed or drank quickly, but not as much against conduits. 

## Testing

I did a bit of testing on a local server - holy water or anti magic substantially increases your ability to fight in chill, but you will still start taking serious slowdown and damage with longer exposures. Void chill on its own without protection still slows you quite effectively within a couple seconds, but is not so lethal anymore after expiring and wearing off, unless you were exposed for a prolonged time. Leporazine works as described as well.

However, these changes definitely need to be testmerged on the live server, to see how they interact with real combat. I am entirely open to value changes or reverting certain parts of the PR. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Duration of the void chill status effect reduced from 30s -> 10s.
balance: Body temp loss per stack, per second of void chill reduced from 12K to 6K. 
balance: Holy water being in your system now once again reduces void chill temp loss to 3K per stack, per second and also allows you to purge 1 stack every 2 seconds. Anti-magic of any kind does the same thing. 
balance: Anti-magic no longer fully protects you from void conduits.
balance: Void chill no longer stops all body heating at 5 stacks. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
