### PR TITLE
makes walls as tough as reinforced airlocks

### DIFF
--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -841,7 +841,7 @@
 	var/living_collision_dam = 20
 	var/object_punched_damage = 400
 	var/object_collision_damage = 120
-	var/wall_collision_damage = 300
+	var/wall_collision_damage = 600
 
 /datum/action/cooldown/spell/touch/buster/megabuster/before_cast(atom/cast_on)
 	. = ..()

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -13,8 +13,8 @@
 	sheet_amount = 1
 	girder_type = /obj/structure/girder/reinforced
 	explosive_resistance = 2
-	max_integrity = 600 //Monkestation edit
-	damage_deflection = 75 // can't be damaged with most conventional weapons or tools Monkestation edit
+	max_integrity = 900
+	damage_deflection = 75 // can't be damaged with most conventional weapons or tools
 	rad_insulation = RAD_HEAVY_INSULATION
 	rust_resistance = RUST_RESISTANCE_REINFORCED
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall. also indicates the temperature at wich the wall will melt (currently only able to melt with H/E pipes)
@@ -228,10 +228,9 @@
 	return ..()
 
 /turf/closed/wall/r_wall/syndicate
-	//MONKESTATION EDIT - Swapped original name and description into the hull subtype.
+	// Swapped original name and description into the hull subtype.
 	name = "reinforced plastitanium wall"
 	desc = "A reinforced, ominous wall made of an alloy of plasma and titanium, with plasteel reinforcement layered underneath. Good luck getting through this."
-	//END OF EDIT
 	icon = 'icons/turf/walls/plastitanium_wall.dmi'
 	icon_state = "plastitanium_wall-0"
 	base_icon_state = "plastitanium_wall"
@@ -263,7 +262,7 @@
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	fixed_underlay = list("space" = TRUE)
 
-//MONKESTATION ADDITION - Hull subtype for syndicate r_walls
+// Hull subtype for syndicate r_walls
 /turf/closed/wall/r_wall/syndicate/hull
 	name = "hull"
 	desc = "The armored hull of an ominous looking ship."
@@ -283,4 +282,3 @@
 	icon_state = "map-overspace"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	fixed_underlay = list("space" = TRUE)
-//END OF ADDITION

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -35,22 +35,19 @@
 
 	var/list/dent_decals
 
-	//Monkestation edit start
-	max_integrity = 300
-	damage_deflection = 22 // big chunk of solid metal
+	max_integrity = 600
+	damage_deflection = 30 // big chunk of solid metal
 	uses_integrity = TRUE
 	armor_type = /datum/armor/wall
 
 /datum/armor/wall
-	melee = 60
-	bullet = 60
-	laser = 60
-	energy = 0
-	bomb = 0
-	bio = 0
-	acid = 50
-	wound = 0
-//Monkestation edit end
+	melee = 30
+	bullet = 30
+	laser = 20
+	energy = 20
+	bomb = 10
+	fire = 80
+	acid = 70
 
 /turf/closed/wall/mouse_drop_receive(atom/dropping, mob/user, params)
 	if(dropping != user || !iscarbon(dropping))
@@ -121,7 +118,6 @@
 		fixed_underlay = string_assoc_list(fixed_underlay)
 		underlays += underlay_appearance
 
-	//monkestation edit start
 	if(SSstation_coloring.wall_trims)
 		trim_color = SSstation_coloring.get_default_color()
 
@@ -134,7 +130,6 @@
 	. += ..()
 	. += deconstruction_hints(user)
 
-//monkestation edit start
 /turf/closed/wall/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
 	. = ..()
 	if(.) // add a dent if it took damage
@@ -163,7 +158,6 @@
 	if(damage_flag == MELEE)
 		playsound(src, 'sound/effects/meteorimpact.ogg', 50, TRUE) //Otherwise there's no sound for hitting the wall, since it's just dismantled
 	dismantle_wall(TRUE, TRUE)
-//monkestation edit end
 
 /turf/closed/wall/proc/deconstruction_hints(mob/user)
 	return span_notice("The outer plating is <b>welded</b> firmly in place.")
@@ -210,7 +204,7 @@
 
 /turf/closed/wall/ex_act(severity, target)
 	if(target == src)
-		dismantle_wall(TRUE, TRUE) //monkestation edit
+		dismantle_wall(TRUE, TRUE)
 		return
 
 	switch(severity)
@@ -222,16 +216,14 @@
 		if(EXPLODE_HEAVY)
 			dismantle_wall(prob(50), TRUE)
 		if(EXPLODE_LIGHT)
-			take_damage(150, BRUTE, BOMB) // less kaboom monkestation edit
+			take_damage(150, BRUTE, BOMB) // less kaboom
 	if(!density)
 		..()
 
 
 /turf/closed/wall/blob_act(obj/structure/blob/B)
-	//monkestation edit start
 	take_damage(400, BRUTE, MELEE, FALSE)
 	playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
-	//monkestation edit end
 
 /turf/closed/wall/attack_paw(mob/living/user, list/modifiers)
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -244,14 +236,12 @@
 		return
 	if(arm.bodypart_disabled)
 		return
-	//monkestation edit start
 	user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
 	take_damage(400, BRUTE, MELEE, FALSE)
 	playsound(src, 'sound/effects/bang.ogg', 50, 1)
 	to_chat(user, span_notice("You punch the wall."))
 	hulk_recoil(arm, user)
 	return TRUE
-	//monkestation edit end
 
 /**
  *Deals damage back to the hulk's arm.
@@ -280,7 +270,7 @@
 	playsound(src, 'sound/weapons/genhit.ogg', 25, TRUE)
 	add_fingerprint(user)
 
-/turf/closed/wall/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers) //monkestation edit
+/turf/closed/wall/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if (!ISADVANCEDTOOLUSER(user))
 		to_chat(user, span_warning("You don't have the dexterity to do this!"))
@@ -293,16 +283,15 @@
 	add_fingerprint(user)
 
 	//the istype cascade has been spread among various procs for easy overriding
-	if(try_clean(attacking_item, user) || try_wallmount(attacking_item, user) || try_decon(attacking_item, user)) //monkestation edit
+	if(try_clean(attacking_item, user) || try_wallmount(attacking_item, user) || try_decon(attacking_item, user))
 		return
 
 	return ..() || (uses_integrity && attacking_item.attack_atom(src, user))
 
 /turf/closed/wall/proc/try_clean(obj/item/W, mob/living/user, turf/T)
-	if(!(user.istate & ISTATE_HARM)) //monkestation edit
+	if(!(user.istate & ISTATE_HARM))
 		return FALSE
 
-	//monkestation edit start
 	if(W.tool_behaviour == TOOL_WELDER)
 		if(!W.tool_start_check(user, amount=0))
 			to_chat(user, span_warning("You need more fuel to repair [src]!"))
@@ -328,7 +317,6 @@
 			dent_decals.Cut()
 			return TRUE
 		return TRUE
-	//monkestation edit end
 	return FALSE
 
 /turf/closed/wall/proc/try_wallmount(obj/item/W, mob/user)
@@ -361,23 +349,10 @@
 
 /turf/closed/wall/singularity_pull(S, current_size)
 	. = ..()
-	//monkestation edit start
 	if(current_size >= STAGE_FIVE)
 		take_damage(300, armour_penetration=100) // LORD SINGULOTH CARES NOT FOR YOUR "ARMOR"
 	else if(current_size == STAGE_FOUR)
 		take_damage(150, armour_penetration=100)
-	//monkestation edit end
-
-/* //MONKESTATION REMOVAL: Deprecated, obselete old code proc
-/turf/closed/wall/proc/wall_singularity_pull(current_size)
-	if(current_size >= STAGE_FIVE)
-		if(prob(50))
-			dismantle_wall()
-		return
-	if(current_size == STAGE_FOUR)
-		if(prob(30))
-			dismantle_wall()
-*/
 
 /turf/closed/wall/narsie_act(force, ignore_mobs, probability = 20)
 	. = ..()
@@ -417,12 +392,10 @@
 			return TRUE
 	return FALSE
 
-//monkestation edit start
 /turf/proc/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8)) // this only exists because turf code is terrible, monkestation
 	return
 
 /turf/closed/wall/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8))
-//monkestation edit end
 	if(LAZYLEN(dent_decals) >= MAX_DENT_DECALS)
 		return
 


### PR DESCRIPTION

## About The Pull Request
walls have 600 integrity, same armor as airlocks, and 30 damage deflection. reinforced walls have 900 integrity.

## Why It's Good For The Game
its dumb that its easier to bust down walls than airlocks

## Changelog

:cl:
balance: walls have 600 integrity, same armor as airlocks, and 30 damage deflection. reinforced walls have 900 integrity.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

