### PR TITLE
Engiborgs no longer consume 5 sheets to refill 1 sheet

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	embed_type = /datum/embedding/rods
 	novariants = TRUE
 	matter_amount = 2
-	cost = 250
+	cost = HALF_SHEET_MATERIAL_AMOUNT
 	source = /datum/robot_energy_storage/iron
 	merge_type = /obj/item/stack/rods
 

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -30,7 +30,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	point_value = 2
 	tableVariant = /obj/structure/table/glass
 	matter_amount = 4
-	cost = 500
+	cost = SHEET_MATERIAL_AMOUNT
 	source = /datum/robot_energy_storage/glass
 
 /datum/armor/sheet_glass

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	tableVariant = /obj/structure/table
 	material_type = /datum/material/iron
 	matter_amount = 4
-	cost = 500
+	cost = SHEET_MATERIAL_AMOUNT
 	source = /datum/robot_energy_storage/iron
 	stairs_type = /obj/structure/stairs
 

--- a/code/modules/mob/living/silicon/robot/energy_storage.dm
+++ b/code/modules/mob/living/silicon/robot/energy_storage.dm
@@ -42,11 +42,15 @@
 
 /datum/robot_energy_storage/iron
 	name = "Iron Synthesizer"
+	max_energy = SHEET_MATERIAL_AMOUNT * 60
+	recharge_rate = SHEET_MATERIAL_AMOUNT * 7.5
 	renewable = FALSE
 	mat_type = /datum/material/iron
 
 /datum/robot_energy_storage/glass
 	name = "Glass Synthesizer"
+	max_energy = SHEET_MATERIAL_AMOUNT * 60
+	recharge_rate = SHEET_MATERIAL_AMOUNT * 7.5
 	renewable = FALSE
 	mat_type = /datum/material/glass
 

--- a/code/modules/mob/living/silicon/robot/model/_model.dm
+++ b/code/modules/mob/living/silicon/robot/model/_model.dm
@@ -200,7 +200,7 @@
 	if(!sendmats)
 		return
 	var/obj/machinery/recharge_station/charger = cyborg_owner.loc
-	if(istype(charger))
+	if(!istype(charger))
 		return
 	var/datum/component/material_container/mat_container = charger.materials.mat_container
 	if(!mat_container || charger.materials.on_hold())
@@ -211,7 +211,7 @@
 			continue
 		if(energy_storage.max_energy == energy_storage.energy) // Skipping full.
 			continue
-		var/to_stock = min(energy_storage.max_energy / 8, energy_storage.max_energy - energy_storage.energy, mat_container.get_material_amount(energy_storage.mat_type))
+		var/to_stock = min(energy_storage.recharge_rate / 8, energy_storage.max_energy - energy_storage.energy, mat_container.get_material_amount(energy_storage.mat_type))
 		if(!to_stock) // Silo doesn't have what we want.
 			continue
 		energy_storage.energy += charger.materials.use_materials(list(GET_MATERIAL_REF(energy_storage.mat_type) = to_stock), action = "resupplied", name = "units")

--- a/code/modules/mob/living/silicon/robot/model/_model.dm
+++ b/code/modules/mob/living/silicon/robot/model/_model.dm
@@ -211,7 +211,7 @@
 			continue
 		if(energy_storage.max_energy == energy_storage.energy) // Skipping full.
 			continue
-		var/to_stock = min(energy_storage.recharge_rate / 8, energy_storage.max_energy - energy_storage.energy, mat_container.get_material_amount(energy_storage.mat_type))
+		var/to_stock = min(energy_storage.recharge_rate, energy_storage.max_energy - energy_storage.energy, mat_container.get_material_amount(energy_storage.mat_type))
 		if(!to_stock) // Silo doesn't have what we want.
 			continue
 		energy_storage.energy += charger.materials.use_materials(list(GET_MATERIAL_REF(energy_storage.mat_type) = to_stock), action = "resupplied", name = "units")


### PR DESCRIPTION

## About The Pull Request
Fixes engineering cyborgs inability to recharge/refill their materials due to an inverted check.

The iron and glass synthesizer for engineering cyborgs have been updated to use `*_MATERIAL_AMOUNT` defines since it was still using values back when these defines didn't exist and when a sheet was equal to 500.

Because of the above, engineering cyborgs now correctly consumes 1sheet of metal instead of 5 sheets to refill their synthesizer(s).

## Why It's Good For The Game
Bugfix and improvements.

## Testing
Iron & Glass Synthesizer now uses correct units (100u per sheet -> 6000):
<img width="222" height="178" alt="image" src="https://github.com/user-attachments/assets/24e2dbf2-d395-4ea3-a6f8-beb7c6302e3e" />

Iron & Glass Synthesizer after making a sheet of r-glass (0.5 metal sheet + 1 glass sheet):
<img width="213" height="38" alt="image" src="https://github.com/user-attachments/assets/9e186bec-83b2-4e1d-9c60-bed6a96f497d" />

Iron & Glass Synthesizer after making a displaced girder + full tile window (2 sheets per):
<img width="212" height="33" alt="image" src="https://github.com/user-attachments/assets/f1670277-bd38-4211-bf74-4d2c9f13dd94" />

Refilling after consuming material above:
<img width="200" height="263" alt="bloon_alert" src="https://github.com/user-attachments/assets/f895563a-30de-4808-a3b6-069d41be03d1" />
## Changelog
:cl:
qol: Engineering cyborg's status tab now displays a more accurate amount of iron/glass for their synthesizer.
fix: Refilling metal/glass via cyborg rechargers for engineering cyborgs now works.
fix: Refilling metal/glass via cyborg rechargers no longer consumes 5 sheets to refill 1 sheet of iron.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
