### PR TITLE
lowers sec gps alert delay to 15 seconds from 20

### DIFF
--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -264,7 +264,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	playsound(our_gps_device, 'sound/items/gps/four_ping.ogg', 35, TRUE)
 	our_gps_device.say("Transmitting distress signal...")
 
-	addtimer(CALLBACK(src, PROC_REF(attempt_to_send_signal), alert_text), 20 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(attempt_to_send_signal), alert_text), 15 SECONDS)
 
 /datum/component/gps/item/security_gps/proc/attempt_to_send_signal(alert_text)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
since i tech locked them this should make them more worth it i feel. still more than enough time to disable one if it's one on one.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: lowered sec gps alert delay to 15 seconds from 20
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
