### PR TITLE
small regrowth mineral turf changes

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -85,7 +85,7 @@
 		if(card)
 			to_chat(user, span_notice("[point_value] mining points have been paid out!"))
 			card.registered_account.mining_points += point_value
-			GLOB.lavaland_points_generated += point_value //monkestation edit
+			GLOB.lavaland_points_generated += point_value
 
 /obj/structure/geyser/wittel
 	reagent_id = /datum/reagent/wittel

--- a/monkestation/code/modules/factory_type_beat/ore_vent.dm
+++ b/monkestation/code/modules/factory_type_beat/ore_vent.dm
@@ -299,6 +299,7 @@
 		var/point_reward_val = (MINER_POINT_MULTIPLIER * boulder_size) - MINER_POINT_MULTIPLIER // We remove the base value of discovering the vent
 		user_id_card.registered_account.mining_points += point_reward_val
 		user_id_card.registered_account.bank_card_talk("You have been awarded [point_reward_val] mining points for your efforts.")
+		GLOB.lavaland_points_generated += point_reward_val
 	node.pre_escape() //Visually show the drone is done and flies away.
 	node = null
 	add_overlay(mutable_appearance('monkestation/code/modules/factory_type_beat/icons/terrain.dmi', "well", ABOVE_MOB_LAYER, src, GAME_PLANE))
@@ -363,6 +364,7 @@
 			return
 		user_id_card.registered_account.mining_points += (MINER_POINT_MULTIPLIER)
 		user_id_card.registered_account.bank_card_talk("You've been awarded [MINER_POINT_MULTIPLIER] mining points for discovery of an ore vent.")
+		GLOB.lavaland_points_generated += (MINER_POINT_MULTIPLIER)
 		return
 
 	if(scan_only) //Placed here to allow rewards

--- a/monkestation/code/modules/liquids/liquid_ocean.dm
+++ b/monkestation/code/modules/liquids/liquid_ocean.dm
@@ -722,23 +722,31 @@ GLOBAL_VAR_INIT(lavaland_points_generated, 0)
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	defer_change = TRUE
 
+/// The threshold of lavaland points that need to be surpassed before mineral chance starts to increase.
+#define LAVALAND_POINTS_CHANCE_THRESHOLD 55000
 
-/turf/closed/mineral/random/regrowth/New(loc, mineral_increase)
-	if(isnum(mineral_increase))
-		src.mineralChance += mineral_increase
-	. = ..()
+/// For each set of this amount of points, the regrow timer will decrease by 1 second.
+#define LAVALAND_POINTS_PER_SECOND 1000
+
+/// For each set of this amount of points beyond LAVALAND_POINTS_CHANCE_THRESHOLD, the mineral chance increases by 1.
+#define LAVALAND_POINTS_PER_CHANCE 1000
 
 /turf/closed/mineral/random/regrowth/Destroy(force)
 	. = ..()
-	var/timer = max(1 MINUTES - round(max(1, GLOB.lavaland_points_generated) / 1000), 5 SECONDS)
+	var/timer = max(1 MINUTES - round(max(1, GLOB.lavaland_points_generated) / LAVALAND_POINTS_PER_SECOND), 5 SECONDS)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(regrow_mineral), get_turf(src)), timer)
 
+/// Creates a regrowth material turf ontop of an another turf.
 /proc/regrow_mineral(turf/location)
-	var/mineral_increase = 0
-	if(GLOB.lavaland_points_generated > 55000)
-		mineral_increase = min(87, (GLOB.lavaland_points_generated - 55000) / 1000)
-	var/turf/closed/mineral/random/regrowth/regrowth_turf = location.ChangeTurf(/turf/closed/mineral/random/regrowth, flags = CHANGETURF_INHERIT_AIR)
-	regrowth_turf?.mineralChance += mineral_increase
+	var/turf/closed/mineral/random/regrowth/regrowth_turf = location.PlaceOnTop(/turf/closed/mineral/random/regrowth, flags = CHANGETURF_INHERIT_AIR)
+	if(GLOB.lavaland_points_generated <= LAVALAND_POINTS_CHANCE_THRESHOLD)
+		return
+	var/mineral_increase = (GLOB.lavaland_points_generated - LAVALAND_POINTS_CHANCE_THRESHOLD) / LAVALAND_POINTS_PER_CHANCE
+	regrowth_turf.mineralChance = clamp(initial(regrowth_turf.mineralChance) + mineral_increase, 0, 100)
+
+#undef LAVALAND_POINTS_CHANCE_THRESHOLD
+#undef LAVALAND_POINTS_PER_SECOND
+#undef LAVALAND_POINTS_PER_CHANCE
 
 /turf/closed/mineral/random/regrowth/underwater
 	turf_type = /turf/open/floor/plating/ocean/dark


### PR DESCRIPTION

## About The Pull Request
The regrowth mineral turfs (as seen in the goldgrub pen southeast of the mining base) will no longer create lava turfs if you manually mine them twice.

The amount of lavaland points given by the discovery and the completion of ore vent is now tracked and contributes to the chance of the aforementioned regrowth mineral turfs.

## Why It's Good For The Game
Bugfix and improves an underused (or forgotten) feature a bit.

## Testing
None.

## Changelog
:cl:
add: Ore vent discovery and completion now contribute points towards regrowth turf's mineral chance.
fix: The regrowth turfs from the goldgrub pen no longer create lava underneath them when mined twice.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
