### PR TITLE
Moves the hypospray's draw from a mode to right click (and a runtime fix)

### DIFF
--- a/code/__DEFINES/hyposprays.dm
+++ b/code/__DEFINES/hyposprays.dm
@@ -1,6 +1,5 @@
 #define HYPO_INJECT "Inject"
 #define HYPO_SPRAY "Spray"
-#define HYPO_DRAW "Draw"
 
 #define HYPO_UPGRADE_PIERCING (1<<0)
 #define HYPO_UPGRADE_SPEED (1<<1)

--- a/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
+++ b/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
@@ -324,6 +324,10 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/hypospray/proc/draw(mob/living/user, atom/target)
+	if(vial == null)
+		balloon_alert(user, "no vial!")
+		return ITEM_INTERACT_BLOCKING
+
 	if(vial.reagents.total_volume >= vial.reagents.maximum_volume)
 		balloon_alert(user, "container full!")
 		return ITEM_INTERACT_BLOCKING

--- a/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
+++ b/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
@@ -1,7 +1,6 @@
 GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 	HYPO_INJECT = image(icon = 'icons/obj/medical/syringe.dmi', icon_state = "hypo_mode_inject"),
 	HYPO_SPRAY = image(icon = 'icons/obj/medical/syringe.dmi', icon_state = "hypo_mode_spray"),
-	HYPO_DRAW = image(icon = 'icons/obj/medical/syringe.dmi', icon_state = "hypo_mode_draw"),
 ))
 
 /obj/item/hypospray
@@ -88,8 +87,6 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 			. += span_notice("[src] is set to inject contents on application.")
 		if(HYPO_SPRAY)
 			. += span_notice("[src] is set to spray contents on application.")
-		if(HYPO_DRAW)
-			. += span_notice("[src] is set to draw on application.")
 
 /obj/item/hypospray/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	if(istype(attacking_item, /obj/item/reagent_containers))
@@ -113,16 +110,6 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 		var/obj/item/hypospray_upgrade/upgrade = attacking_item
 		upgrade.install(src, user)
 		return TRUE
-
-/obj/item/hypospray/attack_self_secondary(mob/user, list/modifiers)
-	if(user.can_perform_action(src, FORBID_TELEKINESIS_REACH|ALLOW_RESTING))
-		if("ctrl" in modifiers)
-			if(upgrade_flags & HYPO_UPGRADE_NOZZLE)
-				set_transfer_amount(user)
-				return
-			cycle_transfer_amount(user, BACKWARD)
-			return
-		unload_vial(user)
 
 /obj/item/hypospray/attack_self(mob/user, list/modifiers)
 	if(user.can_perform_action(src, FORBID_TELEKINESIS_REACH|ALLOW_RESTING))
@@ -156,14 +143,17 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 					return
 			if(HYPO_SPRAY)
 				return spray(user, target)
-			if(HYPO_DRAW)
-				if(target.reagents)
-					return draw(user, target)
-				else
-					return
+
 	else if(target.reagents || mode == HYPO_SPRAY)
 		balloon_alert(user, "no vial!")
 		return ITEM_INTERACT_BLOCKING
+
+/obj/item/hypospray/interact_with_atom_secondary(atom/target, mob/living/user, list/modifiers)
+	if(target.reagents)
+		return draw(user, target)
+	else
+		return
+
 
 /obj/item/hypospray/proc/cycle_transfer_amount(mob/user, direction = FORWARD)
 	var/list_len = length(possible_transfer_amounts)

--- a/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
+++ b/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
@@ -140,8 +140,6 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 			if(HYPO_INJECT)
 				if(target.reagents)
 					return inject(user, target)
-				else
-					return
 			if(HYPO_SPRAY)
 				return spray(user, target)
 
@@ -325,7 +323,7 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/hypospray/proc/draw(mob/living/user, atom/target)
-	if(vial == null)
+	if(!vial)
 		balloon_alert(user, "no vial!")
 		return ITEM_INTERACT_BLOCKING
 

--- a/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
+++ b/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
@@ -69,9 +69,10 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 	. = ..()
 	if(vial)
 		. += span_notice("[vial] has [vial.reagents.total_volume]u remaining. You can [EXAMINE_HINT("R-click")] the hypospray in your active hand to remove a vial, or [EXAMINE_HINT("click")] it while it is in your offhand to remove a vial")
+		. += span_notice("[EXAMINE_HINT("right click")] to draw from a container or take a blood sample from a person.")
 	else
 		. += span_notice("It has no container loaded in. You can [EXAMINE_HINT("click")] with a vial to load it.")
-	. += span_notice("Currently injects [transfer_amount]u. [EXAMINE_HINT("ctrl click")] to change the transfer amount.")
+	. += span_notice("Currently transfers [transfer_amount]u. [EXAMINE_HINT("ctrl click")] to change the transfer amount.")
 	if(upgrade_flags & HYPO_UPGRADE_PIERCING)
 		. += span_notice("[src] has a polycarbonate diamond tipped needle, allowing it to pierce thick clothing.")
 	if(upgrade_flags & HYPO_UPGRADE_SPEED)


### PR DESCRIPTION

## About The Pull Request

What the title says, also fixed a runtime that happens when you try to draw from a container with no vial

## Why It's Good For The Game

Having to switch modes to draw from containers makes the hypospray a bit annoying to use. This makes it a bit nicer.

(also bug fixes good!)

## Testing

Loaded the game, Used hypospray with vials, without vials, drew blood from spawned humans injected them with chems, sprayed them, everything works.

## Changelog
:cl:
qol: Moved the hypospray's draw function from a mode to right click
fix: Fixed a runtime that happens when you try to draw from a container with no vial in the hypospray

/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
