### PR TITLE
[DONATOR REQUEST] The Pharoah's Tunic

### DIFF
--- a/monkestation/code/modules/loadouts/donator/personal.dm
+++ b/monkestation/code/modules/loadouts/donator/personal.dm
@@ -583,3 +583,9 @@
 	item_path = /obj/item/clothing/suit/hooded/colorblockhoodie
 	donator_only = TRUE
 	requires_purchase = FALSE
+
+/datum/loadout_item/suit/pharoh
+	name = "Pharoh's Tunic"
+	item_path = /obj/item/clothing/suit/costume/nemes
+	donator_only = TRUE
+	requires_purchase = FALSE


### PR DESCRIPTION
Adds the "pharoah tunic" as a donator loadout item.
## About The Pull Request

Self-explanatory, just adds a costume (pharoah tunic) as a donator item, located in the Suit category.

## Why It's Good For The Game

It's not harmful, and donators have this as one of their perks.

## Testing
## Changelog
:cl:
add: Added donator item to loadout.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
