### PR TITLE
fixes borg experimental welder not auto-refueling when off

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -758,13 +758,17 @@
 		return .
 	for(var/obj/item/weldingtool/largetank/cyborg/tool in borg.model.usable_modules)
 		tool.refuel = TRUE
+		tool.can_off_process = TRUE
+		if(!tool.welding)
+			START_PROCESSING(SSobj, tool)
 
 /obj/item/borg/upgrade/experimental_weldingtool/deactivate(mob/living/silicon/robot/borg, user = usr)
 	. = ..()
 	if(!.)
 		return .
 	for(var/obj/item/weldingtool/largetank/cyborg/tool in borg.model.usable_modules)
-		tool.refuel = FALSE
+		tool.refuel = initial(tool.refuel)
+		tool.can_off_process = initial(tool.can_off_process) // It'll stop processing on its own.
 
 /obj/item/borg/upgrade/gps
 	name = "cyborg global positioning system upgrade"


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/Monkestation/Monkestation2.0/issues/12267

Cyborg welders that have been upgraded via the experimental welder upgrade now correctly automatically refuel their welder when it is off.

## Why It's Good For The Game
Bugfix.
## Testing
Cyborg welder refueling per process when off (gif):
<img width="323" height="350" alt="refuel_when_off" src="https://github.com/user-attachments/assets/39fdb621-7d37-43f0-94c9-fff945db6bed" />

## Changelog
:cl:
fix: Cyborg welders that have been upgraded via the experimental welder upgrade now correctly automatically refuel their welder when it is off.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
