### PR TITLE
adjusts taser select sounds + miner salve doesn't give a damage overlay

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -4,22 +4,24 @@
 	fire_sound = 'sound/weapons/taser.ogg'
 	e_cost = LASER_SHOTS(5.25, STANDARD_CELL_CHARGE)
 	harmful = FALSE
-	select_sound = 'sound/weapons/gun/energy/egun_toggle_taser.ogg'
+	select_sound = 'sound/weapons/gun/energy/egun_toggle_noammo.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/yellow
 
 /obj/item/ammo_casing/energy/electrode/hos
 	e_cost = LASER_SHOTS(6.25, STANDARD_CELL_CHARGE * 1.2)
+	select_sound = 'sound/weapons/gun/energy/egun_toggle_taser.ogg'
 
 /obj/item/ammo_casing/energy/electrode/spec
 	e_cost = LASER_SHOTS(10.25, STANDARD_CELL_CHARGE)
-	select_sound = 'sound/weapons/gun/energy/egun_toggle_noammo.ogg'
 
 /obj/item/ammo_casing/energy/electrode/gun
 	fire_sound = 'sound/weapons/gun/pistol/shot.ogg'
 	e_cost = LASER_SHOTS(10.25, STANDARD_CELL_CHARGE)
+	select_sound = 'sound/weapons/gun/energy/egun_toggle_taser.ogg'
 
 /obj/item/ammo_casing/energy/electrode/old
 	e_cost = LASER_SHOTS(2.25, STANDARD_CELL_CHARGE)
+	select_sound = 'sound/weapons/gun/energy/egun_toggle_taser.ogg'
 
 /obj/item/ammo_casing/energy/disabler
 	projectile_type = /obj/projectile/beam/disabler

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -315,7 +315,7 @@
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
 	ph = 2.6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_AFFECTS_WOUNDS
-	metabolized_traits = list(TRAIT_ANALGESIA)
+	metabolized_traits = list(TRAIT_ANALGESIA, TRAIT_NO_DAMAGE_OVERLAY)
 
 /datum/reagent/medicine/mine_salve/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustBruteLoss(-0.25 * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)


### PR DESCRIPTION

## About The Pull Request
just switched the taser sounds around so it makes more sense on the advanced taser 

miner salve doesnt give a damage overlay

## Why It's Good For The Game
miner salve is supposed to mask how much health you have so im not sure why it gives a damage overlay

## Changelog

:cl:
sound: just switched the taser select sounds around so it makes more sense on the advanced taser .
fix: miner salve doesnt give a damage overlay.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

