### PR TITLE
Increases the Contractor modsuit's complexity from 15 to 20, gives it biohazard X protection and adds a inbuilt quick cuff module

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1009,8 +1009,8 @@
 	inbuilt_modules = list(
 		/obj/item/mod/module/welding/syndicate,
 		/obj/item/mod/module/night,
-		/obj/item/mod/module/hearing_protection
-		/obj/item/mod/module/quick_cuff,
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/quick_cuff
 	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1006,7 +1006,12 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0.25
 	ui_theme = "syndicate"
-	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/night, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/welding/syndicate,
+		/obj/item/mod/module/night,
+		/obj/item/mod/module/hearing_protection
+		/obj/item/mod/module/quick_cuff,
+	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1099,7 +1104,12 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	ui_theme = "syndicate"
-	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/night, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/welding/syndicate,
+		/obj/item/mod/module/night,
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/quick_cuff,
+	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1168,7 +1178,14 @@
 	slowdown_active = 0
 	ui_theme = "syndicate"
 	slot_flags = ITEM_SLOT_BELT
-	inbuilt_modules = list(/obj/item/mod/module/infiltrator, /obj/item/mod/module/storage/belt, /obj/item/mod/module/demoralizer, /obj/item/mod/module/hearing_protection, /obj/item/mod/module/night)
+	inbuilt_modules = list(
+		/obj/item/mod/module/infiltrator,
+		/obj/item/mod/module/storage/belt,
+		/obj/item/mod/module/demoralizer,
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/night,
+		/obj/item/mod/module/quick_cuff,
+	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1233,7 +1250,10 @@
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
 	slowdown_inactive = 0.0
 	slowdown_active = -0.5
-	inbuilt_modules = list(/obj/item/mod/module/quick_carry/advanced, /obj/item/mod/module/organ_thrower)
+	inbuilt_modules = list(
+		/obj/item/mod/module/quick_carry/advanced,
+		/obj/item/mod/module/organ_thrower,
+	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1316,7 +1336,11 @@
 	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	ui_theme = "wizard"
-	inbuilt_modules = list(/obj/item/mod/module/anti_magic/wizard, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/anti_magic/wizard,
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/quick_cuff
+	)
 	allowed_suit_storage = list(
 		/obj/item/teleportation_scroll,
 		/obj/item/highfrequencyblade/wizard,
@@ -1377,7 +1401,15 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	ui_theme = "hackerman"
-	inbuilt_modules = list(/obj/item/mod/module/welding/camera_vision, /obj/item/mod/module/hacker, /obj/item/mod/module/weapon_recall, /obj/item/mod/module/adrenaline_boost, /obj/item/mod/module/energy_net, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/welding/camera_vision,
+		/obj/item/mod/module/hacker,
+		/obj/item/mod/module/weapon_recall,
+		/obj/item/mod/module/adrenaline_boost,
+		/obj/item/mod/module/energy_net,
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/quick_cuff
+	)
 	allowed_suit_storage = list(
 		/obj/item/gun,
 		/obj/item/ammo_box,
@@ -1503,7 +1535,10 @@
 	slowdown_active = 0.5
 	slowdown_inactive = 1
 	ui_theme = "ntos_terminal"
-	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/welding/syndicate,
+		/obj/item/mod/module/hearing_protection,
+	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1573,7 +1608,10 @@
 	siemens_coefficient = 0
 	slowdown_inactive = 0.5
 	slowdown_active = 0
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/quick_cuff
+	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1655,7 +1693,10 @@
 	armor_type = /datum/armor/mod_theme_elite
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
-	inbuilt_modules = list(/obj/item/mod/module/welding/syndicate)
+	inbuilt_modules = list(
+		/obj/item/mod/module/welding/syndicate,
+		/obj/item/mod/module/quick_cuff
+	)
 
 /datum/mod_theme/apocryphal
 	name = "apocryphal"
@@ -1673,7 +1714,10 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 10
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/quick_cuff
+	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1738,7 +1782,10 @@
 	siemens_coefficient = 0
 	slowdown_inactive = 0.5
 	slowdown_active = 0
-	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/quick_cuff
+	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,
@@ -1919,6 +1966,9 @@
 	slowdown_inactive = 0
 	slowdown_active = 0
 	activation_step_time = 0.1 SECONDS
+	inbuilt_modules = list(
+		/obj/item/mod/module/quick_cuff
+	)
 	allowed_suit_storage = list(
 		/obj/item/gun,
 	)

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -181,7 +181,6 @@
 		/obj/item/mod/module/pepper_shoulders,
 		/obj/item/mod/module/criminalcapture,
 		/obj/item/mod/module/visor/sechud, // monkestation addition
-		/obj/item/mod/module/quick_cuff,
 	)
 
 /obj/item/mod/control/pre_equipped/safeguard
@@ -196,7 +195,6 @@
 		/obj/item/mod/module/projectile_dampener,
 		/obj/item/mod/module/pepper_shoulders,
 		/obj/item/mod/module/visor/sechud, // monkestation addition
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack,
@@ -211,7 +209,6 @@
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/pathfinder,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
@@ -238,7 +235,6 @@
 		/obj/item/mod/module/pathfinder,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/dna_lock,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack,
@@ -257,7 +253,6 @@
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/dna_lock,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
@@ -277,7 +272,6 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
@@ -312,7 +306,6 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
@@ -330,7 +323,6 @@
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/flamethrower,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
@@ -348,7 +340,6 @@
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/quick_carry,
 		/obj/item/mod/module/visor/diaghud,
-		/obj/item/mod/module/quick_cuff,
 	)
 
 
@@ -374,7 +365,6 @@
 		/obj/item/mod/module/storage/large_capacity,
 		/obj/item/mod/module/energy_shield/wizard,
 		/obj/item/mod/module/emp_shield/advanced,
-		/obj/item/mod/module/quick_cuff,
 	)
 
 /obj/item/mod/control/pre_equipped/ninja
@@ -389,7 +379,6 @@
 		/obj/item/mod/module/dispenser/ninja,
 		/obj/item/mod/module/dna_lock/reinforced,
 		/obj/item/mod/module/emp_shield/pulse,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/stealth/ninja,
@@ -443,7 +432,6 @@
 		/obj/item/mod/module/emp_shield,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/flashlight,
-		/obj/item/mod/module/quick_cuff,
 	)
 	/// The insignia type, insignias show what sort of member of the ERT you're dealing with.
 	var/insignia_type = /obj/item/mod/module/insignia
@@ -494,7 +482,6 @@
 		/obj/item/mod/module/emp_shield,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/flashlight,
-		/obj/item/mod/module/quick_cuff,
 	)
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory/syndie
@@ -511,7 +498,6 @@
 		/obj/item/mod/module/pathfinder,
 		/obj/item/mod/module/flashlight/darkness,
 		/obj/item/mod/module/dna_lock,
-		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/shove_blocker,
 		/obj/item/mod/module/noslip,
 	)
@@ -542,7 +528,6 @@
 		/obj/item/mod/module/emp_shield/advanced,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/jetpack,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack,
@@ -556,7 +541,6 @@
 		/obj/item/mod/module/emp_shield/advanced,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/jetpack,
-		/obj/item/mod/module/quick_cuff,
 	)
 
 /obj/item/mod/control/pre_equipped/corporate
@@ -569,7 +553,6 @@
 		/obj/item/mod/module/hat_stabilizer,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/emp_shield/advanced,
-		/obj/item/mod/module/quick_cuff,
 	)
 
 /obj/item/mod/control/pre_equipped/chrono
@@ -621,7 +604,6 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/anomaly_locked/kinesis/plus,
 		/obj/item/mod/module/shove_blocker,
-		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/rad_protection, // monkestation edit
 	)
 	default_pins = list(

--- a/monkestation/code/modules/antagonists/contractor/items/modsuit/theme.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/modsuit/theme.dm
@@ -18,7 +18,12 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	ui_theme = "syndicate"
-	inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor, /obj/item/mod/module/welding/syndicate, /obj/item/mod/module/hearing_protection)
+	inbuilt_modules = list(
+		/obj/item/mod/module/chameleon/contractor,
+		/obj/item/mod/module/welding/syndicate,
+		/obj/item/mod/module/hearing_protection,
+		/obj/item/mod/module/quick_cuff,
+	)
 	allowed_suit_storage = list(
 		/obj/item/flashlight,
 		/obj/item/tank/internals,

--- a/monkestation/code/modules/antagonists/contractor/items/modsuit/theme.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/modsuit/theme.dm
@@ -12,6 +12,7 @@
 	default_skin = "contractor"
 	armor_type = /datum/armor/mod_contractor_armor
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
+	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0


### PR DESCRIPTION

## About The Pull Request

Title, also moved quick cuff module on the modsuits that have it to inbuilt_modules

## Why It's Good For The Game

Contractor mod's complexity is pretty pitiful right now, you need to remove modules you start with as a drifting contractor to fit in the scorpion hook upgrade for example.

For the quick cuff module it's something every combat modsuit (security and syndicate ones) have, this is the suit where it doesn't make sense not to have it.

For the biohazard protection it's something every spaceproof modsuit has and there is no reason for this one specifically to not be completely sealed from biohazards.

## Testing

spawned mods, checked modules, cuffed npcs, everything works

## Changelog
:cl:
balance: The contractor modsuit's complexity has been increased from 15 to 20
balance: The contractor modsuit's biohazard has been increased to 100%
balance: The contractor modsuit starts with an inbuilt quick cuff module
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
