### PR TITLE
Updates cryo message to indicate that it does not permanently remove you from the round

### DIFF
--- a/monkestation/code/modules/cryopods/_cryopod.dm
+++ b/monkestation/code/modules/cryopods/_cryopod.dm
@@ -692,7 +692,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	else
 		visible_message(span_infoplain("[user] starts putting [dropped] into the cryo pod."))
 
-	to_chat(dropped, span_warning("<b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b>"))
+	to_chat(dropped, span_warning("<b>If you ghost, log out or close your client now, your character will shortly be temporarily removed from the round. You may awaken from cryosleep by dragging yourself back into the cryopod after 15 minutes have passed.</b>"))
 
 	log_admin("[key_name(dropped)] entered a stasis pod.")
 	message_admins("[key_name_admin(dropped)] entered a stasis pod. [ADMIN_JMP(src)]")


### PR DESCRIPTION

## About The Pull Request
changes cryo message
## Why It's Good For The Game
It's not accurate. it doesn't permanently remove you, it's temporary, it should reflect that. also gives a little tip on how to emerge from cryo
## Testing
tested on localhost
<img width="631" height="57" alt="image" src="https://github.com/user-attachments/assets/2cc23d8c-31fb-4442-a90e-6113163a7c05" />

## Changelog
:cl: Cujo
qol: Updated the cryo message to reflect that it does not permanently remove you from the round, and gives a hint on how to emerge from cryo. 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
