### PR TITLE
adds a dozen mints to the snack vendor contraband section

### DIFF
--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -32,6 +32,7 @@
 	)
 	contraband = list(
 		/obj/item/food/syndicake = 6,
+		/obj/item/food/mint = 12,
 		/obj/item/food/peanuts/ban_appeal = 3,
 		/obj/item/food/candy/bronx = 1,
 	)


### PR DESCRIPTION

## About The Pull Request
title 

## Why It's Good For The Game

https://youtu.be/pXAs9pWH-to?si=uPC3ygne-qg5qPya&t=250

only other reliable way of getting it is emagging a booze dispenser.

## Changelog

:cl:
add: added a dozen mints to the snack vendor contraband section.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

