### PR TITLE
gives traitors access to microbombs

### DIFF
--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -78,3 +78,11 @@
 	desc = "An implant and firing pin that allows you restrict any pin weapon to those with the implant."
 	item = /obj/item/storage/box/syndie_kit/weapons_auth
 	cost = 2
+
+/datum/uplink_item/implants/microbomb
+	name = "Microbomb Implant"
+	desc = "An implant injected into the body, and later activated either manually or automatically upon death. \
+			The more implants inside of you, the higher the explosive power. \
+			This will permanently destroy your body, however."
+	item = /obj/item/storage/box/syndie_kit/imp_microbomb
+	cost = 2

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -770,15 +770,6 @@
 	surplus = 40 //monkestation edit: from 0 to 40
 	purchasable_from = UPLINK_NUKE_OPS
 
-/datum/uplink_item/implants/microbomb
-	name = "Microbomb Implant"
-	desc = "An implant injected into the body, and later activated either manually or automatically upon death. \
-			The more implants inside of you, the higher the explosive power. \
-			This will permanently destroy your body, however."
-	item = /obj/item/storage/box/syndie_kit/imp_microbomb
-	cost = 2
-	purchasable_from = UPLINK_NUKE_OPS
-
 /datum/uplink_item/implants/macrobomb
 	name = "Macrobomb Implant"
 	desc = "An implant injected into the body, and later activated either manually or automatically upon death. \


### PR DESCRIPTION

## About The Pull Request
title

## Why It's Good For The Game
probably not but it's funny. if someone wants to blow all their TC and stroll into somewhere important while obliterating themself so be it. 

## Changelog

:cl:
add: gave traitors access to microbomb implants in their uplink.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

