### PR TITLE
Adds mining tools to dimensional gloves

### DIFF
--- a/monkestation/code/modules/clothing/gloves/gloves.dm
+++ b/monkestation/code/modules/clothing/gloves/gloves.dm
@@ -103,6 +103,11 @@
 			/obj/item/switchblade,
 			/obj/item/cane,
 			/obj/item/highfrequencyblade,
+			/obj/item/kinetic_crusher,
+			/obj/item/resonator,
+			/obj/item/pickaxe,
+			/obj/item/shovel,
+			/obj/item/trench_tool,
 		),
 		cant_hold_list = list(
 			/obj/item/gun/magic, // no magic


### PR DESCRIPTION

## About The Pull Request
Adds kinetic crushers and other mining tools to the dimensional gloves.
## Why It's Good For The Game
For the miner traitors who want to larp.
## Testing
## Changelog
:cl:
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
