### PR TITLE
makes dummy thicc quirk sound check prude preferences 

### DIFF
--- a/monkestation/code/datums/quirks/positive_quirks/ass.dm
+++ b/monkestation/code/datums/quirks/positive_quirks/ass.dm
@@ -39,4 +39,4 @@
 /datum/quirk/dummy_thick/proc/on_mob_move()
 	SIGNAL_HANDLER
 	if(prob(33))
-		playsound(quirk_holder, "sound/misc/clap_short.ogg", vol = 70, vary = TRUE, extrarange = 5, ignore_walls = TRUE)
+		playsound(quirk_holder, "sound/misc/clap_short.ogg", vol = 70, vary = TRUE, extrarange = 5, ignore_walls = TRUE, mixer_channel = CHANNEL_PRUDE)


### PR DESCRIPTION

## About The Pull Request
makes the sound applied by dummy thicc quirk be in CHANNEL_PRUDE so it's properly stopped by people w prude mode on 
## Why It's Good For The Game
butt related quirk should check for prude mode settings
## Testing
tested in local host it stops the sounds 
## Changelog
:cl: Cujo
fix: Dummy thicc quirk sounds now properly check prude mode settings.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
