### PR TITLE
Vending machines no longer have a small chance to RR you. Because thats cool.

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -965,7 +965,7 @@
 			if(carbon_head)
 				if(carbon_head.dismember())
 					carbon_target.visible_message(span_danger("[carbon_head] explodes in a shower of gore beneath [src]!"),	span_userdanger("Oh f-"))
-					carbon_head.drop_organs()
+					carbon_head.drop_organs(carbon_target)
 					qdel(carbon_head)
 					new /obj/effect/gibspawner/human/bodypartless(get_turf(carbon_target), carbon_target)
 			return TRUE


### PR DESCRIPTION

## About The Pull Request
Fixes a bug with drop_organs() so it actually works, and thus when it Qdels() your head you arent without a brain/body ect ect.
## Why It's Good For The Game
Its a bug fix. The line of code was right there
## Testing
## Changelog
:cl:
fix: Vending machine's HEADGIB no longer deletes the brain as intended
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
