### PR TITLE
fixes clockwork soul vessel not having clockwork antag status when becoming cyborg

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -372,14 +372,17 @@
 			new_borg.set_lockcharge(TRUE)
 			to_chat(new_borg, span_warning("Error: Servo motors unresponsive."))
 
-//monkestation edit start
-		if(be_clockwork && new_borg.mind)
+		var/should_convert_to_clockwork_cult = be_clockwork
+		if(istype(inserting_mmi, /obj/item/mmi/posibrain/soul_vessel))
+			var/obj/item/mmi/posibrain/soul_vessel/clockwork_mmi = inserting_mmi
+			if(clockwork_mmi.give_clock_cultist)
+				should_convert_to_clockwork_cult = TRUE
+		if(should_convert_to_clockwork_cult && new_borg.mind)
 			var/datum/antagonist/clock_cultist/new_servant_datum = new
 			if(old_servant_datum)
 				new_servant_datum.silent = TRUE
 			new_borg.mind.add_antag_datum(new_servant_datum)
 			new_servant_datum.silent = FALSE
-//monkestation edit end
 
 		return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/Monkestation/Monkestation2.0/issues/12308

Clockwork Soul Vessels that are placed into an empty default (non-clockwork) robot suit now correctly converts them into being a clockwork cultist when they become a cyborg.

## Why It's Good For The Game
Bugfix.

## Testing
Spawned Soul Vessel & Prebuilt Robot Suit. Entered Soul Vessel. Placed Soul Vessel into Prebuilt Robot Suit. Became cyborg with clockwork antag status.

## Changelog

:cl:
fix: Clockwork Soul Vessels now correctly carry over their clockwork antag status whenever becoming a cyborg.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
