### PR TITLE
Nanite chamber give more volume with lasers

### DIFF
--- a/monkestation/code/modules/research/nanites/nanite_chamber.dm
+++ b/monkestation/code/modules/research/nanites/nanite_chamber.dm
@@ -20,7 +20,7 @@
 	var/busy_icon_state
 	var/busy_message
 	var/message_cooldown = 0
-	var/nanites_given = 40 // 100 base with 2 t1 lasers
+	var/nanites_given = 30 // 100 base with 2 t1 lasers
 
 /obj/machinery/nanite_chamber/Initialize(mapload)
 	. = ..()
@@ -31,7 +31,7 @@
 	scan_level = 0
 	for(var/datum/stock_part/scanning_module/P in component_parts)
 		scan_level += P.tier
-	nanites_given = 40
+	nanites_given = 30
 	for(var/datum/stock_part/micro_laser/laser in component_parts) // (100 - 170 - 240 - 310)
 		nanites_given += laser.tier * 35
 

--- a/monkestation/code/modules/research/nanites/nanite_chamber.dm
+++ b/monkestation/code/modules/research/nanites/nanite_chamber.dm
@@ -73,7 +73,7 @@
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Priming nanites...", "[initial(icon_state)]_active"),40)
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Injecting...", "[initial(icon_state)]_active"),70)
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Activating nanites...", "[initial(icon_state)]_falling"),110)
-	addtimer(CALLBACK(src, PROC_REF(complete_injection), locked_state), 130)
+	addtimer(CALLBACK(src, PROC_REF(complete_injection), locked_state),130)
 
 /obj/machinery/nanite_chamber/proc/complete_injection(locked_state)
 	//TODO MACHINE DING

--- a/monkestation/code/modules/research/nanites/nanite_chamber.dm
+++ b/monkestation/code/modules/research/nanites/nanite_chamber.dm
@@ -20,6 +20,7 @@
 	var/busy_icon_state
 	var/busy_message
 	var/message_cooldown = 0
+	var/nanites_given = 60 // 130 base with 2 t1 lasers
 
 /obj/machinery/nanite_chamber/Initialize(mapload)
 	. = ..()
@@ -30,6 +31,9 @@
 	scan_level = 0
 	for(var/datum/stock_part/scanning_module/P in component_parts)
 		scan_level += P.tier
+	nanites_given = 60
+	for(var/datum/stock_part/micro_laser/laser in component_parts) // (130 - 200 - 270 - 340)
+		nanites_given += laser.tier * 35
 
 /obj/machinery/nanite_chamber/examine(mob/user)
 	. = ..()
@@ -69,7 +73,7 @@
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Priming nanites...", "[initial(icon_state)]_active"),40)
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Injecting...", "[initial(icon_state)]_active"),70)
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Activating nanites...", "[initial(icon_state)]_falling"),110)
-	addtimer(CALLBACK(src, PROC_REF(complete_injection), locked_state),130)
+	addtimer(CALLBACK(src, PROC_REF(complete_injection), locked_state), nanites_given)
 
 /obj/machinery/nanite_chamber/proc/complete_injection(locked_state)
 	//TODO MACHINE DING

--- a/monkestation/code/modules/research/nanites/nanite_chamber.dm
+++ b/monkestation/code/modules/research/nanites/nanite_chamber.dm
@@ -20,7 +20,7 @@
 	var/busy_icon_state
 	var/busy_message
 	var/message_cooldown = 0
-	var/nanites_given = 60 // 130 base with 2 t1 lasers
+	var/nanites_given = 40 // 100 base with 2 t1 lasers
 
 /obj/machinery/nanite_chamber/Initialize(mapload)
 	. = ..()
@@ -32,7 +32,7 @@
 	for(var/datum/stock_part/scanning_module/P in component_parts)
 		scan_level += P.tier
 	nanites_given = 60
-	for(var/datum/stock_part/micro_laser/laser in component_parts) // (130 - 200 - 270 - 340)
+	for(var/datum/stock_part/micro_laser/laser in component_parts) // (100 - 170 - 240 - 310)
 		nanites_given += laser.tier * 35
 
 /obj/machinery/nanite_chamber/examine(mob/user)
@@ -73,7 +73,7 @@
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Priming nanites...", "[initial(icon_state)]_active"),40)
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Injecting...", "[initial(icon_state)]_active"),70)
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "Activating nanites...", "[initial(icon_state)]_falling"),110)
-	addtimer(CALLBACK(src, PROC_REF(complete_injection), locked_state), nanites_given)
+	addtimer(CALLBACK(src, PROC_REF(complete_injection), locked_state), 130)
 
 /obj/machinery/nanite_chamber/proc/complete_injection(locked_state)
 	//TODO MACHINE DING
@@ -81,7 +81,7 @@
 	set_busy(FALSE)
 	if(!occupant)
 		return
-	occupant.AddComponent(/datum/component/nanites, 100)
+	occupant.AddComponent(/datum/component/nanites, nanites_given)
 
 /obj/machinery/nanite_chamber/proc/remove_nanites(datum/nanite_program/NP)
 	if(machine_stat & (NOPOWER|BROKEN))

--- a/monkestation/code/modules/research/nanites/nanite_chamber.dm
+++ b/monkestation/code/modules/research/nanites/nanite_chamber.dm
@@ -31,7 +31,7 @@
 	scan_level = 0
 	for(var/datum/stock_part/scanning_module/P in component_parts)
 		scan_level += P.tier
-	nanites_given = 60
+	nanites_given = 40
 	for(var/datum/stock_part/micro_laser/laser in component_parts) // (100 - 170 - 240 - 310)
 		nanites_given += laser.tier * 35
 

--- a/monkestation/code/modules/research/nanites/public_chamber.dm
+++ b/monkestation/code/modules/research/nanites/public_chamber.dm
@@ -19,10 +19,17 @@
 	var/busy = FALSE
 	var/busy_icon_state
 	var/message_cooldown = 0
+	var/nanites_given = 25 // 75 base with 2 t1 lasers
 
 /obj/machinery/public_nanite_chamber/Initialize(mapload)
 	. = ..()
 	occupant_typecache = GLOB.typecache_living
+
+/obj/machinery/public_nanite_chamber/RefreshParts()
+	. = ..()
+	nanites_given = 25
+	for(var/datum/stock_part/micro_laser/laser in component_parts) // (75 - 125 - 175 - 225)
+		nanites_given += laser.tier * 25
 
 /obj/machinery/public_nanite_chamber/RefreshParts()
 	. = ..()
@@ -61,7 +68,7 @@
 	if(attacker)
 		occupant.investigate_log("was injected with nanites with cloud ID [cloud_id] by [key_name(attacker)] using [src] at [AREACOORD(src)].", INVESTIGATE_NANITES)
 		log_combat(attacker, occupant, "injected", null, "with nanites via [src]")
-	occupant.AddComponent(/datum/component/nanites, 75, cloud_id)
+	occupant.AddComponent(/datum/component/nanites, nanites_given, cloud_id)
 
 /obj/machinery/public_nanite_chamber/proc/change_cloud(mob/living/attacker)
 	if(machine_stat & (NOPOWER|BROKEN))


### PR DESCRIPTION

## About The Pull Request
As you upgrade nanite chambers laser parts more nanite volume is given from public and regular chambers.
(75, 125, 175, 225) for publics. 
(100, 170, 240, 310) for regular chambers
Numbers are not something Im set on but public chambers shouldn't go any higher really.
## Why It's Good For The Game
Machines with parts but no tangible effects to those parts always are annoying. This gives a tangible effect. for something relivant.
## Testing
Did it at t1
<img width="605" height="423" alt="Screenshot 2026-08-03 202030" src="https://github.com/user-attachments/assets/f25c5f53-4d18-4406-8e0b-a9b06e6996f7" />
Did it at t4
<img width="640" height="394" alt="image_2026-08-03_202246111" src="https://github.com/user-attachments/assets/c2c5a60d-ea5a-45ce-b80c-4ff01181406b" />

## Changelog
:cl:
add: Upgrading nanite chambers lasers increases volume of nanites initially given, by 25 per laser tier for publics, and 35 for regular chambers
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
