### PR TITLE
Kitchen pans will no longer talk to you

### DIFF
--- a/monkestation/code/modules/brewin_and_chewin/chewing/tracker.dm
+++ b/monkestation/code/modules/brewin_and_chewin/chewing/tracker.dm
@@ -442,9 +442,7 @@
 	if(active_step.custom_food_buff)
 		custom_food_buff = active_step.custom_food_buff
 	if(active_step.finish_text)
-		var/datum/chewin_cooking/recipe_tracker/parent = parent_ref.resolve()
-		var/obj/item/resolved_ref = parent.holder_ref.resolve()
-		resolved_ref.say(active_step.finish_text) // I want runetext womp womp
+		used_obj.visible_message(span_notice("[active_step.finish_text]"))
 
 	if(!(active_step.flags & CHEWIN_IS_OPTIONAL))
 		current_step = active_step


### PR DESCRIPTION

## About The Pull Request
Changes how cooking steps work to make kitchen pans (and maybe other kitchen objs) no longer talk to you, instead having a visible message.
## Why It's Good For The Game
A kitchen pan should not be able to talk with you... the message is still displayed like 8 times which is another issue in of itself but atleast they don't talk anymore. More consistent with other kitchen utilities that have span_notice messages.

This has a downside of not having a dedicated blind message as one was never added originally to the cooking steps ;p 
## Testing
before 
<img width="333" height="40" alt="image" src="https://github.com/user-attachments/assets/26437564-1380-4aa3-9a85-2aeba12e62d3" />
after 
<img width="214" height="40" alt="image" src="https://github.com/user-attachments/assets/1c6864e7-7a68-4a2c-89f7-5be4aced7247" />

## Changelog
:cl: Cujo
fix: Kitchen pans (and maybe other kitchen utilities) will no longer talk to you.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
