### PR TITLE
Changeling armor now list that it slows chemical generation in description

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -524,7 +524,7 @@
 /datum/action/changeling/suit/armor
 	name = "Chitinous Armor"
 	desc = "We turn our skin into tough chitin to protect us from damage, as well as pepperspray and flashbangs. Costs 20 chemicals."
-	helptext = "Upkeep of the armor requires a low expenditure of chemicals. The armor provides decent protection against brute force and energy weapons. Cannot be used in lesser form."
+	helptext = "Upkeep of the armor requires a low expenditure of chemicals. The armor provides decent protection against brute force and energy weapons. Cannot be used in lesser form. Slows chemical generation when active."
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 20
 	dna_cost = 2


### PR DESCRIPTION

## About The Pull Request
Just adds "Slows chemical generation while active" to changeling armor power description in shop

## Why It's Good For The Game
ling armor got chem slowdown in another PR but unlike all other powers with chem slowdown its not mentioned at all in its description.
Just keeps it inline with other powers and lets players know whats actually going on.

## Testing
Yes tested booted up spawned ling description good

## Changelog

:cl:
fix: changeling armor now list that it slows chemical generation
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

