### PR TITLE
fix blood from virus dishes not transferring diseases

### DIFF
--- a/monkestation/code/modules/virology/items/virusdish.dm
+++ b/monkestation/code/modules/virology/items/virusdish.dm
@@ -116,7 +116,15 @@ GLOBAL_LIST_INIT(virusdishes, list())
 			return ITEM_INTERACT_BLOCKING
 		growth = growth - 50
 		var/obj/item/reagent_containers/syringe/syringe_tool = tool
-		var/list/data = list("viruses"=null,"blood_DNA"=null,"blood_type" = get_blood_type(BLOOD_TYPE_O_MINUS), "resistances"=null,"trace_chem"=null,"viruses"=list(),"immunity"=list())
+		var/list/data = list(
+			"viruses"= null,
+			"blood_DNA"= null,
+			"blood_type" = get_blood_type(BLOOD_TYPE_O_MINUS),
+			"resistances"= null,
+			"trace_chem"= null,
+			"viruses"= list(),
+			"immunity"= list()
+		)
 		data["viruses"] |= list(contained_virus)
 		syringe_tool.reagents.add_reagent(/datum/reagent/blood, syringe_tool.volume, data, creation_callback = CALLBACK(src, PROC_REF(on_blood_created)))
 		to_chat(user, span_notice("You take some blood from the [src]."))

--- a/monkestation/code/modules/virology/items/virusdish.dm
+++ b/monkestation/code/modules/virology/items/virusdish.dm
@@ -116,7 +116,7 @@ GLOBAL_LIST_INIT(virusdishes, list())
 			return ITEM_INTERACT_BLOCKING
 		growth = growth - 50
 		var/obj/item/reagent_containers/syringe/syringe_tool = tool
-		var/list/data = list("viruses"=null,"blood_DNA"=null,"resistances"=null,"trace_chem"=null,"viruses"=list(),"immunity"=list())
+		var/list/data = list("viruses"=null,"blood_DNA"=null,"blood_type" = get_blood_type(BLOOD_TYPE_O_MINUS), "resistances"=null,"trace_chem"=null,"viruses"=list(),"immunity"=list())
 		data["viruses"] |= list(contained_virus)
 		syringe_tool.reagents.add_reagent(/datum/reagent/blood, syringe_tool.volume, data, creation_callback = CALLBACK(src, PROC_REF(on_blood_created)))
 		to_chat(user, span_notice("You take some blood from the [src]."))

--- a/monkestation/code/modules/virology/items/virusdish.dm
+++ b/monkestation/code/modules/virology/items/virusdish.dm
@@ -117,13 +117,13 @@ GLOBAL_LIST_INIT(virusdishes, list())
 		growth = growth - 50
 		var/obj/item/reagent_containers/syringe/syringe_tool = tool
 		var/list/data = list(
-			"viruses"= null,
-			"blood_DNA"= null,
+			"viruses" = null,
+			"blood_DNA" = null,
 			"blood_type" = get_blood_type(BLOOD_TYPE_O_MINUS),
-			"resistances"= null,
-			"trace_chem"= null,
-			"viruses"= list(),
-			"immunity"= list()
+			"resistances" = null,
+			"trace_chem" = null,
+			"viruses" = list(),
+			"immunity" = list()
 		)
 		data["viruses"] |= list(contained_virus)
 		syringe_tool.reagents.add_reagent(/datum/reagent/blood, syringe_tool.volume, data, creation_callback = CALLBACK(src, PROC_REF(on_blood_created)))

--- a/monkestation/code/modules/virology/items/virusdish.dm
+++ b/monkestation/code/modules/virology/items/virusdish.dm
@@ -116,9 +116,9 @@ GLOBAL_LIST_INIT(virusdishes, list())
 			return ITEM_INTERACT_BLOCKING
 		growth = growth - 50
 		var/obj/item/reagent_containers/syringe/syringe_tool = tool
-		var/list/data = list("viruses"=null,"blood_DNA"=null,"blood_type"="O-","resistances"=null,"trace_chem"=null,"viruses"=list(),"immunity"=list())
+		var/list/data = list("viruses"=null,"blood_DNA"=null,"resistances"=null,"trace_chem"=null,"viruses"=list(),"immunity"=list())
 		data["viruses"] |= list(contained_virus)
-		syringe_tool.reagents.add_reagent(/datum/reagent/blood, syringe_tool.volume, data)
+		syringe_tool.reagents.add_reagent(/datum/reagent/blood, syringe_tool.volume, data, creation_callback = CALLBACK(src, PROC_REF(on_blood_created)))
 		to_chat(user, span_notice("You take some blood from the [src]."))
 		return ITEM_INTERACT_SUCCESS
 
@@ -176,6 +176,9 @@ GLOBAL_LIST_INIT(virusdishes, list())
 	if(user && target)
 		to_chat(user,span_notice("You empty \the [src]'s reagents into \the [target]."))
 	reagents.clear_reagents()
+
+/obj/item/weapon/virusdish/proc/on_blood_created(datum/reagent/new_blood)
+	new_blood.AddElement(/datum/element/blood_reagent, null, get_blood_type(BLOOD_TYPE_O_MINUS))
 
 /obj/item/weapon/virusdish/process()
 	if(!contained_virus || !open)


### PR DESCRIPTION
## About The Pull Request

title
because virus dishes just created blood out of literally nowhere it lacked `/datum/element/blood_reagent` which has procs used for reagent exposure (so disease spread included)
just gotta manually add it on creation

## Why It's Good For The Game

bug fix

## Testing

blood from virus dish has proper data and element
<img width="474" height="444" alt="image" src="https://github.com/user-attachments/assets/17b0ffc5-ff55-4bfe-b907-cecdd06cab07" />
<img width="644" height="831" alt="image" src="https://github.com/user-attachments/assets/e2acbd79-9abe-430a-b52f-0c3cde765d5a" />


## Changelog

:cl:
fix: blood from virus dishes now properly spreads diseases
/:cl:


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
