### PR TITLE
removes cyborg from required_enemies for all antags, ups monster hunter minimum pop to roll

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -372,7 +372,6 @@
 	antag_datum = /datum/antagonist/nukeop
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,
 		JOB_HEAD_OF_SECURITY,

--- a/monkestation/code/modules/assault_ops/code/roundstart_event.dm
+++ b/monkestation/code/modules/assault_ops/code/roundstart_event.dm
@@ -24,7 +24,6 @@
 	maximum_antags = 5
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,
 		JOB_HEAD_OF_SECURITY,

--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodcult.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodcult.dm
@@ -24,7 +24,6 @@
 	)
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodling.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodling.dm
@@ -26,7 +26,6 @@
 	)
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_HEAD_OF_SECURITY,

--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodsuckers.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodsuckers.dm
@@ -27,7 +27,6 @@
 	)
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/changeling.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/changeling.dm
@@ -25,7 +25,6 @@
 	)
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/clockwork_cult.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/clockwork_cult.dm
@@ -24,7 +24,6 @@
 	)
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
@@ -29,7 +29,6 @@
 	maximum_antags = 10 //so 10 maximum is for the rare megapop rounds. i hope this just doesnt spawn 10 ops with 30 ready.
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/darkspawn.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/darkspawn.dm
@@ -27,7 +27,6 @@
 	required_enemies = 5
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_DETECTIVE,
 		JOB_HEAD_OF_SECURITY,

--- a/monkestation/code/modules/storytellers/converted_events/solo/ghosts/nuclear_operative_ghost.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/ghosts/nuclear_operative_ghost.dm
@@ -25,7 +25,6 @@
 	maximum_antags = 4
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/heretic.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/heretic.dm
@@ -28,7 +28,6 @@
 	)
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/monsterhunter.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/monsterhunter.dm
@@ -27,7 +27,7 @@
 		JOB_AI,
 		JOB_CYBORG,
 	)
-	min_players = 10 //no required enemies due to instead needing enemy antags
+	min_players = 30 //round ender
 	weight = 25
 	maximum_antags = 1
 	prompted_picking = TRUE

--- a/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
@@ -27,7 +27,6 @@
 	maximum_antags = 5
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/spies.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/spies.dm
@@ -30,7 +30,6 @@
 	)
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,

--- a/monkestation/code/modules/storytellers/converted_events/solo/wizard.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/wizard.dm
@@ -14,7 +14,6 @@
 	maximum_antags = 1
 	enemy_roles = list(
 		JOB_AI,
-		JOB_CYBORG,
 		JOB_CAPTAIN,
 		JOB_BLUESHIELD,
 		JOB_DETECTIVE,


### PR DESCRIPTION

## About The Pull Request
removes cyborgs from required_enemies for all antags

ups monster hunter min pop to 30 from 10
## Why It's Good For The Game
1st monster hunter is a round ender, 10 pop is comically low, regardless of it having a strict list of enemies it is capable of ending the round and should require a sufficiently high enough pop to roll. right now it is lower than the antags it's suppsoed to hunt

second, cyborgs have nothing to do with frankly any of these antags. cyborgs aren't meant to validhunt, they should not be weighed the same as security or heads of staff. Ai's are much more involved and while they shouldn't valid hunt either they atleast have some power over what's going on in the station and can be similarly valued to a head of staff. 

I can't imagine this changes much in terms of antags rolling outside of low pop hours where a handful of cyborgs can tip the list of required enemies easily over into high threat antags despite there being 0 command or 0 sec. Lists of required enemies were already extremely generous often requiring 5 at the maximum, if there is less than 5 heads of staff and security combined it doesn't need to roll a high threat. with 3 cyborgs and an AI it's already capable of rolling most antags, a single head of staff or even secass would push that over to the rest. 
If this does end up being too strict, it would be better to tone required enemies down rather than rely on cyborgs acting as fillers 
## Testing
no thansk
## Changelog
:cl: Cujo
balance: Cyborgs no longer count as required enemies for antag rolls.
balance: Monster Hunter now requires 30 pop to roll instead of 10.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
