### PR TITLE
Make strongarms preconfigured instead of two rights, because who has two right arms

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -152,5 +152,8 @@ End Monkestation Removal*/
 	name = "Strong-Arm Implant Set"
 	desc = "A crate containing two implants, which can be surgically implanted to empower the strength of human arms. Warranty void if exposed to electromagnetic pulses."
 	cost = CARGO_CRATE_VALUE * 6
-	contains = list(/obj/item/organ/internal/cyberimp/arm/strongarm = 2)
+	contains = list(
+		/obj/item/organ/internal/cyberimp/arm/strongarm,
+		/obj/item/organ/internal/cyberimp/arm/strongarm/l,
+		)
 	crate_name = "Strong-Arm implant crate"

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -155,5 +155,5 @@ End Monkestation Removal*/
 	contains = list(
 		/obj/item/organ/internal/cyberimp/arm/strongarm,
 		/obj/item/organ/internal/cyberimp/arm/strongarm/l,
-		)
+	)
 	crate_name = "Strong-Arm implant crate"


### PR DESCRIPTION

## About The Pull Request
Makes strongarms crates have a left and a right implant. Because otherwise its just annoying
## Why It's Good For The Game
## Testing
## Changelog
:cl:
qol: Strongarm crates now contain a left and a right implant instead of two rights
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
