### PR TITLE
fixes robotact typo

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosRobotact.jsx
+++ b/tgui/packages/tgui/interfaces/NtosRobotact.jsx
@@ -354,7 +354,7 @@ export const NtosRobotactContent = (props) => {
               <LabeledList.Item label="Status">
                 <Box color={masterAI_online ? 'good' : 'bad'}>
                   {!MasterAI_connected
-                    ? 'No Conection'
+                    ? 'No Connection'
                     : masterAI_online
                       ? 'Online'
                       : 'Unresponsive'}


### PR DESCRIPTION

## About The Pull Request
Fixes the typo that occurs within the cyborg-exclusive RoboTact app to correctly display "No Connection" instead of "No Conection" whenever they don't have a master AI.

## Why It's Good For The Game
Typo bad.

## Testing
None.

## Changelog
:cl:
spellcheck: Fixes the typo that within the RoboTact app when a cyborg has no connection to an AI.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
