### PR TITLE
heretic min players change

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/heretic.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/heretic.dm
@@ -41,7 +41,7 @@
 	)
 	required_enemies = 5
 	weight = 5
-	min_players = 45
+	min_players = 40
 
 /datum/round_event_control/antagonist/heretic/get_weight()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

change heretic min players to 40 from 45

## Why It's Good For The Game

consistency, all the other high threat antags are either 35 or 40 so you'd kinda expect heretic to be the same too

## Testing
## Changelog
:cl:
balance: Heretics need 40 players readied up to roll.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
