### PR TITLE
`trans_id_to` calls `on_transfer_creation`

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -516,7 +516,7 @@
 			if(current_reagent.intercept_reagents_transfer(holder, cached_amount))//Use input amount instead.
 				break
 			force_stop_reagent_reacting(current_reagent)
-			holder.add_reagent(current_reagent.type, amount, trans_data, chem_temp, current_reagent.purity, current_reagent.ph, no_react = TRUE, ignore_splitting = current_reagent.chemical_flags & REAGENT_DONOTSPLIT)
+			holder.add_reagent(current_reagent.type, amount, trans_data, chem_temp, current_reagent.purity, current_reagent.ph, no_react = TRUE, ignore_splitting = current_reagent.chemical_flags & REAGENT_DONOTSPLIT, creation_callback = CALLBACK(src, PROC_REF(on_transfer_creation), current_reagent, holder))
 			remove_reagent(current_reagent.type, amount, 1)
 			break
 


### PR DESCRIPTION
## About The Pull Request

title
making blood into pills made it so it got rid of its blood reagent element 
hopefully makes disease pills possible again
closes #12279 

## Why It's Good For The Game

bug fix

## Changelog

:cl:
fix: making blood into pills should now properly transfer its blood reagent element
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
