### PR TITLE
Even More AI Fixes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -42136,7 +42136,7 @@
 	name = "Control Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms_admin,
 /turf/open/floor/iron/dark/textured,
 /area/station/tcommsat/computer)
 "nBn" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32918,6 +32918,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/ai_monitored/turret_protected/ai)
 "luE" = (

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1200,11 +1200,12 @@
 
 /mob/living/silicon/ai/forceMove(atom/destination)
 	var/turf/current_turf = get_turf(src)
+	var/turf/new_turf = get_turf(destination)
 	. = ..()
 	if(.)
 		end_multicam()
 		var/datum/ai_os/past_os = GLOB.ai_os["[current_turf.z]"]
-		if(past_os)
+		if(past_os && (current_turf.z != new_turf.z))
 			past_os.remove_ai(src)
 
 /mob/living/silicon/ai/up()

--- a/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
@@ -71,6 +71,9 @@ GLOBAL_LIST_EMPTY(data_cores)
 /obj/machinery/ai/data_core/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
 	var/datum/ai_os/old_os = GLOB.ai_os["[old_turf.z]"]
 	. = ..()
+	//z-level is the same, ignore us.
+	if(old_os == linked_os)
+		return
 	for(var/mob/living/silicon/ai/ai_contents as anything in contents)
 		old_os.remove_ai(ai_contents)
 		linked_os.add_ai(ai_contents)

--- a/code/modules/mob/living/silicon/ai/decentralized_ai.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized_ai.dm
@@ -36,7 +36,7 @@
 	if(last_used_data_core && !QDELETED(last_used_data_core))
 		if(last_used_data_core.can_transfer_ai(src, ignore_z_levels))
 			last_used_data_core.transfer_AI(src)
-			return
+			return TRUE
 	//it's gone pal
 	last_used_data_core = null
 


### PR DESCRIPTION
## About The Pull Request

Fixes AIs losing all CPU/RAM when shunting to a new data core, or having their core moved between station z-levels
Fixes AIs getting a message about failing to exit a mech when they successfully exit their mech
Fixes Meta AI core not being cooled
Fixes Box Network Admin office not being behind Tcomms Admin `access`

## Why It's Good For The Game

Closes https://github.com/Monkestation/Monkestation2.0/issues/12083
Closes https://github.com/Monkestation/Monkestation2.0/issues/12045 (I believe)
Closes https://github.com/Monkestation/Monkestation2.0/issues/12074

## Changelog

:cl:
fix: AIs no longer lose all assigned CPU & ram when shunting between data cores (or between station z-levels)
fix: Fixes AI mechs (again)
fix: [MetaStation] Fixes AI cooling
fix: [BoxStation] Fixes Network Admin office being behind general telecomms access instead of Telecomms Admin access.
/:cl: