### PR TITLE
Cyborg RPED change and bluespace upgrade research change

### DIFF
--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -223,12 +223,6 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 
-/obj/item/storage/part_replacer/cyborg/Initialize(mapload)
-	. = ..()
-
-	atom_storage.max_slots = 200
-	atom_storage.max_total_storage = 400
-
 /obj/item/storage/part_replacer/proc/get_sorted_parts(ignore_stacks = FALSE)
 	var/list/part_list = list()
 	//Assemble a list of current parts, then sort them by their rating!

--- a/code/modules/research/techweb/cyborg_nodes.dm
+++ b/code/modules/research/techweb/cyborg_nodes.dm
@@ -164,9 +164,7 @@
 	display_name = "Cyborg Upgrades: Bluespace"
 	description = "Enabling compatibility of our bluespace technology for usage within cyborgs."
 	prereq_ids = list(
-		"cyborg_upgrades_engineering",
-		"cyborg_upgrades_medical",
-		"cyborg_upgrades_mining",
+		"adv_robotics",
 		"practical_bluespace"
 	)
 	design_ids = list(


### PR DESCRIPTION

## About The Pull Request
- Reduces the addtional storage given by Cyborg RPED.
- Reduces the required research for Cyborg Upgrades: Bluespace from practical bluespace, engineering cyborgs upgrades, mining cyborg upgrades, medical cyborg upgrades, to just practical bluespace and advanced robotics.
## Why It's Good For The Game
Practical bluespace is practically one of the most the most early rushed and fundamental research in the game for its normal counterpoints. Being unlocked in less than 5 minutes if you are trying. Mining satchel of holding, blue space rapid part exchange devices, and bluespace syringe. To get it on cyborg takes three years as you don't just need practical blue space, instead you need all three cyborg models respective base kit research, which combined means your invested into effectively 10+ minutes of dedicated research (Needing advanced engineering, advanced mining, advanced biotech to get the respective cyborg research to name a few) just to get a basic upgrade for everyone else unlocked usually at 5 minutes into the round. Without expierments

I can't speak to the lengths of blue space syringes on medical cyborgs, but satchels of holding are commonplace enough for miners to tide, withhold mats, or even kill over science not actually researching them as normal satchels are limiting in their capacity and crates limited by their movement and risk destruction. Bluespace RPED's are not that more crazy in practical terms for cyborgs. As their main selling points are 1. Their storage capacity (something I had already gave the cyborg one.) 2. The fact they fit in backpacks. (which doesn't matter to cyborgs) 3. You don't have to screwdriver open any panels. This is the only really applicable one. 
So dropping the several and expanding list of required cyborg upgrades prerequisites to just adv robotics akin to other upgrades like Night vision seems most practical.

As for nerfing the capacity of basic Cyborg RPED, back in #6131 I had increased the capacity by 4x as then it was an upgrade you had to get through engineering research which made it underwhelming and a little clunky to use. But now it is just base kit alongside the other change to make it easier to research the upgraded version, I feel its fair to adjust it back to it's original value.
## Testing
## Changelog
:cl:
balance: Cyborg RPED has had their capacity reduced back to their original value (200 parts -> 50 parts)
balance: Cyborg Upgrades: Bluespace has had it's research requirements reduced to practical_bluespace and adv_robotics
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
