### PR TITLE
Thesues robotics and flatpacker

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -64747,7 +64747,10 @@
 	pixel_x = -7
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/north,
+/obj/machinery/door/window/left/directional/north{
+	req_access = list("robotics");
+	name = "Robotic's Desk"
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Robotics Shutters";
 	id = "roboticsurgery"

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -13359,6 +13359,7 @@
 	dir = 9
 	},
 /obj/structure/table,
+/obj/item/flatpack,
 /obj/item/multitool,
 /obj/item/toy/figure/cargotech{
 	pixel_x = -8
@@ -22508,6 +22509,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
+/obj/item/flatpack,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "gJs" = (
@@ -83460,6 +83462,10 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/reinforced,
 /obj/machinery/airalarm/directional/north,
+/obj/item/flatpack{
+	pixel_x = 1;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "yhr" = (


### PR DESCRIPTION

## About The Pull Request
- Adds flatpacker to Theseus
- Robotics window is no longer no access
## Why It's Good For The Game
Missing asset thats standard on all other stations, closes: #11948
Otherwise if you get access to medical you can tide without issue into robotics.
## Testing
## Changelog
:cl:
map: Flatpackers have been added to Theseus.
map: Theseus Robotics Desk window is now under robotics access.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
