### PR TITLE
ACTUALLY removes the duplicate drain from tramstation medical 

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -26744,7 +26744,6 @@
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/structure/drain,
-/obj/structure/drain,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "hpE" = (


### PR DESCRIPTION

## About The Pull Request
removes one of the two drains that are ontop of eachother
## Why It's Good For The Game
mapping bug. i guess there was two duplicate drains on the map and i just assumed i removed it last time (hint: i didnt) 
## Testing
test?
## Changelog
:cl: Cujo
del: Removes the duplicate shower drain from Tramstation Medical for real this time
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
