### PR TITLE
Smithed weapons can now fit in dimensional gloves

### DIFF
--- a/monkestation/code/modules/clothing/gloves/gloves.dm
+++ b/monkestation/code/modules/clothing/gloves/gloves.dm
@@ -91,6 +91,7 @@
 			/obj/item/throwing_star,
 			/obj/item/shield,
 			/obj/item/spear,
+			/obj/item/smithed_part/weapon_part,
 			/obj/item/dualsaber,
 			/obj/item/fireaxe,
 			/obj/item/flamethrower,


### PR DESCRIPTION
## About The Pull Request
Bugfix
## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: Smithed weapons can now fit into dimensional gloves
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
