### PR TITLE
Fixes the syndicate surgery kit not being able to fit its own tools after they're removed (+ minor buff)

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -152,33 +152,31 @@
 	)
 	generate_items_inside(items_inside, src)
 
-/obj/item/storage/medkit/surgery_syndie
+/obj/item/storage/medkit/surgery/syndie
 	name = "suspicous surgical medkit"
-	desc = "An suspicous coloured medkit full of advanced medical equipment."
+	desc = "A suspicously colored medkit full of advanced medical equipment."
 	icon_state = "medkit_tactical_lite"
 	inhand_icon_state = "medkit-tactical"
 	damagetype_healed = HEAL_ALL_DAMAGE
 
-/obj/item/storage/medkit/surgery_syndie/PopulateContents()
+/obj/item/storage/medkit/surgery/syndie/PopulateContents()
 	if(empty)
 		return
 	var/list/items_inside = list(
+		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/scalpel/advanced = 1,
 		/obj/item/retractor/advanced = 1,
 		/obj/item/cautery/advanced = 1,
+		/obj/item/blood_filter/advanced = 1,
 		/obj/item/surgical_drapes = 1,
 		/obj/item/stack/medical/gauze/twelve = 1,
 		/obj/item/reagent_containers/medigel/sterilizine = 1,
-		/obj/item/bonesetter = 1,
-		/obj/item/blood_filter = 1,
-		/obj/item/stack/medical/bone_gel = 1,
-		/obj/item/stack/sticky_tape/surgical = 1,
 		/obj/item/reagent_containers/syringe = 1,
 		/obj/item/reagent_containers/cup/bottle/sodium_thiopental = 1,
 	)
 	generate_items_inside(items_inside,src)
 
-/obj/item/storage/medkit/surgery_syndie/get_medbot_skin()
+/obj/item/storage/medkit/surgery/syndie/get_medbot_skin()
 	return "bezerk"
 
 /obj/item/storage/medkit/ancient
@@ -448,8 +446,7 @@
 
 //------------------------------------------------------------------------------------------------
 // Combat Medkits. The better tactical medkits. TO-DO: Go and replace tactical medkits with these.
-//------------------------------------------------------------------------------------------------
-/obj/item/storage/medkit/combat
+//----------------------------------------------------------------------------------------------
 	name = "combat medical kit"
 	desc = "I hope you've got insurance."
 	icon_state = "medkit_tactical"

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -18,7 +18,7 @@
 	name = "Full Syndicate Surgery Medkit"
 	desc = "The Syndicate surgery medkit is a toolkit containing all surgery tools, surgical drapes, \
 			a syringe, and some sedatives."
-	item = /obj/item/storage/medkit/surgery_syndie
+	item = /obj/item/storage/medkit/surgery/syndie
 	cost = 3
 
 /datum/uplink_item/device_tools/combat_medkit


### PR DESCRIPTION

## About The Pull Request

Syndicate surgery kit now fits its own tools (moved to a subtype of the surgery medkit), also replaced the blood filter, bonesetter, bone gel and surgical tape with a biocorrector and added an advanced health analyzer

## Why It's Good For The Game

Surgery kit not fitting the tools it comes with is silly, also it's supposed to come with advanced tier tools so not having the biocorrector seems like an oversight, also health analyzer is a nice tool to have when doing tend wounds surgery

## Testing

Launched the game, spawned the kit, tools can be removed and added

## Changelog
:cl:
fix: Syndicate surgery kit can fit its own tools now
balance: Syndicate surgery kit starts with a biocorrector instead of the tier 1 equivalents
balance: Syndicate surgery kit starts with an advanced health analyzer
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
