### PR TITLE
Adds flashbang protection to the contractor modsuit

### DIFF
--- a/monkestation/code/modules/antagonists/contractor/items/modsuit/theme.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/modsuit/theme.dm
@@ -18,7 +18,7 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	ui_theme = "syndicate"
-	inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor)
+	inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor, /obj/item/mod/module/welding/syndicate, /obj/item/mod/module/hearing_protection)
 	allowed_suit_storage = list(
 		/obj/item/flashlight,
 		/obj/item/tank/internals,


### PR DESCRIPTION

## About The Pull Request

Makes it more inline with other syndicate modsuits

## Why It's Good For The Game

Other syndicate modsuits are flashbang proof, It's not obvious that the modsuit doesn't protect you from flashbangs unless you check the modules and you'd expect it to be flashbang proof since the other modsuits the same antag can get are..

## Testing

Launched the game, spawned the modsuit and threw flashbangs in view while wearing it. works.
## Changelog
:cl:
balance: gives the contractor modsuit eye and ear protection

/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
