### PR TITLE
2 minor AI fixes

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized/server_cabinet.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/server_cabinet.dm
@@ -42,7 +42,7 @@
 	register_context()
 
 /obj/machinery/ai/server_cabinet/Destroy(force)
-	installed_racks.Cut()
+	LAZYCLEARLIST(installed_racks)
 	//Recalculate all the CPUs and RAM :)
 	linked_os.update_hardware()
 	linked_os = null

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -221,15 +221,6 @@
 	else
 		eyeobj.RemoveInvisibility(type)
 
-/mob/living/silicon/ai/verb/toggle_acceleration()
-	set category = "AI Commands"
-	set name = "Toggle Camera Acceleration"
-
-	if(incapacitated())
-		return
-	acceleration = !acceleration
-	to_chat(usr, "Camera acceleration has been toggled [acceleration ? "on" : "off"].")
-
 /mob/eye/camera/ai/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), message_range)
 	. = ..()
 	if(relay_speech && speaker && ai && !radio_freq && speaker != ai && SScameras.is_visible_by_cameras(speaker))


### PR DESCRIPTION
## About The Pull Request

Server cabinets no longer create copies of itself
AI no longer has "Toggle Camera Acceleration" verb that completely replaces the need to research camera acceleration

## Why It's Good For The Game

2 small fixes now that I got a bit of time.

Closes https://github.com/Monkestation/Monkestation2.0/issues/12212
Closes https://github.com/Monkestation/Monkestation2.0/issues/12165

## Changelog

:cl:
fix: AIs no longer have Toggle Camera Acceleration verb.
fix: Server cabinets no longer duplicate themselves when you deconstruct it.
/:cl: