### PR TITLE
You can now do surgery on robotic limbs while the target is standing up

### DIFF
--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -309,7 +309,7 @@
 		target.balloon_alert(user, "not the right type of limb!")
 		return
 
-	if (IS_IN_INVALID_SURGICAL_POSITION(target, surgery))
+	if (IS_IN_INVALID_SURGICAL_POSITION(target, surgery) && surgery.requires_bodypart_type == 1)
 		target.balloon_alert(user, "patient is not lying down!")
 		return
 

--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -309,7 +309,7 @@
 		target.balloon_alert(user, "not the right type of limb!")
 		return
 
-	if (IS_IN_INVALID_SURGICAL_POSITION(target, surgery) && surgery.requires_bodypart_type == 1)
+	if (IS_IN_INVALID_SURGICAL_POSITION(target, surgery) && BODYTYPE_ORGANIC)
 		target.balloon_alert(user, "patient is not lying down!")
 		return
 


### PR DESCRIPTION

## About The Pull Request
check if a limb is organic AND the target is laying down before giving the "patient must lay down" thing
## Why It's Good For The Game
Imagine how cool you will look when you do surgery on your arm or whatever standing up. No more laying on the floor like a loser. YOu can stand up and look COOL! 

It works for self surgery on robotic limbs and working on others. you forgo the location speed modifier entirely so it's only for looks. Shouldn't cause any issues with wounds since it's a robotic limb, and combat mode still allows you to stab yourself even if you have an active surgery. 
## Testing
Tested on a local host, can do surgery while I'm standing up on robotic limbs. No change to organics
## Changelog
:cl: Cujo
add: You can now do surgery on robotic limbs while the target is standing up.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
