### PR TITLE
security incendiary ammo doesn't leave fire trails but stack more fire

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -57,7 +57,7 @@
 /obj/projectile/bullet/incendiary/shotgun/no_trail
 	name = "precision incendiary slug"
 	damage = 35
-	fire_stacks = 5
+	fire_stacks = 6
 	leaves_fire_trail = FALSE
 
 /obj/projectile/bullet/pellet

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -57,6 +57,7 @@
 /obj/projectile/bullet/incendiary/shotgun/no_trail
 	name = "precision incendiary slug"
 	damage = 35
+	fire_stacks = 5
 	leaves_fire_trail = FALSE
 
 /obj/projectile/bullet/pellet

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -55,7 +55,8 @@
 /obj/projectile/bullet/incendiary/c46x30mm
 	name = "4.6x30mm incendiary bullet"
 	damage = 10
-	fire_stacks = 1
+	fire_stacks = 4
+	leaves_fire_trail = FALSE
 
 /obj/projectile/bullet/c46x30mm/salt
 	name = "4.6x30mm saltshot bullet"

--- a/code/modules/research/designs/autolathe/security_designs.dm
+++ b/code/modules/research/designs/autolathe/security_designs.dm
@@ -155,7 +155,7 @@
 	id = "incendiary_slug"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*2)
-	build_path = /obj/item/ammo_casing/shotgun/incendiary
+	build_path = /obj/item/ammo_casing/shotgun/incendiary/no_trail
 	category = list(
 		RND_CATEGORY_HACKED,
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO,


### PR DESCRIPTION

## About The Pull Request
title

mainly affects WT and incendiary slugs

## Why It's Good For The Game
the subsystem that dispels hotspots eats shit often on highpop rounds so the fire trails stick around for minutes which is annoying and unfun to deal with


## Changelog

:cl:
balance: incendiary slugs and WT ammo don't leave fire trails but stack more fire on the target to compensate.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

