### PR TITLE
Sets slasher sighting minimum pop to 20 

### DIFF
--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/ghost_role.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/ghost_role.dm
@@ -1,8 +1,9 @@
 /datum/round_event_control/slasher
 	name = "Slasher Sighting"
 	typepath = /datum/round_event/ghost_role/slasher
-	weight = 14 // for now, disabled. prev weight of 14. max occurrances set to 0 to disable the storyteller from running the event. can still be manually done by admins as requested.
+	weight = 14
 	max_occurrences = 1
+	min_players = 20
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_SPOOKY, TAG_COMBAT, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE


### PR DESCRIPTION

## About The Pull Request
removes an unnecessary comment (slasher is not disabled so, why have it?) and sets slasher minimum pop to 20 
## Why It's Good For The Game
Changelings, nightmares, pretty much any similar antag murderbone esq antag has a minimum pop of at least 20 to roll. Slasher was for some reason exempt from this, 20 is still pretty generous and atleast gives the crew a much more fair chance against them as they can be insanely powerful.

It was additionally bumped up to be a high event instead of medium and as such should share a pop limit as many other high threat antags do. 
## Testing
compiled in local host 
## Changelog
:cl: Cujo
balance: Slasher sighting now requires a minimum of 20 pop to roll
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
