### PR TITLE
Lowers recoil on pistols, crossbows, and revolvers, increases it on sawn offs

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 ///accuracy penalty of sawn off guns
 #define SAWN_OFF_ACC_PENALTY 25
 ///added recoil of sawn off guns
-#define SAWN_OFF_RECOIL 1
+#define SAWN_OFF_RECOIL 1.5
 
 //ammo box sprite defines
 ///ammo box will always use provided icon state

--- a/code/modules/projectiles/guns/ballistic/crossbow.dm
+++ b/code/modules/projectiles/guns/ballistic/crossbow.dm
@@ -23,6 +23,7 @@
 	weapon_weight = WEAPON_HEAVY
 	initial_caliber = CALIBER_REBAR
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/normal
+	recoil = 0
 	fire_sound = 'sound/items/xbow_lock.ogg'
 	can_be_sawn_off = FALSE
 	tac_reloads = FALSE
@@ -108,6 +109,7 @@
 	inhand_icon_state = "speargun"
 	worn_icon_state = "speargun"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/harpoon
+	recoil = 0
 	fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
 	can_be_sawn_off = FALSE
 

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -4,6 +4,7 @@
 	icon_state = "pistol"
 	w_class = WEIGHT_CLASS_SMALL
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m9mm
+	recoil = 0.3
 	can_suppress = TRUE
 	burst_size = 1
 	fire_delay = 0

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -3,6 +3,7 @@
 	desc = "A suspicious revolver. Uses .357 ammo."
 	icon_state = "revolver"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder
+	recoil = 0.6
 	fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
 	load_sound = 'sound/weapons/gun/revolver/load_bullet.ogg'
 	eject_sound = 'sound/weapons/gun/revolver/empty.ogg'


### PR DESCRIPTION

## About The Pull Request
Crossbows and harpoon gun now have 0 recoil
Pistols now have 0.3 recoil
revolvers now have 0.6 recoil
sawn off guns now have a recoil of 1.5
(all of these compared to the default of 1)

## Why It's Good For The Game
Recoil currently just kinda sucks, vast majority of the guns in the game share the exact same recoil regardless of if it makes any sense. Hopefully makes it a little less miserable to use pistols one handed and just makes the recoil system make more sense overall.
Sawn off recoil increase is because of the above and because there is very little downside to carrying a sawn off shotgun in your bag, it has a accuracy penalty but beyond that nothing else, hopefully creates a little more downside in using sawn off weapons.

## Testing
yes tested, loaded in, spawned guns, tested

## Changelog

:cl:
balance: lowers recoil on pistols and revolvers
balance: removes recoil on crossbows and harpoon guns
balance: increases recoil on sawn off guns
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

