### PR TITLE
Crushing lootbox debt pr

### DIFF
--- a/monkestation/code/modules/client/preferences/inventory.dm
+++ b/monkestation/code/modules/client/preferences/inventory.dm
@@ -33,7 +33,7 @@
 	if(!ckey || !SSdbcore.IsConnected())
 		return FALSE
 
-	if(!max_round_coins && respects_roundcap)
+	if(amount > 0 && (!max_round_coins && respects_roundcap))
 		to_chat(parent, "You've hit the Monkecoin limit for this shift, please try again next shift.")
 		return
 

--- a/monkestation/code/modules/trading/lootbox_buying.dm
+++ b/monkestation/code/modules/trading/lootbox_buying.dm
@@ -10,7 +10,7 @@
 
 	var/negative_loot = prefs.lootboxes_owned < 0
 	if(negative_loot)
-		message_admins("[key_name_admin(src)] had negative loot boxes, it's possible they have already bought multiple for free! They have a debt of [prefs.lootboxes_owned].")
+		message_admins("[key_name_admin(src)] has negative loot boxes, it's possible they have already bought multiple for free! They have a debt of [prefs.lootboxes_owned].")
 		logger.Log(LOG_CATEGORY_META, "[src] had negative loot boxes!")
 		to_chat(src, span_warning("You currently have negative lootboxes ([prefs.lootboxes_owned])! You will need to buy these back before you can open more."))
 

--- a/monkestation/code/modules/trading/lootbox_buying.dm
+++ b/monkestation/code/modules/trading/lootbox_buying.dm
@@ -1,47 +1,53 @@
-/client/var/lootbox_prompt = FALSE
-
 /client/proc/try_open_or_buy_lootbox()
-	if(!prefs || lootbox_prompt)
+	if(!prefs)
 		return
+
+	var/has_loot_boxes = (prefs.lootboxes_owned > 0)
+
 	if(isnewplayer(mob))
-		to_chat(src, span_warning("You can't [prefs.lootboxes_owned ? "open" : "buy"] a lootbox here! Observe or spawn in first, then try again."))
+		to_chat(src, span_warning("You can't [has_loot_boxes ? "open" : "buy"] a lootbox here! Observe or spawn in first, then try again."))
 		return
-	if(!prefs.lootboxes_owned)
-		lootbox_prompt = TRUE
+
+	var/negative_loot = prefs.lootboxes_owned < 0
+	if(negative_loot)
+		message_admins("[key_name_admin(src)] had negative loot boxes, it's possible they have already bought multiple for free! They have a debt of [prefs.lootboxes_owned].")
+		logger.Log(LOG_CATEGORY_META, "[src] had negative loot boxes!")
+		to_chat(src, span_warning("You currently have negative lootboxes ([prefs.lootboxes_owned])! You will need to buy these back before you can open more."))
+
+	if(!has_loot_boxes)
 		buy_lootbox()
-	if(prefs.lootboxes_owned)
-		open_lootbox()
+		return
+
+	open_lootbox()
 
 /client/proc/buy_lootbox()
 	if(!prefs)
-		lootbox_prompt = FALSE
 		return
+
 	if(!prefs.has_coins(LOOTBOX_COST))
 		to_chat(src, span_warning("You do not have enough Monkecoins to buy a lootbox!"))
-		lootbox_prompt = FALSE
 		return
-	switch(tgui_alert(src, "Would you like to purchase a lootbox? 5K", "Buy a lootbox!", list("Yes", "No")))
-		if("Yes")
-			attempt_lootbox_buy()
-			lootbox_prompt = FALSE
-		else
-			lootbox_prompt = FALSE
-			return
+
+	var/choice = tgui_alert(src, "Would you like to purchase a lootbox? 5K", "Buy a lootbox!", list("Yes", "No"))
+	if(choice != "Yes")
+		return
+
+	attempt_lootbox_buy()
 
 /client/proc/attempt_lootbox_buy()
 	if(!prefs.has_coins(LOOTBOX_COST))
 		to_chat(src, span_warning("You do not have enough Monkecoins to buy a lootbox!"))
-		lootbox_prompt = FALSE
 		return
+
 	if(!prefs.adjust_metacoins(ckey, -LOOTBOX_COST, "Bought a lootbox"))
 		return
+
 	prefs.lootboxes_owned++
 	prefs.save_preferences()
 
+	to_chat(src, span_notice("Lootbox bought. You now own [prefs.lootboxes_owned] lootboxes."))
+
 /client/proc/open_lootbox()
-	message_admins("[ckey] opened a lootbox!")
-	logger.Log(LOG_CATEGORY_META, "[src] has opened a lootbox!", list("currency_left" = prefs.metacoins))
-	log_game("[key_name(src)] opened a lootbox!")
 	if(!mob)
 		return
 
@@ -49,11 +55,28 @@
 		to_chat(mob, span_warning("You can't open a lootbox here! The lootbox has been added to your inventory. Observe or spawn in first, then click the button again."))
 		return
 
-	if(!prefs.lootboxes_owned)
+	if(prefs.lootboxes_owned <= 0)
 		return
+
+	message_admins("[key_name_admin(src)] opened a lootbox!")
+	logger.Log(LOG_CATEGORY_META, "[src] has opened a lootbox!", list("currency_left" = prefs.metacoins))
+	log_game("[key_name(src)] opened a lootbox!")
+
 	prefs.lootboxes_owned--
 	prefs.save_preferences()
 	mob.trigger_lootbox_on_self()
+
+	to_chat(src, span_notice("Lootbox opened. You now own [prefs.lootboxes_owned] lootboxes."))
+
+/client/proc/give_lootbox(amount)
+	if(!prefs)
+		return
+
+	prefs.lootboxes_owned += amount
+	prefs.save_preferences()
+
+	to_chat(src, span_notice("You have been given [amount] lootboxes! Open them using the escape menu."))
+	to_chat(src, span_notice("You now own [prefs.lootboxes_owned] lootboxes."))
 
 /proc/give_lootboxes_to_randoms(amount)
 	for(var/i = 1 to amount)
@@ -61,10 +84,3 @@
 		if(!mob.client)
 			continue
 		mob.client.give_lootbox(1)
-
-/client/proc/give_lootbox(amount)
-	if(!prefs)
-		return
-	prefs.lootboxes_owned += amount
-	to_chat(mob, span_notice("You have been given [amount] lootboxes! Open it using the escape menu."))
-	prefs.save_preferences()


### PR DESCRIPTION

## About The Pull Request
Protects against negative loot boxes, if you get negative loot boxes you go into debt and have to pay it off to open more.

Fixes monke coin limit applying to removals.

Removes lootbox_prompt you can't bypass the cost by opening multiple prompts and worst case it stops you from being able to ever open/buy a new crate.

fixes https://github.com/Monkestation/Monkestation2.0/issues/12112.
## Why It's Good For The Game
Muh economy
## Testing
## Changelog
:cl:
fix: Added protections against negative lootboxes, work to pay off your debt!
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
