### PR TITLE
you can now pull anime tails and they don't like it 

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -508,3 +508,8 @@
 	description = "What... what was that ominous feeling?"
 	mood_change = -10
 	timeout = 5 MINUTES
+
+/datum/mood_event/tailpulled
+	description = "I hate getting my tail pulled!"
+	mood_change = -3
+	timeout = 2 MINUTES

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -29,11 +29,6 @@
 	mood_change = 1
 	timeout = 2 MINUTES
 
-/datum/mood_event/tailpulled
-	description = "I love getting my tail pulled!"
-	mood_change = 1
-	timeout = 2 MINUTES
-
 /datum/mood_event/arcade
 	description = "I beat the arcade game!"
 	mood_change = 3

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -163,7 +163,7 @@
 		return
 
 	var/mob/living/carbon/possible_throwable = user.pulling
-	if(!possible_throwable.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL))
+	if(!possible_throwable.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL) && !possible_throwable.get_organ_slot(ORGAN_SLOT_EXTERNAL_ANIME_BOTTOM))
 		return
 
 	if(ishuman(possible_throwable))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -504,15 +504,18 @@
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
 			to_chat(helper, span_warning("[src] looks visibly upset as you pat [p_them()] on the head."))
 
-	else if ((helper.zone_selected == BODY_ZONE_PRECISE_GROIN) && !isnull(src.get_organ_by_type(/obj/item/organ/external/tail)))
+	else if ((helper.zone_selected == BODY_ZONE_PRECISE_GROIN) && (!isnull(src.get_organ_by_type(/obj/item/organ/external/tail)) || src.get_organ_slot(ORGAN_SLOT_EXTERNAL_ANIME_BOTTOM)))
 		helper.visible_message(span_notice("[helper] pulls on [src]'s tail!"), \
 					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(helper, src))
 		to_chat(helper, span_notice("You pull on [src]'s tail!"))
 		to_chat(src, span_notice("[helper] pulls on your tail!"))
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH)) //How dare they!
 			to_chat(helper, span_warning("[src] makes a grumbling noise as you pull on [p_their()] tail."))
+			add_mood_event("tailpulled", /datum/mood_event/tailpulled)
+			src.emote("scream")
 		else
 			add_mood_event("tailpulled", /datum/mood_event/tailpulled)
+			src.emote("scream")
 
 	else if ((helper.zone_selected == BODY_ZONE_PRECISE_GROIN) && (istype(head, /obj/item/clothing/head/costume/kitty) || istype(head, /obj/item/clothing/head/collectable/kitty)))
 		var/obj/item/clothing/head/faketail = head

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -509,7 +509,7 @@
 					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(helper, src))
 		to_chat(helper, span_notice("You pull on [src]'s tail!"))
 		to_chat(src, span_notice("[helper] pulls on your tail!"))
-		if(HAS_TRAIT(src, TRAIT_BADTOUCH) && HAS_TRAIT(src, TRAIT_ANALGESIA)) //How dare they!
+		if(HAS_TRAIT(src, TRAIT_BADTOUCH) && !HAS_TRAIT(src, TRAIT_ANALGESIA)) //How dare they!
 			to_chat(helper, span_warning("[src] makes a grumbling noise as you pull on [p_their()] tail."))
 			add_mood_event("tailpulled", /datum/mood_event/tailpulled)
 			src.emote("scream")

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -509,11 +509,11 @@
 					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(helper, src))
 		to_chat(helper, span_notice("You pull on [src]'s tail!"))
 		to_chat(src, span_notice("[helper] pulls on your tail!"))
-		if(HAS_TRAIT(src, TRAIT_BADTOUCH)) //How dare they!
+		if(HAS_TRAIT(src, TRAIT_BADTOUCH) && HAS_TRAIT(src, TRAIT_ANALGESIA)) //How dare they!
 			to_chat(helper, span_warning("[src] makes a grumbling noise as you pull on [p_their()] tail."))
 			add_mood_event("tailpulled", /datum/mood_event/tailpulled)
 			src.emote("scream")
-		else
+		else if (!HAS_TRAIT(src, TRAIT_ANALGESIA))
 			add_mood_event("tailpulled", /datum/mood_event/tailpulled)
 			src.emote("scream")
 


### PR DESCRIPTION

## About The Pull Request
allows you to pull anime tails 

all tail pulling is now a 2 minute negative moodlet. this would hurt and this isn't freaky tg 

also makes you scream, because it hurts 

ALSO allows you to hulk throw them too
## Why It's Good For The Game
removal of freaky tg tail pulling that is a positive moodlet for Some Reason, that moodlet didn't need to exist at all. instead replaces it with the ability to pull anime tails (on top of all regular tails) and makes the user scream and have a 2 minute negative moodlet. 

it's funny, leads to some silly things you can do in character and i dunno get sec involved over a tail pulling. not really any different than splashing an anime quirk user with water 

also fixes bad touch not applying the tail pulling moodlet 

Also allows you to hulk throw them, it works on every other tail no reason it shouldnt' work on these too.
## Testing
tested on localhost theres some spritesheet runtimes but i didnt touch nonathat 
## Changelog
:cl: Cujo
add: You can now pull anime tails. 
add: You can now hulk throw people with anime tails.
balance: Tail pulling no longer gives a positive moodlet, and instead gives a negative moodlet.
fix: People with bad touch will now get the tail pulled moodlet.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
