### PR TITLE
Makes megafauna move around when idle (except for those with arena's)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -33,6 +33,7 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	life_subsystem_type = /datum/controller/subsystem/mobs/megafauna
+	turns_per_move = 10
 	/// Crusher loot dropped when the megafauna is killed with a crusher
 	var/list/crusher_loot
 	/// Achievement given to surrounding players when the megafauna is killed
@@ -202,7 +203,12 @@
 // MONKESTATION EDIT ADDITION START
 // This on purpose does not call parent, do not make it call parent, we literally use NOTHING from our parents, we're fine.
 /mob/living/simple_animal/hostile/megafauna/Life(seconds_per_tick, times_fired)
-	if(AIStatus != AI_IDLE || !COOLDOWN_FINISHED(src, rawr_cooldown))
+	if(AIStatus != AI_IDLE)
+		return
+
+	handle_automated_movement()
+
+	if(!COOLDOWN_FINISHED(src, rawr_cooldown))
 		return
 
 	var/list/targets = ListTargets()


### PR DESCRIPTION

(Definetelly needs a TM)

## About The Pull Request

- Fixes megafauna's not moving
- Bumps megafauna's movespeed to 1 tile every 20 seconds when idle

Note: Hierophant only moves when angered, it stays in its arena otherwise
Wendigo/Blood-drunk/Clockwork knight never wander. This is just what was defined before the PR

## Why It's Good For The Game

> Fixes megafauna's not moving
- Technically a bug, technically. There's been quite a bit of complaints about megafauna camping bodies, i've waited for this PR because someone else said they *might* make it and then i forgot about it so now its here.
> Bumps megafauna's movespeed to 1 tile every 20 seconds when idle
- They are currently set at 2 seconds per 1 tile, bit too fast imo

## Testing

I stared at a megafauna for 1 minute, it indeed did move every 20 seconds

## Changelog

:cl:
fix: Megafauna will now move when idle every 20 seconds
/:cl:

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
