### PR TITLE
fix crash when examining people with bloody clothes

### DIFF
--- a/code/game/atoms/atom_examine.dm
+++ b/code/game/atoms/atom_examine.dm
@@ -144,10 +144,7 @@
 
 /// Icon displayed in examine
 /atom/proc/get_examine_icon(mob/user)
-	if(length(overlays) > 2 || (greyscale_colors && greyscale_config))
-		return ma2html(src, user)
-	else
-		return iconstate2html(icon, icon_state, "")
+	return icon2html(src, user)
 
 /**
  * Formats the atom's name into a string for use in examine (as the "title" of the atom)


### PR DESCRIPTION
## About The Pull Request

this sadly makes it so bloody overlays dont show up on examine so its more of a bandaid fix but at least it stops crashes

## Why It's Good For The Game

crashing clients is bad

## Changelog

:cl:
fix: fixed client crashes when examining people with bloody clothes
/:cl:


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
