### PR TITLE
Edits some species blacklist for quirks

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -115,7 +115,7 @@
 #define SPECIES_NIGHTMARE "nightmare"
 #define SPECIES_MONKEY "monkey"
 #define SPECIES_MOTH "moth"
-#define SPECIES_TUNDRA "tundra" //Monkestation Addition
+#define SPECIES_TUNDRA "tundra"
 #define SPECIES_MUSHROOM "mush"
 #define SPECIES_PLASMAMAN "plasmaman"
 #define SPECIES_PODPERSON "pod"
@@ -130,19 +130,19 @@
 #define SPECIES_ZOMBIE "zombie"
 #define SPECIES_ZOMBIE_SHAMBLER "shambler"
 #define SPECIES_ZOMBIE_INFECTIOUS "memezombie"
-#define SPECIES_ZOMBIE_INFECTIOUS_RUNNER "runnerzombie" //Monkestation Addition
+#define SPECIES_ZOMBIE_INFECTIOUS_RUNNER "runnerzombie"
 #define SPECIES_ZOMBIE_INFECTIOUS_TANK "tankzombie" //monkestation edit
 #define SPECIES_ZOMBIE_INFECTIOUS_SPITTER "spitterzombie" //monkestation edit
 #define SPECIES_ZOMBIE_INFECTIOUS_BLOATER "bloaterzombie" //monkestation edit
 #define SPECIES_ZOMBIE_KROKODIL "krokodil_zombie"
 #define SPECIES_OOZELING "oozeling"
 #define SPECIES_IPC "ipc"
-#define SPECIES_ONI "oni" //Monkestation Addition
-#define SPECIES_SIMIAN "simian" //Monkestation Addition
-#define SPECIES_GOBLIN "goblin" //Monkestation Addition
-#define SPECIES_FLORAN "floran" //Monkestation Addition
-#define SPECIES_SATYR "satyr" //Monkestation Addition
-#define SPECIES_TERATOMA "teratoma" //Monkestation Addition
+#define SPECIES_ONI "oni"
+#define SPECIES_SIMIAN "simian"
+#define SPECIES_GOBLIN "goblin"
+#define SPECIES_FLORAN "floran"
+#define SPECIES_SATYR "satyr"
+#define SPECIES_TERATOMA "teratoma"
 #define SPECIES_TRAINED_MONKEY "trainedmonkey"
 // Like species IDs, but not specifically attached a species.
 #define BODYPART_ID_ALIEN "alien"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -131,9 +131,9 @@
 #define SPECIES_ZOMBIE_SHAMBLER "shambler"
 #define SPECIES_ZOMBIE_INFECTIOUS "memezombie"
 #define SPECIES_ZOMBIE_INFECTIOUS_RUNNER "runnerzombie"
-#define SPECIES_ZOMBIE_INFECTIOUS_TANK "tankzombie" //monkestation edit
-#define SPECIES_ZOMBIE_INFECTIOUS_SPITTER "spitterzombie" //monkestation edit
-#define SPECIES_ZOMBIE_INFECTIOUS_BLOATER "bloaterzombie" //monkestation edit
+#define SPECIES_ZOMBIE_INFECTIOUS_TANK "tankzombie"
+#define SPECIES_ZOMBIE_INFECTIOUS_SPITTER "spitterzombie"
+#define SPECIES_ZOMBIE_INFECTIOUS_BLOATER "bloaterzombie"
 #define SPECIES_ZOMBIE_KROKODIL "krokodil_zombie"
 #define SPECIES_OOZELING "oozeling"
 #define SPECIES_IPC "ipc"

--- a/code/datums/quirks/negative_quirks/blood_deficiency.dm
+++ b/code/datums/quirks/negative_quirks/blood_deficiency.dm
@@ -11,6 +11,7 @@
 	quirk_flags = QUIRK_HUMAN_ONLY
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
 	var/min_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
+		species_blacklist = list(SPECIES_IPC, SPECIES_OOZELING, SPECIES_PLASMAMAN)
 
 /datum/quirk/blooddeficiency/post_add()
 	update_mail()

--- a/code/datums/quirks/negative_quirks/blood_deficiency.dm
+++ b/code/datums/quirks/negative_quirks/blood_deficiency.dm
@@ -11,7 +11,7 @@
 	quirk_flags = QUIRK_HUMAN_ONLY
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
 	var/min_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
-		species_blacklist = list(SPECIES_IPC, SPECIES_OOZELING, SPECIES_PLASMAMAN)
+	species_blacklist = list(SPECIES_IPC, SPECIES_OOZELING, SPECIES_PLASMAMAN)
 
 /datum/quirk/blooddeficiency/post_add()
 	update_mail()

--- a/code/datums/quirks/negative_quirks/food_allergy.dm
+++ b/code/datums/quirks/negative_quirks/food_allergy.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(possible_food_allergies, list(
 	mail_goodies = list(/obj/item/reagent_containers/medipen)
 	/// Footype flags that will trigger the allergy
 	var/target_foodtypes = NONE
-	species_blacklist = list(SPECIES_IPC, SPECIES_OOZELING)
+	species_blacklist = list(SPECIES_IPC)
 
 /datum/quirk/item_quirk/food_allergic/add(client/client_source)
 	if(target_foodtypes != NONE) // Already set, don't care

--- a/code/datums/quirks/negative_quirks/frail.dm
+++ b/code/datums/quirks/negative_quirks/frail.dm
@@ -9,4 +9,4 @@
 	medical_record_text = "Patient is absurdly easy to injure. Please take all due diligence to avoid possible malpractice suits."
 	hardcore_value = 4
 	mail_goodies = list(/obj/effect/spawner/random/medical/minor_healing)
-	species_blacklist = list(SPECIES_IPC)
+	species_blacklist = list(SPECIES_IPC, SPECIES_OOZELING)

--- a/code/datums/quirks/negative_quirks/immunodeficiency.dm
+++ b/code/datums/quirks/negative_quirks/immunodeficiency.dm
@@ -11,6 +11,8 @@
 		/obj/item/reagent_containers/syringe/antiviral,
 		/obj/item/healthanalyzer/simple/disease,
 	)
+	species_blacklist = list(SPECIES_IPC)
+
 
 /datum/quirk/item_quirk/immunodeficiency/add(client/client_source)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
oozelings, ipcs, and plasmamen can no longer have blood deficiency quirk

IPCs can no longer have immunodeficiency quirk

oozelings can no longer have frail quirk 

oozelings can have food allergy quirk

## Why It's Good For The Game
Most of these are just oversights and free points on species they dont affect at all which is the entire reason we have the species blacklist for quirks.

For food allergy there isnt any real reason oozelings shouldn't be able to have this quirk, histamine does brute burn and oxy damage on OD so they dont get much benefit from it still dying, and they can have the normal allergery quirk anyways

## Testing
booted up, tried to select quirks, no let me

## Changelog

:cl:
balance: ipcs, oozelings, and plasma men can no longer have blood deficiency quirk
balance: ipcs can no longer have immunodeficiency quirk
balance: oozelings can no longer have frail quirk
balance: oozelings can have food allergy quirk
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

