### PR TITLE
disables infective exo-locomotion in research web

### DIFF
--- a/monkestation/code/modules/research/designs/nanite_designs.dm
+++ b/monkestation/code/modules/research/designs/nanite_designs.dm
@@ -104,7 +104,7 @@
 	program_type = /datum/nanite_program/emp
 	category = list("Utility Nanites")
 
-///datum/design/nanites/spreading
+//datum/design/nanites/spreading
 //	name = "Infective Exo-Locomotion"
 //	desc = "The nanites gain the ability to survive for brief periods outside of the human body, as well as the ability to start new colonies without an integration process; \
 //			resulting in an extremely infective strain of nanites."

--- a/monkestation/code/modules/research/designs/nanite_designs.dm
+++ b/monkestation/code/modules/research/designs/nanite_designs.dm
@@ -104,13 +104,13 @@
 	program_type = /datum/nanite_program/emp
 	category = list("Utility Nanites")
 
-/datum/design/nanites/spreading
-	name = "Infective Exo-Locomotion"
-	desc = "The nanites gain the ability to survive for brief periods outside of the human body, as well as the ability to start new colonies without an integration process; \
-			resulting in an extremely infective strain of nanites."
-	id = "spreading_nanites"
-	program_type = /datum/nanite_program/spreading
-	category = list("Utility Nanites")
+///datum/design/nanites/spreading
+//	name = "Infective Exo-Locomotion"
+//	desc = "The nanites gain the ability to survive for brief periods outside of the human body, as well as the ability to start new colonies without an integration process; \
+//			resulting in an extremely infective strain of nanites."
+//	id = "spreading_nanites"
+//	program_type = /datum/nanite_program/spreading
+//	category = list("Utility Nanites")
 
 /datum/design/nanites/nanite_sting
 	name = "Nanite Sting"

--- a/monkestation/code/modules/research/designs/nanite_designs.dm
+++ b/monkestation/code/modules/research/designs/nanite_designs.dm
@@ -106,7 +106,7 @@
 
 //datum/design/nanites/spreading
 //	name = "Infective Exo-Locomotion"
-//	desc = "The nanites gain the ability to survive for brief periods outside of the human body, as well as the ability to start new colonies without an integration process; \
+//	desc = "The nanites gain the ability to survive for brief periods outside of the human body, as well as the ability to start new colonies without an integration process;
 //			resulting in an extremely infective strain of nanites."
 //	id = "spreading_nanites"
 //	program_type = /datum/nanite_program/spreading


### PR DESCRIPTION

## About The Pull Request

The PR quite unceremoniously comments out the datum design for Infective Exo-Locomotion from the techweb, removing it entirely. If antags want to spread their nanites to the furthest corners of the station, they should have to go there themselves and spread it. This is one option for making nanites somewhat interactive, another option would be to remove the stealth program, which circumvents being able to tell a nanite infection is even spreading for anyone but roboticists, the AI, and powergamers.
## Why It's Good For The Game

As a roleplay game, interaction is important. An antagonist roboticist can just make a stealthy nanite cloud that spreads throughout the station with nobody being able to tell anything has happened until everyone is dead. From an interaction perspective, this is pretty abysmal. It would be nice for said antagonist to put some sort of effort in to raising their victim count, besides just making and sending a single nanite program and then fluoride staring for the rest of the shift as every person that'd stand in their way unceremoniously dies for the crime of existing in the proximity of another player. Probably the best option would be creating new tells to be able to discern that you've been infected with nanomachines, but this is more of a quick band-aid solution.
## Testing

Worked fine. It's not in the research tree.
## Changelog
:cl:
del: removed infective exo-locomotion from the techweb
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
