### PR TITLE
Removes the recoil from foam dart toy guns

### DIFF
--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -14,6 +14,8 @@
 	item_flags = NONE
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 	casing_ejector = FALSE
+	recoil = 0
+
 
 /obj/item/gun/ballistic/automatic/toy/unrestricted
 	pin = /obj/item/firing_pin
@@ -22,6 +24,7 @@
 	name = "foam force pistol"
 	desc = "A small, easily concealable toy handgun. Ages 8 and up."
 	accepted_magazine_type = /obj/item/ammo_box/magazine/toy/pistol
+	recoil = 0
 	fire_sound = 'sound/items/syringeproj.ogg'
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 
@@ -49,6 +52,7 @@
 	weapon_weight = WEAPON_LIGHT
 	pb_knockback = 0
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
+	recoil = 0
 
 /obj/item/gun/ballistic/shotgun/toy/handle_chamber(mob/living/user, empty_chamber = TRUE, from_firing = TRUE, chamber_next_round = TRUE)
 	. = ..()
@@ -88,6 +92,7 @@
 	casing_ejector = FALSE
 	clumsy_check = FALSE
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
+	recoil = 0
 
 /obj/item/gun/ballistic/automatic/c20r/toy/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_DONK)
@@ -109,6 +114,7 @@
 	casing_ejector = FALSE
 	clumsy_check = FALSE
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
+	recoil = 0
 
 /obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/firing_pin


### PR DESCRIPTION

## About The Pull Request

Removes recoil from every foam dart gun in the game

## Why It's Good For The Game

They're toy guns, it's kinda silly when the riot foam pistol has the same recoil as a real Makarov.
This doesn't really affect clown ops balance since nukies start with a skillchip that makes them not have recoil

Balance wise this only affects traitors buying the riot foam dart pistol, contractors starting with the C-20 toy version and crew buying them from imports and printing riot darts from a hacked autolathe.

## Testing

hopped on and spawned them, no recoil.

## Changelog
:cl:
balance: Foam dart guns no longer have recoil.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
