### PR TITLE
Increase bio armor to 100 on contractor (for real this time)

### DIFF
--- a/monkestation/code/modules/antagonists/contractor/items/modsuit/theme.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/modsuit/theme.dm
@@ -75,7 +75,7 @@
 	laser = 35
 	energy = 35
 	bomb = 30
-	bio = 40
+	bio = 100
 	fire = 80
 	acid = 90
 	wound = 30


### PR DESCRIPTION

## About The Pull Request
I forgot to commit it in https://github.com/Monkestation/Monkestation2.0/pull/12161

## Why It's Good For The Game

all spaceproof mods have biohazard 100, no reason for this one in particular to not have it

## Testing

haven't tested but should work, just a variable change

## Changelog
:cl:
balance: bumps up contractor modsuit biohazard protection to 100 (missed this change previously)
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
