### PR TITLE
Small atmospherics arm buff

### DIFF
--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
@@ -147,9 +147,9 @@
 	desc = "A set of atmospheric tools hidden behind a concealed panel on the user's arm."
 	icon_state = "toolkit_atmosph"
 	items_to_create = list(
-		/obj/item/extinguisher,
-		/obj/item/analyzer,
-		/obj/item/crowbar,
+		/obj/item/extinguisher/advanced,
+		/obj/item/analyzer/ranged,
+		/obj/item/crowbar/cyborg,
 		/obj/item/holosign_creator/atmos
 	)
 


### PR DESCRIPTION

## About The Pull Request
Changes the fire extinguisher, and gas analyzer to their advanced versions and replaces crowbar with cyborg version
## Why It's Good For The Game
Currently this probably sits at the most underwhelming toolarm, at least barber gives you baldium/ways to spread reagents. So a light pick me up.  I dont expect we'll see anyone start going out of their way for it but it gives some minor love.
The only way I see that happening if It got some destructive tool akin to the fire axe. Which, does not seem a great idea. Maybe for the emag version, but not the base.
## Testing
## Changelog
:cl:
balance: Replaces the atmospherics arm toolset with Advanced fire extinguisher, ranged gas analyzer, and cyborg crowbar from their normal versions
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
