### PR TITLE
Brig med now requires medical hours instead of sec hours

### DIFF
--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -9,7 +9,7 @@
 	supervisors = SUPERVISOR_HOS
 	exp_requirements = 600
 	exp_required_type = EXP_TYPE_CREW
-	exp_required_type_department = EXP_TYPE_SECURITY
+	exp_required_type_department = EXP_TYPE_MEDICAL
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "BRIG_PHYSICIAN"
 


### PR DESCRIPTION

## About The Pull Request
Title, simply shifts required hours to unlock brig phys from sec to medbay

## Why It's Good For The Game
Brig med requires much more medical knowledge than sec knowledge. Most of the sec stuff you are required to know is extremely minor/closer to common sense. They aren't expected to fight or really fill any duties of a secoff except for in extreme situations so sec hours for this job just dont really make sense.

Very frequently I see brig meds with basically 0 clue what they are doing beyond basic surgery, not using forma, letting people rot, sit in stasis forever, etc. I think locking it behind medbay hours will hopefully help a little with all that.

## Testing
No DB on my local to test but doesn't runtime and one line change should be fine.

## Changelog

:cl:
balance: brig med now requires medical hours instead of sec hours
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

