### PR TITLE
Prunes AI research slightly

### DIFF
--- a/code/modules/research/techweb/ai_nodes.dm
+++ b/code/modules/research/techweb/ai_nodes.dm
@@ -73,7 +73,7 @@
 	display_name = "Advanced CPU Sockets"
 	description = "256 bit computing allows the introduction of another CPU core."
 	design_ids = list("ai_cpu_socket_3")
-	prereq_ids = list("ai_arch_256", "ai_cpu_2")
+	prereq_ids = list("ai_arch_256")
 	research_costs = list(TECHWEB_POINT_TYPE_AI = TECHWEB_TIER_3_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE)
 
@@ -100,7 +100,7 @@
 	display_name = "Advanced Memory Bus"
 	description = "256 bit computing allows the introduction of another memory module."
 	design_ids = list("ai_ram_socket_3")
-	prereq_ids = list("ai_arch_256", "ai_ram_2")
+	prereq_ids = list("ai_arch_256")
 	research_costs = list(TECHWEB_POINT_TYPE_AI = TECHWEB_TIER_3_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE)
 


### PR DESCRIPTION

## About The Pull Request
Ai CPU 3 and RAM 3 no longer have CPU 2 AND RAM 2 as prerequisites. As they both also have 256bit Computing as a prereq which requires CPU/RAM 2 as a prereq.

Effectively this changes nothing gameplay/research wise, but making the research tree slightly easier to follow.
## Why It's Good For The Game

## Testing
## Changelog
:cl:
qol: Ai research had redundant prerequisites pruned from CPU 3 and RAM 3 
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
