### PR TITLE
0perating room and lavaland base fans

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -60758,7 +60758,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/medical{
-	name = "0perating Theater"
+	name = "Operating Theater"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /obj/effect/turf_decal/tile/blue/opposingcorners,

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -7463,6 +7463,7 @@
 	name = "Mining Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating/lavaland_atmos,
 /area/mine/production)
 "Ra" = (


### PR DESCRIPTION

## About The Pull Request
- Heliostation 0perating room is no longer spelt with a Zero
- Lavaland base side entrance has a tiny fan now
## Why It's Good For The Game
Spellcheck closes: #12246

Every other major entrance/exit has one and it doesn't even have a airlock cycler to anything so it gets slightly annoying to actually practically use thanks to space wind.
## Testing
## Changelog
:cl:
map: Heliostation 0perating room is now Operating room
map: Lavaland mining station now has a tiny fan on the side exit
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
