### PR TITLE
Gives IceBox kitchen a button for their shutters

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -55772,6 +55772,11 @@
 /obj/machinery/oven/range,
 /obj/effect/turf_decal/siding/white/corner,
 /obj/machinery/light/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "kitchencounter";
+	name = "Counter Shutters Control";
+	req_access = list("kitchen")
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen)
 "qZL" = (


### PR DESCRIPTION
## About The Pull Request

They have shutters but no button for it. Alas.

## Changelog

:cl:
fix: [IceBox] Added a button to toggle the kitchen's shutters.
/:cl: