### PR TITLE
Lowers Saya block chance

### DIFF
--- a/monkestation/code/modules/cybernetics/implant_items/weapons/mantis_blade.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/weapons/mantis_blade.dm
@@ -149,8 +149,8 @@
 	. = ..()
 	r_hand = owner.get_held_items_for_side(RIGHT_HANDS, FALSE)
 	l_hand = owner.get_held_items_for_side(LEFT_HANDS, FALSE)
-	r_hand.block_chance += 40
-	l_hand.block_chance += 40
+	r_hand.block_chance += 50
+	l_hand.block_chance += 50
 	ADD_TRAIT(owner, TRAIT_CANT_ATTACK, TRAIT_STATUS_EFFECT(id))
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/shield_blades)
 	owner.balloon_alert_to_viewers("starts blocking!")

--- a/monkestation/code/modules/cybernetics/implant_items/weapons/mantis_blade.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/weapons/mantis_blade.dm
@@ -149,8 +149,8 @@
 	. = ..()
 	r_hand = owner.get_held_items_for_side(RIGHT_HANDS, FALSE)
 	l_hand = owner.get_held_items_for_side(LEFT_HANDS, FALSE)
-	r_hand.block_chance += 65
-	l_hand.block_chance += 65
+	r_hand.block_chance += 40
+	l_hand.block_chance += 40
 	ADD_TRAIT(owner, TRAIT_CANT_ATTACK, TRAIT_STATUS_EFFECT(id))
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/shield_blades)
 	owner.balloon_alert_to_viewers("starts blocking!")


### PR DESCRIPTION

## About The Pull Request
Lowers saya block chance in defensive stance from 65 on each shield to 50 on each shield

## Why It's Good For The Game
Sayas right now are currently just insane and with two 65% block chances they have roughly a 87% block chance or a 13% chance of actually being hit, they are insanely tanky and virtually unkillable in any context you have to actually fight them.

Dropping their block chances to two 50% ups to chance to actually hit them to a 25% chance/lowers the block chance to 75% that of a desword or holding two riot shields(although riot shields can break if they block to much damage)
This is still pretty high honestly and it may need a further nerf to either its block chance or in some otherway, but hopefully makes it a little more reasonable/realistically killable.

## Testing
Yes compiles and block chances are the new ones when blocking.

## Changelog

:cl:
add: Added new mechanics or gameplay changes
balance: Saya block chance down to 50%
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

