### PR TITLE
makes mute & corporate sponsorship incompatible quirks

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -56,7 +56,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Prosthetic Limb", "Monoplegic"),
 		list("Cyborg Pre-screened dogtag", "Unborgable"),
 		list("Revival Blacklist", "Uncloneable Neurons"),
-		list("Mute", "Fluffy Tongue")
+		list("Mute", "Fluffy Tongue"),
+		list("Mute", "Corporate Sponsorship"),
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()


### PR DESCRIPTION

## About The Pull Request
makes mute and corporate sponsorship incompatible
## Why It's Good For The Game
oversight unless corporate sponsor does something but pretty sure it just makes you talk which You Can't Do if you are a mute so
## Testing
it compiled 
## Changelog
:cl: Cujo
fix: Makes mute and corporate sponsorship incompatible quirks
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
