### PR TITLE
Removes the tech-9 from the blueshield gun beacon

### DIFF
--- a/monkestation/code/modules/blueshield/gun.dm
+++ b/monkestation/code/modules/blueshield/gun.dm
@@ -10,7 +10,6 @@
 		"Unmarked Takbok Revolver Gunset" = /obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok/blueshield,
 		"Custom Hellfire Laser Rifle" = /obj/item/gun/energy/laser/hellgun/blueshield,
 		"Bogseo Submachinegun Gunset" = /obj/item/storage/toolbox/guncase/skyrat/xhihao_large_case/bogseo,
-		"Tech-9" = /obj/item/storage/toolbox/guncase/skyrat/pistol/tech_9,
 		"S.A.Y.A. Arm Defense System Cyberset" = /obj/item/storage/box/shield_blades,
 	)
 


### PR DESCRIPTION

## About The Pull Request
Title, tech-9/glocko is no longer avaliable in blueshield gun beacon.

## Why It's Good For The Game
The glocko is a insanely OP weapon with a 4 round burst doing 80 damage a burst, able to crit through even high armor at insane speeds this gun has been nerfed in the past and while it could maybe be nerfed more I feel its simply just unneeded. 

The paco already exist which this gun is a burst version of, nerfs to make it more reasonable kinda result in it just being the paco/possibly a worse paco. In terms of pistol options the blueshield also already has the takbok, which is a revolver that does 32 damage a shot being a pretty good sidearm but Im not against letting them just pick a straight up paco if they want it or some other alternatives.

Lastly, the gun itself is kinda a meme in the first place being a "glock with a switch" which it doesn't make much sense for blueshield to have a glock with a switch nor for it to be their standard weapon. Its just a bit dumb and a hehe funny that was just really OP and added with no regard for any balance really, the base idea was kinda already to far gone to really be reeled in/work even after nerfs.

## Testing
Booted up, spawned gun beacon, all well

## Changelog

:cl:
balance: blueshield no longer recieves the tech-9 as a option
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

