### PR TITLE
Some traitor uplink weapon changes

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -58,10 +58,6 @@
 #define CALIBER_HARPOON "harpoon"
 /// The caliber used by the rebar crossbow.
 #define CALIBER_REBAR "sharpened rod"
-/// The caliber used by the rebar crossbow when forced to hold 2 rods.
-#define CALIBER_REBAR_FORCED "sharpened rod"
-/// The caliber used by the syndicate rebar crossbow.
-#define CALIBER_REBAR_SYNDIE "sharpened rod"
 /// The caliber used by the meat hook.
 #define CALIBER_HOOK "hook"
 /// The caliber used by the changeling tentacle mutation.

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -459,6 +459,12 @@
 	extra_to_spawn = /obj/item/ammo_box/magazine/whispering_jester_45_magazine
 	ammo_box_to_spawn = /obj/item/ammo_box/c45/caseless
 
+/obj/item/storage/toolbox/guncase/traitor/revolver
+	name = "\improper Syndicate revolver gun case"
+	weapon_to_spawn = /obj/item/gun/ballistic/revolver/syndicate
+	extra_to_spawn = /obj/item/ammo_box/a357
+	ammo_box_to_spawn = null
+
 /obj/item/storage/toolbox/guncase/traitor/wespe
 	name = "\improper Wespe pistol gun case"
 	weapon_to_spawn = /obj/item/gun/ballistic/automatic/pistol/sol/evil/unrestricted

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -411,7 +411,9 @@
 	new weapon_to_spawn (src)
 	for(var/i in 1 to 2)
 		new extra_to_spawn (src)
-	new ammo_box_to_spawn(src)
+
+	if(ammo_box_to_spawn != null)
+		new ammo_box_to_spawn(src)
 
 /obj/item/storage/toolbox/guncase/traitor/update_icon_state()
 	. = ..()
@@ -463,7 +465,11 @@
 	name = "\improper Syndicate revolver gun case"
 	weapon_to_spawn = /obj/item/gun/ballistic/revolver/syndicate
 	extra_to_spawn = /obj/item/ammo_box/a357
-	ammo_box_to_spawn = null
+
+/obj/item/storage/toolbox/guncase/traitor/revolver/PopulateContents()
+	new weapon_to_spawn (src)
+	for(var/i in 1 to 3)
+		new extra_to_spawn (src)
 
 /obj/item/storage/toolbox/guncase/traitor/wespe
 	name = "\improper Wespe pistol gun case"

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -412,7 +412,7 @@
 	for(var/i in 1 to 2)
 		new extra_to_spawn (src)
 
-	if(ammo_box_to_spawn != null)
+	if(ammo_box_to_spawn)
 		new ammo_box_to_spawn(src)
 
 /obj/item/storage/toolbox/guncase/traitor/update_icon_state()

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -467,9 +467,9 @@
 	extra_to_spawn = /obj/item/ammo_box/a357
 
 /obj/item/storage/toolbox/guncase/traitor/revolver/PopulateContents()
-	new weapon_to_spawn (src)
+	new weapon_to_spawn(src)
 	for(var/i in 1 to 3)
-		new extra_to_spawn (src)
+		new extra_to_spawn(src)
 
 /obj/item/storage/toolbox/guncase/traitor/wespe
 	name = "\improper Wespe pistol gun case"

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -48,7 +48,7 @@
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/syndie
 	max_ammo = 3
 	caliber = CALIBER_REBAR_SYNDIE
-	ammo_type = /obj/item/ammo_casing/rebar
+	ammo_type = /obj/item/ammo_casing/rebar/syndie
 
 /obj/item/ammo_box/magazine/internal/boltaction/minerjdj
 	name = "GIGANTIC RIFLE BREECH THAT SHOULD NOT EXIST"

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -33,7 +33,7 @@
 	caliber = CALIBER_HARPOON
 	ammo_type = /obj/item/ammo_casing/harpoon
 
-/obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/normal
+/obj/item/ammo_box/magazine/internal/boltaction/rebarxbow
 	name = "single round magazine"
 	max_ammo = 1
 	caliber = CALIBER_REBAR
@@ -42,12 +42,12 @@
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/force
 	name = "two round magazine"
 	max_ammo = 2
-	caliber = CALIBER_REBAR_FORCED
+	caliber = CALIBER_REBAR
 	ammo_type = /obj/item/ammo_casing/rebar
 
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/syndie
 	max_ammo = 3
-	caliber = CALIBER_REBAR_SYNDIE
+	caliber = CALIBER_REBAR
 	ammo_type = /obj/item/ammo_casing/rebar/syndie
 
 /obj/item/ammo_box/magazine/internal/boltaction/minerjdj

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -46,7 +46,6 @@
 	ammo_type = /obj/item/ammo_casing/rebar
 
 /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/syndie
-	max_ammo = 3
 	caliber = CALIBER_REBAR
 	ammo_type = /obj/item/ammo_casing/rebar/syndie
 

--- a/code/modules/projectiles/guns/ballistic/crossbow.dm
+++ b/code/modules/projectiles/guns/ballistic/crossbow.dm
@@ -22,7 +22,7 @@
 	cartridge_wording = "rod"
 	weapon_weight = WEAPON_HEAVY
 	initial_caliber = CALIBER_REBAR
-	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/normal
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow
 	recoil = 0
 	fire_sound = 'sound/items/xbow_lock.ogg'
 	can_be_sawn_off = FALSE
@@ -93,7 +93,6 @@
 	inhand_icon_state = "rebarxbowsyndie"
 	worn_icon_state = "rebarxbowsyndie"
 	w_class = WEIGHT_CLASS_NORMAL
-	initial_caliber = CALIBER_REBAR_SYNDIE
 	draw_time = 1
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/syndie
 

--- a/code/modules/projectiles/guns/ballistic/crossbow.dm
+++ b/code/modules/projectiles/guns/ballistic/crossbow.dm
@@ -93,7 +93,7 @@
 	inhand_icon_state = "rebarxbowsyndie"
 	worn_icon_state = "rebarxbowsyndie"
 	w_class = WEIGHT_CLASS_NORMAL
-	initial_caliber = CALIBER_REBAR
+	initial_caliber = CALIBER_REBAR_SYNDIE
 	draw_time = 1
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/rebarxbow/syndie
 

--- a/code/modules/projectiles/guns/ballistic/crossbow.dm
+++ b/code/modules/projectiles/guns/ballistic/crossbow.dm
@@ -87,7 +87,7 @@
 /obj/item/gun/ballistic/rifle/rebarxbow/syndie
 	name = "syndicate rebar crossbow"
 	desc = "The syndicate liked the bootleg rebar crossbow NT engineers made, so they showed what it could be if properly developed. \
-			Holds three shots without a chance of exploding, and features a built in scope. Compatible with all known crossbow ammunition."
+			features a built in scope. Compatible with all known crossbow ammunition."
 	base_icon_state = "rebarxbowsyndie"
 	icon_state = "rebarxbowsyndie"
 	inhand_icon_state = "rebarxbowsyndie"

--- a/code/modules/projectiles/projectile/bullets/crossbow.dm
+++ b/code/modules/projectiles/projectile/bullets/crossbow.dm
@@ -32,7 +32,7 @@
 	icon_state = "rebar"
 	damage = 60
 	dismemberment = 2 //It's a budget sniper rifle.
-	armour_penetration = 30 //A bit better versus armor.
+	armour_penetration = 60 //A bit better versus armor.
 	wound_bonus = 10
 	bare_wound_bonus = 20
 	embed_falloff_tile = -3

--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -17,7 +17,7 @@
 
 /datum/uplink_item/ammo/pistol
 	name = "9mm Magazine Case"
-	desc = "A case containing three additional 8-round 9mm magazines, compatible with the Makarov pistol, as well as \
+	desc = "A case containing three additional 12-round 9mm magazines, compatible with the Makarov pistol, as well as \
 		a box of loose 9mm ammunition."
 	item = /obj/item/storage/toolbox/guncase/traitor/ammunition
 	cost = 2
@@ -26,7 +26,7 @@
 
 /datum/uplink_item/ammo/pistolap
 	name = "9mm Armour Piercing Magazine"
-	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
+	desc = "An additional 12-round 9mm magazine, compatible with the Makarov pistol. \
 			These rounds are less effective at injuring the target but penetrate protective gear."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/ap
@@ -35,7 +35,7 @@
 
 /datum/uplink_item/ammo/pistolhp
 	name = "9mm Hollow Point Magazine"
-	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
+	desc = "An additional 12-round 9mm magazine, compatible with the Makarov pistol. \
 			These rounds are more damaging but ineffective against armour."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/hp
@@ -44,7 +44,7 @@
 
 /datum/uplink_item/ammo/pistolfire
 	name = "9mm Incendiary Magazine"
-	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
+	desc = "An additional 12-round 9mm magazine, compatible with the Makarov pistol. \
 			Loaded with incendiary rounds which inflict little damage, but ignite the target."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/fire

--- a/code/modules/uplink/uplink_items/firearms.dm
+++ b/code/modules/uplink/uplink_items/firearms.dm
@@ -49,9 +49,9 @@
 /datum/uplink_item/firearms/revolver
 	name = "Syndicate Revolver"
 	desc = "Waffle Co.'s modernized Syndicate revolver. Fires 7 brutal rounds of .357 Magnum."
-	item = /obj/item/gun/ballistic/revolver/syndicate
+	item = /obj/item/storage/toolbox/guncase/traitor/revolver
 	progression_minimum = 30 MINUTES
-	cost = 10
+	cost = 12
 	surplus = 50
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
@@ -59,7 +59,7 @@
 	name = "Syndicate Rebar Crossbow"
 	desc = "A much more proffessional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
 	item = /obj/item/storage/box/syndie_kit/rebarxbowsyndie
-	cost = 10
+	cost = 12
 
 /datum/uplink_item/firearms/laser_musket
 	name = "Syndicate Laser Musket"
@@ -98,12 +98,6 @@
 	desc = "A single surplus Plastikov SMG and two extra magazines. A terrible weapon, perfect for henchmen."
 	item = /obj/item/storage/box/syndie_kit/shit_smg_bundle
 	cost = 4
-
-/datum/uplink_item/firearms/renoster
-	name = "Renoster Shotgun Case"
-	desc = "A twelve gauge shotgun with an eight shell capacity underneath. Comes with two boxes of buckshot."
-	item = /obj/item/storage/toolbox/guncase/nova/opfor/renoster
-	cost = 10
 
 /datum/uplink_item/firearms/slipstick
 	name = "Syndie Lipstick"

--- a/code/modules/uplink/uplink_items/firearms.dm
+++ b/code/modules/uplink/uplink_items/firearms.dm
@@ -59,7 +59,7 @@
 	name = "Syndicate Rebar Crossbow"
 	desc = "A much more proffessional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
 	item = /obj/item/storage/box/syndie_kit/rebarxbowsyndie
-	cost = 12
+	cost = 8
 
 /datum/uplink_item/firearms/laser_musket
 	name = "Syndicate Laser Musket"

--- a/code/modules/uplink/uplink_items/firearms.dm
+++ b/code/modules/uplink/uplink_items/firearms.dm
@@ -57,7 +57,7 @@
 
 /datum/uplink_item/firearms/rebarxbowsyndie
 	name = "Syndicate Rebar Crossbow"
-	desc = "A much more proffessional version of the engineer's bootleg rebar crossbow. 3 shot mag, quicker loading, and better ammo. Owners manual included."
+	desc = "A much more proffessional version of the engineer's bootleg rebar crossbow. Quicker loading, and better ammo. Owners manual included."
 	item = /obj/item/storage/box/syndie_kit/rebarxbowsyndie
 	cost = 8
 


### PR DESCRIPTION

## About The Pull Request

Replaces the syndie revolver with a syndie revolver case that comes with 3 speedloaders and bumps the price to 12 TC

Reduced the syndicate rebar crossbow ammo cap from 3 to 1, increased the AP of jagged rods and reduced the price to 8 TC

also fixed the makarov magazine descriptions to say 12 rounds instead of 8

also removed a duplicate renoster uplink entry definition
## Why It's Good For The Game

the revolver is in a spot where it's difficult to justify buying it when the weapons in its price range or lower have a way better ammo economy and longevity in fights (makarov comes with mags and ammo boxes, rebar just needs rods for jagged ammo and musket is charged by using inhand)

Syndie rebar ammo cap nerf is cause it's just not fun to fight against even when you have proper the proper equipment to deal with it (armor and ligament reinforcement surgery) it can still kill you in one burst, this deligates it to a maiming/softening role instead


## Testing

Launched local, used debug uplink and bought and used both, everything works

## Changelog
:cl:
balance: Replaced the syndicate revolver in the traitor uplink with a revolver case that comes with the revolver and 3 speedloaders for 12TC
balance: Syndicate rebar crossbow is now 8 tc
balance: Syndicate rebar crossbow now starts with a jagged iron rods a the starting ammo
balance: Syndicate rebar crossbow now only holds one rod in its internal magazine
spellcheck: makarov magazine descriptions now correctly say 12 rounds instead of 8 on the uplink
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
