### PR TITLE
incendiary bullet fire trails auto-delete in 2.5 seconds

### DIFF
--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -19,8 +19,9 @@
 		return
 	var/turf/location = get_turf(src)
 	if(location)
-		new /obj/effect/hotspot(location)
+		var/obj/effect/hotspot/fire_hotspot = new /obj/effect/hotspot(location)
 		location.hotspot_expose(700, 50, 1)
+		QDEL_IN(fire_hotspot, 2.5 SECONDS)
 
 /// Incendiary bullet that more closely resembles a real flamethrower sorta deal, no visible bullet, just flames.
 /obj/projectile/bullet/incendiary/fire


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
atmos lags out and hotspots dont delete on time leading to annoying unfun hotspots that last minutes.

## Changelog

:cl:
fix: incendiary bullet fire trails auto-delete in 2.5 seconds to mitigate hangtime from lag.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

