### PR TITLE
Makes surgical masks mapped in near anesthetic tanks & cleans up dupe code

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_oldstation.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_oldstation.dmm
@@ -945,7 +945,7 @@
 "fi" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /turf/open/floor/iron/icemoon,
 /area/ruin/space/ancientstation/beta/medbay)
 "fj" = (
@@ -6056,7 +6056,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/rnd)
 "GM" = (

--- a/_maps/RandomRuins/SpaceRuins/InfestedFlotilla.dmm
+++ b/_maps/RandomRuins/SpaceRuins/InfestedFlotilla.dmm
@@ -6277,7 +6277,7 @@
 /obj/structure/table,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /obj/item/tank/internals/anesthetic,
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/infested_flotilla)

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -4618,7 +4618,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/rnd)
 "sL" = (
@@ -5950,7 +5950,7 @@
 "BQ" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/beta/medbay)
 "BX" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16228,7 +16228,7 @@
 	},
 /obj/structure/table,
 /obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /obj/item/tank/internals/anesthetic,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -969,11 +969,11 @@
 /obj/item/tank/internals/anesthetic{
 	pixel_x = -3
 	},
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = 3
 	},
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle,
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,

--- a/_maps/map_files/Graveyard/Graveyard.dmm
+++ b/_maps/map_files/Graveyard/Graveyard.dmm
@@ -20868,11 +20868,11 @@
 /obj/item/tank/internals/anesthetic{
 	pixel_x = -3
 	},
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = -3
 	},
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle,
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -8703,13 +8703,13 @@
 /obj/item/tank/internals/anesthetic{
 	pixel_x = 3
 	},
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = -3
 	},
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = 3
 	},
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /turf/open/floor/iron/diagonal,
 /area/station/medical/surgery)
 "eqg" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -560,11 +560,11 @@
 /obj/item/tank/internals/anesthetic{
 	pixel_x = -3
 	},
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = -3
 	},
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle,
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = 3
 	},
 /obj/structure/window/reinforced/spawner/directional/west,

--- a/_maps/map_files/Oshan/Oshan.dmm
+++ b/_maps/map_files/Oshan/Oshan.dmm
@@ -11266,7 +11266,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
-/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/breath/muzzle,
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
 	},
@@ -28570,8 +28570,8 @@
 /obj/item/storage/toolbox/electrical/medical,
 /obj/item/tank/internals/anesthetic,
 /obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
+/obj/item/clothing/mask/breath/muzzle,
 /obj/item/wheelchair,
 /obj/item/wheelchair,
 /obj/item/wheelchair,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1750,7 +1750,7 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -72617,13 +72617,13 @@
 /obj/item/tank/internals/anesthetic{
 	pixel_x = -3
 	},
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = -3
 	},
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = -3
 	},
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_y = -3
 	},
 /obj/machinery/button/door/directional/north{

--- a/_maps/shuttles/emergency_bballhooper.dmm
+++ b/_maps/shuttles/emergency_bballhooper.dmm
@@ -385,7 +385,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/table,
 /obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical{
+/obj/item/clothing/mask/breath/muzzle{
 	pixel_x = 5;
 	pixel_y = 2
 	},

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -486,7 +486,7 @@
 	},
 /obj/item/clothing/under/syndicate/scrubs,
 /obj/item/clothing/gloves/latex/nitrile,
-/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/muzzle,
 /obj/item/tank/internals/anesthetic,
 /turf/open/floor/iron,
 /area/shuttle/syndicate/medical)

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -57,8 +57,10 @@
 	righthand_file = 'icons/mob/inhands/clothing/masks_righthand.dmi'
 	body_parts_covered = NONE
 	flags_cover = NONE
-	armor_type = /datum/armor/breath_muzzle
+	clothing_flags = MASKINTERNALS | BLOCKS_SPEECH
+	armor_type = /datum/armor/muzzle_breath
 	equip_delay_other = 25 // my sprite has 4 straps, a-la a head harness. takes a while to equip, longer than a muzzle
+	adjustable = FALSE //no sprites :(
 
 /*
 /obj/item/clothing/mask/breath/muzzle/Initialize(mapload)

--- a/code/modules/clothing/masks/muzzle.dm
+++ b/code/modules/clothing/masks/muzzle.dm
@@ -18,23 +18,6 @@
 			return
 	return ..()
 
-/obj/item/clothing/mask/breath/muzzle
-	name = "surgery mask"
-	desc = "To silence those pesky patients before putting them under."
-	icon_state = "breathmuzzle"
-	inhand_icon_state = "breathmuzzle"
-	lefthand_file = 'icons/mob/inhands/clothing/masks_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/clothing/masks_righthand.dmi'
-	body_parts_covered = NONE
-	flags_cover = NONE
-	clothing_flags = MASKINTERNALS | BLOCKS_SPEECH
-	armor_type = /datum/armor/muzzle_breath
-	equip_delay_other = 25 // my sprite has 4 straps, a-la a head harness. takes a while to equip, longer than a muzzle
-
-/obj/item/clothing/mask/breath/muzzle/examine(mob/user)
-	. = ..()
-	. += "Does not block surgery on covered bodyparts."
-
 /datum/armor/muzzle_breath
 	bio = 100
 


### PR DESCRIPTION

## About The Pull Request
removes duplicate code, theres two surgical masks in codes right now (so examine text shows twice). this fixes that

replaces medical masks with surgical masks which allow you to do surgery on the target's head.
## Why It's Good For The Game
dupe code bad. surgical masks allwo you to do surgery on the head with anesthetic so you can do some evil brainwashing or just overall make anesthetic maybe usable 
## Testing
it doesnt have dupe examine text. i aint teesting every map doe
## Changelog
:cl: Cujo
qol: Replaces medical masks near anesthetic tanks with surgery masks on most maps. This allows you to do surgery on the head whilst having the mask on. 
fix: Fixed examine text on surgery masks showing a duplicate message.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
