### PR TITLE
fixes action button update runtime from clockwork cult

### DIFF
--- a/code/modules/antagonists/clock_cult/ark_subsystem/_ark_subsystem.dm
+++ b/code/modules/antagonists/clock_cult/ark_subsystem/_ark_subsystem.dm
@@ -73,7 +73,7 @@ PROCESSING_SUBSYSTEM_DEF(the_ark)
 
 	if(COOLDOWN_FINISHED(src, action_button_update))
 		for (var/datum/mind/member in GLOB.main_clock_cult.members)
-			member.current.update_mob_action_buttons(UPDATE_BUTTON_STATUS)
+			member.current?.update_mob_action_buttons(UPDATE_BUTTON_STATUS)
 		COOLDOWN_START(src, action_button_update, 1 SECONDS)
 
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
Adds a null check so that a clockwork cultist member doesn't get action button updates when they don't have a body.
## Why It's Good For The Game
Stops this runtime from happening:
```
runtime error: Cannot execute null.update mob action buttons().
 - proc name: adjust clock power (/datum/controller/subsystem/processing/the_ark/proc/adjust_clock_power)
 ```
 
## Testing
None.

## Changelog
:cl:
fix: Fixes clockwork cult power generation trying to update action buttons for mobs that don't exist.
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
