### PR TITLE
makes mute and fluffy tongue incompatible 

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -36,8 +36,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Social Anxiety", "Mute"),
 		list("Mute", "Soft-Spoken"),
 		list("Stormtrooper Aim", "Big Hands"),
-		list("Common Second Language", "Foreigner"), //monkestation edit 2, re-added but replaced bilingual with csl
-		//MONKESTATION ADDITION START
+		list("Common Second Language", "Foreigner"),
 		list("Listener", "Uncommon"),
 		list("Outsider", "Uncommon"),
 		list("Listener", "Mute"),
@@ -58,7 +57,6 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Cyborg Pre-screened dogtag", "Unborgable"),
 		list("Revival Blacklist", "Uncloneable Neurons"),
 		list("Mute", "Fluffy Tongue")
-		//MONKESTATION ADDITION END
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -57,6 +57,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Prosthetic Limb", "Monoplegic"),
 		list("Cyborg Pre-screened dogtag", "Unborgable"),
 		list("Revival Blacklist", "Uncloneable Neurons"),
+		list("Mute", "Fluffy Tongue")
 		//MONKESTATION ADDITION END
 	)
 

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -57,7 +57,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Prosthetic Limb", "Monoplegic"),
 		list("Cyborg Pre-screened dogtag", "Unborgable"),
 		list("Revival Blacklist", "Uncloneable Neurons"),
-		list("Mute", "Fluffy Tongue")
+		list("Mute", "Fluffy Tongue"),
 		//MONKESTATION ADDITION END
 	)
 


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
quirk that affects speech probably shouldnt be allowed with quirk that prevents speech

signer is unaffected by fluffy tongue anyways so it just does nothing
## Testing
tested in local host it works
## Changelog
:cl: Cujo
add: Mute and Fluffy Tongue are now incompatible quirks
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
