### PR TITLE
Cleans up welder code + allows them to have better fuel

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -73,7 +73,7 @@
 /obj/item/weldingtool/update_overlays()
 	. = ..()
 	if(change_icons)
-		var/ratio = get_fuel() / max_fuel
+		var/ratio = reagents.total_volume / max_fuel
 		ratio = CEILING(ratio*4, 1) * 25
 		. += "[initial(icon_state)][ratio]"
 	if(welding)
@@ -82,19 +82,14 @@
 
 /obj/item/weldingtool/process(seconds_per_tick)
 	if(welding)
-		force = 15
-		damtype = BURN
-		use(TRUE)
-		update_appearance()
+		use(1)
 
 	//Welders left on now use up fuel, but lets not have them run out quite that fast
 	else
-		force = 3
-		damtype = BRUTE
-		update_appearance()
 		if(!can_off_process)
 			STOP_PROCESSING(SSobj, src)
 		return
+	update_appearance()
 
 	//This is to start fires. process() is only called if the welder is on.
 	open_flame()
@@ -105,7 +100,17 @@
 	return FIRELOSS
 
 /obj/item/weldingtool/screwdriver_act(mob/living/user, obj/item/tool)
-	flamethrower_screwdriver(tool, user)
+	if(welding)
+		to_chat(user, span_warning("Turn it off first!"))
+		return ITEM_INTERACT_FAILURE
+	status = !status
+	if(status)
+		to_chat(user, span_notice("You resecure [src] and close the fuel tank."))
+		reagents.flags &= ~(OPENCONTAINER)
+	else
+		to_chat(user, span_notice("[src] can now be attached, modified, and refuelled."))
+		reagents.flags |= OPENCONTAINER
+	add_fingerprint(user)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/weldingtool/attackby(obj/item/tool, mob/user, params)
@@ -194,11 +199,6 @@
 	switched_on(user)
 	update_appearance()
 
-/obj/item/weldingtool/proc/handle_fuel_and_temps(used = 0, mob/living/user)
-	use(used)
-	var/turf/location = get_turf(user)
-	location.hotspot_expose(700, 50, 1)
-
 /// Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
 	return reagents.get_reagent_amount(/datum/reagent/fuel)
@@ -228,7 +228,7 @@
 
 /// Turns off the welder if there is no more fuel (does this really need to be its own proc?)
 /obj/item/weldingtool/proc/check_fuel(mob/user)
-	if(get_fuel() <= 0 && welding)
+	if(get_fuel() < 1 && welding)
 		set_light_on(FALSE)
 		switched_on(user)
 		update_appearance()
@@ -268,7 +268,13 @@
 
 /obj/item/weldingtool/examine(mob/user)
 	. = ..()
-	. += "It contains [get_fuel()] unit\s of fuel out of [max_fuel]."
+	. += "It contains [reagents.total_volume] unit\s of fuel out of [max_fuel]."
+	if(status)
+		. += span_notice("Looks like the fuel tank is currently secured firmly in-place.")
+		. += span_notice("You could use a [span_bold("Screwdriver")] on it to allow for attaching, modifying and using unique fuel.")
+	else
+		. += span_notice("Looks like the fuel tank is loose, allowing for modifying its contents freely and attaching or modifying it.")
+		. += span_notice("You could use a [span_bold("Screwdriver")] on it to secure it in-place.")
 
 /obj/item/weldingtool/get_temperature()
 	return welding * heat
@@ -288,20 +294,6 @@
 	else
 		to_chat(user, span_warning("You need more welding fuel to complete this task!"))
 		return FALSE
-
-/// Ran when the welder is attacked by a screwdriver.
-/obj/item/weldingtool/proc/flamethrower_screwdriver(obj/item/tool, mob/user)
-	if(welding)
-		to_chat(user, span_warning("Turn it off first!"))
-		return
-	status = !status
-	if(status)
-		to_chat(user, span_notice("You resecure [src] and close the fuel tank."))
-		reagents.flags &= ~(OPENCONTAINER)
-	else
-		to_chat(user, span_notice("[src] can now be attached, modified, and refuelled."))
-		reagents.flags |= OPENCONTAINER
-	add_fingerprint(user)
 
 /// First step of building a flamethrower (when a welder is attacked by rods)
 /obj/item/weldingtool/proc/flamethrower_rods(obj/item/tool, mob/user)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -205,10 +205,8 @@
 		return FALSE
 
 	if(get_fuel() >= used || passive)
-		if(reagents.remove_reagent(/datum/reagent/napalm, used * 0.5))
-			check_fuel()
-			return TRUE
-		reagents.remove_reagent(/datum/reagent/fuel, used)
+		if(!reagents.remove_reagent(/datum/reagent/napalm, used * 0.5))
+			reagents.remove_reagent(/datum/reagent/fuel, used)
 		check_fuel()
 		return TRUE
 	else
@@ -226,7 +224,7 @@
 
 /// Turns off the welder if there is no more fuel (does this really need to be its own proc?)
 /obj/item/weldingtool/proc/check_fuel(mob/user)
-	if(get_fuel() < 1 && welding)
+	if(get_fuel() <= 0 && welding)
 		set_light_on(FALSE)
 		switched_on(user)
 		update_appearance()

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -81,17 +81,12 @@
 
 
 /obj/item/weldingtool/process(seconds_per_tick)
-	if(welding)
-		use(1)
-
-	//Welders left on now use up fuel, but lets not have them run out quite that fast
-	else
+	if(!welding)
 		if(!can_off_process)
 			STOP_PROCESSING(SSobj, src)
 		return
-	update_appearance()
 
-	//This is to start fires. process() is only called if the welder is on.
+	use(1, TRUE)
 	open_flame()
 
 
@@ -205,11 +200,11 @@
 
 
 /// Uses fuel from the welding tool.
-/obj/item/weldingtool/use(used = 0)
+/obj/item/weldingtool/use(used = 0, passive = FALSE)
 	if(!..() || !isOn() || !check_fuel())
 		return FALSE
 
-	if(get_fuel() >= used)
+	if(get_fuel() >= used || passive)
 		if(reagents.remove_reagent(/datum/reagent/napalm, used * 0.5))
 			check_fuel()
 			return TRUE

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -102,7 +102,7 @@
 /obj/item/weldingtool/screwdriver_act(mob/living/user, obj/item/tool)
 	if(welding)
 		to_chat(user, span_warning("Turn it off first!"))
-		return ITEM_INTERACT_FAILURE
+		return ITEM_INTERACT_BLOCKING
 	status = !status
 	if(status)
 		to_chat(user, span_notice("You resecure [src] and close the fuel tank."))
@@ -201,7 +201,7 @@
 
 /// Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
-	return reagents.get_reagent_amount(/datum/reagent/fuel)
+	return reagents.get_multiple_reagent_amounts(list(/datum/reagent/fuel, /datum/reagent/napalm))
 
 
 /// Uses fuel from the welding tool.
@@ -210,6 +210,9 @@
 		return FALSE
 
 	if(get_fuel() >= used)
+		if(reagents.remove_reagent(/datum/reagent/napalm, used * 0.5))
+			check_fuel()
+			return TRUE
 		reagents.remove_reagent(/datum/reagent/fuel, used)
 		check_fuel()
 		return TRUE
@@ -271,10 +274,14 @@
 	. += "It contains [reagents.total_volume] unit\s of fuel out of [max_fuel]."
 	if(status)
 		. += span_notice("Looks like the fuel tank is currently secured firmly in-place.")
-		. += span_notice("You could use a [span_bold("Screwdriver")] on it to allow for attaching, modifying and using unique fuel.")
+		. += span_notice("You could use a [span_bold("screwdriver")] on it to allow for attaching, modifying and accessing the fuel.")
 	else
 		. += span_notice("Looks like the fuel tank is loose, allowing for modifying its contents freely and attaching or modifying it.")
-		. += span_notice("You could use a [span_bold("Screwdriver")] on it to secure it in-place.")
+		. += span_notice("You could use a [span_bold("screwdriver")] on it to secure it in-place.")
+
+/obj/item/weldingtool/examine_more(mob/user)
+	. = ..()
+	. += span_notice("You think replacing its fuel with napalm could make the flames last a lot longer.")
 
 /obj/item/weldingtool/get_temperature()
 	return welding * heat

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -205,8 +205,8 @@
 		return FALSE
 
 	if(get_fuel() >= used || passive)
-		if(!reagents.remove_reagent(/datum/reagent/napalm, used * 0.5))
-			reagents.remove_reagent(/datum/reagent/fuel, used)
+		if(!reagents.remove_reagent(/datum/reagent/fuel, used))
+			reagents.remove_reagent(/datum/reagent/napalm, used * 0.5)
 		check_fuel()
 		return TRUE
 	else


### PR DESCRIPTION

## About The Pull Request

- Makes it so welders can have napalm as 2x longer lasting fuel compared to welding fuel
- Adds examine text that specifically tells you that you can put different chems in the welding tool using a screwdriver
- Fixes welders being able to be infinitelly on by just giving them non-whole amounts of fuel
- Made it so welding torches no longer show fuel on their gauge, instead they show how much reagents they have in them
- Cleaned up some unnecessary code in `process()`
- `flamethrower_screwdriver()` was moved to `screwdriver_act()`, `handle_fuel_and_temps()` was removed

## Why It's Good For The Game

> Makes it so welders can have napalm as 2x longer lasting fuel compared to welding fuel
- Its a small boost but i think its neat for flavor/interaction with chemistry to make your life easier pre-experimental tools
> Adds examine text that specifically tells you that you can put different chems in the welding tool using a screwdriver
- I doubt more than 2-3 people knew about being able to put non-welding fuel chems into the welder. So yeah
> Fixes welders being able to be infinitelly on by just giving them non-whole amounts of fuel
- Yeah apparently nobody knowing you can put different chems in a welder made this never be found
> Made it so welding torches no longer show fuel on their gauge, instead they show how much reagents they have in them
- I consider this a bugfix, a welder should not be giving away that you put plasma in it because "1/20 fuel left, cant refuel!"
> Cleaned up some unnecessary code in `process()`
- Idk why we set our force and other stuff every tick when we have procs for the torch turning off/on
> `flamethrower_screwdriver()` was moved to `screwdriver_act()`, `handle_fuel_and_temps()` was removed
-  `flamethrower_screwdriver()` was just `screwdriver_act()`, skip the proc overhead. Second proc is a relic and not used.

## Testing

le napalm welder burning on the right whilst the left one ran out

<img width="271" height="203" alt="image" src="https://github.com/user-attachments/assets/c47228a3-e3eb-4102-9d69-cd3cfa69f9e2" />

The examine text (slightly old version, ya get the idea)

<img width="552" height="324" alt="image" src="https://github.com/user-attachments/assets/7a2ef043-2111-4c37-b80b-edec06b6de23" />

## Changelog

:cl:
add: Added napalm being able to be put into welders as long-lasting fuel
qol: The welding tool now has text explaining it can be screwdrivered in examine (and that screwdrivering it allows you to put chems into it)
fix: Welding tools can no longer infinitelly burn when you put integer amounts of fuel into them
fix: Welding tools now show how many reagents they have with their gauge instead of just the fuel amount
/:cl:

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
