### PR TITLE
Cyborg Upgrades: Universal GPS, Experimental Welding Tool

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -743,6 +743,41 @@
 		gas_analyzer.ranged_scan_distance = initial(gas_analyzer.ranged_scan_distance)
 		gas_analyzer.update_appearance()
 
+/obj/item/borg/upgrade/experimental_weldingtool
+	name = "experimental welder upgrade"
+	desc = "An upgrade to fit the self-replenishing tank of an experimental welding tool to a cyborg."
+	icon_state = "module_engineer"
+	require_model = TRUE
+	model_type = list(/obj/item/robot_model/engineering, /obj/item/robot_model/saboteur, /obj/item/robot_model/science)
+	model_flags = BORG_MODEL_ENGINEERING
+
+/obj/item/borg/upgrade/experimental_weldingtool/action(mob/living/silicon/robot/borg, user = usr)
+	. = ..()
+	if(!.)
+		return .
+	for(var/obj/item/weldingtool/largetank/cyborg/tool in borg.model.modules)
+		tool.refuel = TRUE
+
+/obj/item/borg/upgrade/experimental_weldingtool/deactivate(mob/living/silicon/robot/borg, user = usr)
+	. = ..()
+	if(!.)
+		return .
+	for(var/obj/item/weldingtool/largetank/cyborg/tool in borg.model.modules)
+		tool.refuel = FALSE
+
+/obj/item/borg/upgrade/gps
+	name = "cyborg global positioning system upgrade"
+	desc = "An upgrade kit for all cyborgs to connect them to the GPS network."
+	icon_state = "module_general"
+	require_model = TRUE
+	items_to_add = list(/obj/item/gps/cyborg)
+
+/obj/item/borg/upgrade/gps/action(mob/living/silicon/robot/borg, user = usr)
+	for(var/obj/item/gps/cyborg/GPS in borg.model.modules) //mining borgs start with a GPS
+		to_chat(user, span_warning("This unit already has a GPS installed!"))
+		return FALSE
+	. = ..()
+
 /obj/item/borg/upgrade/beaker_app
 	name = "beaker storage apparatus"
 	desc = "A supplementary beaker storage apparatus for medical cyborgs."

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -334,6 +334,21 @@
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "indwelder_cyborg"
 	toolspeed = 0.5
+	///Upgrades allow it to refuel like a experimental welder
+	var/refuel = FALSE
+	var/last_gen = 0
+	var/nextrefueltick = 0
+
+/obj/item/weldingtool/largetank/cyborg/examine(mob/user)
+	. = ..()
+	if(refuel)
+		. += span_notice("It has been upgraded to automatically refuel.")
+
+/obj/item/weldingtool/largetank/cyborg/process()
+	..()
+	if(refuel && (get_fuel() < max_fuel && nextrefueltick < world.time))
+		nextrefueltick = world.time + 10
+		reagents.add_reagent(/datum/reagent/fuel, 1)
 
 /obj/item/weldingtool/mini
 	name = "emergency welding tool"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -879,8 +879,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-// Monkestation edit start: Research touchups
-
 /datum/design/mech_mining_scanner
 	name = "Mining Scanner"
 	id = "mech_mscanner"
@@ -1433,6 +1431,20 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING
 	)
 
+/datum/design/borg_upgrade_gps
+	name = "Cyborg GPS"
+	id = "borg_upgrade_gps"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/gps
+	materials = list( // Same cost as a regular GPS.
+		/datum/material/iron = SMALL_MATERIAL_AMOUNT * 1.5,
+		/datum/material/glass = SMALL_MATERIAL_AMOUNT,
+	)
+	construction_time = 12 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
+	)
+
 /datum/design/borg_upgrade_beaker_app
 	name = "Secondary Beaker Storage"
 	id = "borg_upgrade_beakerapp"
@@ -1539,6 +1551,23 @@
 	construction_time = 4 SECONDS
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MEDICAL
+	)
+
+/datum/design/borg_upgrade_experimental_welder
+	name = "Cyborg Experimental Welding Tool Upgrade"
+	id = "borg_upgrade_experimental_welder"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/experimental_weldingtool
+	materials = list(
+		/datum/material/iron =HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/glass =SMALL_MATERIAL_AMOUNT * 5,
+		/datum/material/plasma =HALF_SHEET_MATERIAL_AMOUNT * 1.5,
+		/datum/material/uranium =SMALL_MATERIAL_AMOUNT * 2
+	)
+	construction_time = 12 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING,
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_SCIENCE
 	)
 
 /datum/design/borg_upgrade_uwu
@@ -1687,8 +1716,6 @@
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 	special_design_flags = WHITELISTED_DESIGN
 
-// Monkestation edit end: Research touchups
-
 /datum/design/synthetic_flash
 	name = "Flash"
 	desc = "When a problem arises, SCIENCE is the solution."
@@ -1819,8 +1846,6 @@
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 	research_icon_state = "cosmohonk-plating"
 
-// MONKE START - changed/added lots of department_flags
-
 /datum/design/mod_paint_kit
 	name = "MOD Paint Kit"
 	desc = "A paint kit for Modular Suits."
@@ -1840,7 +1865,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 3, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 3)
 	construction_time = 5 SECONDS
-	build_path = /obj/item/clothing/neck/link_scryer/auto_link // monkestation edit: auto_link subtype
+	build_path = /obj/item/clothing/neck/link_scryer/auto_link
 	category = list(
 		RND_CATEGORY_MODSUITS + RND_SUBCATEGORY_MODSUITS_MISC
 	)

--- a/code/modules/research/techweb/cyborg_nodes.dm
+++ b/code/modules/research/techweb/cyborg_nodes.dm
@@ -50,7 +50,7 @@
 	design_ids = list(
 		"borg_upgrade_charger",
 		"borg_upgrade_extra_sheet_manipulator",
-		"borg_upgrade_ranged_analyzer"
+		"borg_upgrade_ranged_analyzer",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS / 2)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE)
@@ -90,6 +90,7 @@
 		"borg_upgrade_thrusters",
 		"borg_upgrade_expand",
 		"borg_upgrade_clamp", // Cargo is so lacking that they don't get their own techweb node.
+		"borg_upgrade_gps",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE)
@@ -201,6 +202,20 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS / 2)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE)
 
+/datum/techweb_node/cyborg_upgrades_experimental
+	id = "cyborg_upgrades_experimental"
+	display_name = "Cyborg Upgrades: Experimental"
+	description =  "Turns out there's just mounting points on these things to fit them into cyborgs. Who knew?"
+	prereq_ids = list(
+		"exp_tools",
+		"adv_robotics"
+	)
+	design_ids = list(
+		"borg_upgrade_experimental_welder"
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS / 2)
+	announce_channels = list(RADIO_CHANNEL_SCIENCE)
+
 //
 // Implants
 //
@@ -277,7 +292,7 @@
 		"ci-reviver",
 		"ci-surgery",
 		"ci-toolset",
-		"ci-sprinter", //monkestation addition:
+		"ci-sprinter",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_MEDICAL, RADIO_CHANNEL_ENGINEERING)


### PR DESCRIPTION

## About The Pull Request
[Relevant Bounty](https://discord.com/channels/748354466335686736/1526672847798407260)

Adds 2 more upgrades for cyborgs

Experimental Welding Tool: Upgrade the welding tool of a engi/sci borg to be self refueling under the same terms as an experimental welder.

Cyborg GPS: Grants all cyborg models a GPS, does not allow a mining cyborg to get 2 GPS modules.
## Why It's Good For The Game
I am getting paid monkecoin and a token for this.
Gives the engiborg a method of upgrading their toolset
Gives cyborgs better coordination and recovery or something.
## Testing
Tried to install GPS on mining borg, failed
Tried to install GPS on cargo borg, passed
Tried to install GPS on cargo borg twice, failed

Installed welding fuel into engi borg, used fuel by hitting a wall, waited, and regenerated a few units.
## Changelog
:cl:
add: Added Cyborg GPS, a all model upgrade to cyborgs that gives them a GPS.
add: Added Experimental Welding Tool upgrade to cyborgs, giving engineer/science cyborgs refueling welders.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
