### PR TITLE
Hacked Ninja Cyborgs can pick their initial model

### DIFF
--- a/code/_globalvars/lists/robots.dm
+++ b/code/_globalvars/lists/robots.dm
@@ -1,7 +1,12 @@
-/// To store all the different cyborg models, instead of creating that for each cyborg.
+/// To store all the different cyborg models for station cyborgs, instead of creating that for each cyborg.
 GLOBAL_LIST_EMPTY(cyborg_model_list)
-/// To store all of the different base cyborg model icons, instead of creating them every time we need to display a radial menu.
+/// To store all of the different base cyborg model icons for station cyborgs, instead of creating them every time we need to display a radial menu.
 GLOBAL_LIST_EMPTY(cyborg_base_models_icon_list)
+
+/// To store all the different cyborg models for ninja cyborgs, instead of creating that for each cyborg.
+GLOBAL_LIST_EMPTY(cyborg_model_list_ninja)
+/// To store all of the different base cyborg model icons for ninja cyborgs, instead of creating them every time we need to display a radial menu.
+GLOBAL_LIST_EMPTY(cyborg_base_models_icon_list_ninja)
 
 /// Initializes the global list for what cyborg models that are available for selection and their model icons for radial wheel purposes.
 /proc/initialize_cyborg_model_lists()
@@ -28,3 +33,16 @@ GLOBAL_LIST_EMPTY(cyborg_base_models_icon_list)
 			var/datum/robot_skin/skin = model.default_skin
 			valid_base_models[option] = image(icon = skin.icon, icon_state = skin.icon_state)
 		GLOB.cyborg_base_models_icon_list = valid_base_models
+	if(!length(GLOB.cyborg_model_list_ninja))
+		GLOB.cyborg_model_list_ninja = list(
+			"Assault" = /obj/item/robot_model/syndicate,
+			"Medical" = /obj/item/robot_model/syndicate/medical,
+			"Saboteur" = /obj/item/robot_model/syndicate/saboteur,
+		)
+	if(!length(GLOB.cyborg_base_models_icon_list_ninja))
+		var/valid_base_models = list()
+		for(var/option in GLOB.cyborg_model_list_ninja)
+			var/obj/item/robot_model/model = GLOB.cyborg_model_list_ninja[option]
+			var/datum/robot_skin/skin = model.default_skin
+			valid_base_models[option] = image(icon = skin.icon, icon_state = skin.icon_state)
+		GLOB.cyborg_base_models_icon_list_ninja = valid_base_models

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -322,7 +322,7 @@
 		input_model = pick(GLOB.cyborg_base_models_icon_list_ninja) // Guess they want a random model then.
 	var/obj/item/robot_model/picked_robot_model = GLOB.cyborg_model_list_ninja[input_model]
 	if(!picked_robot_model)
-		CRASH("Ninja failed to give a syndicate robot model to a cyborg.")
+		CRASH("Ninja failed to give a robot model to a cyborg.")
 	apply_model(picked_robot_model)
 	apply_skin(model.default_skin)
 

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -301,23 +301,30 @@
 /mob/living/silicon/robot/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!do_after(ninja, 6 SECONDS, target = src, hidden = TRUE))
 		return
+
+	var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
+	if(ninja_antag)
+		var/datum/objective/cyborg_hijack/objective = locate() in ninja_antag.objectives
+		if(objective)
+			objective.completed = TRUE
+
 	spark_system.start()
 	playsound(loc, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	to_chat(src, span_danger("UPLOAD COMPLETE. NEW CYBORG MODEL DETECTED.  INSTALLING..."))
 	faction = list(ROLE_NINJA)
-	bubble_icon = "syndibot"
 	UnlinkSelf()
 	ionpulse = TRUE
 	laws = new /datum/ai_laws/ninja_override()
-	apply_model(pick(/obj/item/robot_model/syndicate, /obj/item/robot_model/syndicate/medical, /obj/item/robot_model/syndicate/saboteur))
-	apply_skin(model.default_skin)
 
-	var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
-	if(!ninja_antag)
-		return
-	var/datum/objective/cyborg_hijack/objective = locate() in ninja_antag.objectives
-	if(objective)
-		objective.completed = TRUE
+	initialize_cyborg_model_lists()
+	var/input_model = show_radial_menu(src, src, GLOB.cyborg_base_models_icon_list_ninja, custom_check = CALLBACK(src, PROC_REF(check_menu), src), radius = 42, require_near = TRUE)
+	if(!input_model)
+		input_model = pick(GLOB.cyborg_base_models_icon_list_ninja) // Guess they want a random model then.
+	var/obj/item/robot_model/picked_robot_model = GLOB.cyborg_model_list_ninja[input_model]
+	if(!picked_robot_model)
+		CRASH("Ninja failed to give a syndicate robot model to a cyborg.")
+	apply_model(picked_robot_model)
+	apply_skin(model.default_skin)
 
 //CARBON MOBS//
 /mob/living/carbon/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)


### PR DESCRIPTION

## About The Pull Request
Upon getting hacked by a Space Ninja, cyborgs are given a radial menu to choose what model they want rather than being forced into a model that they may not want.

## Why It's Good For The Game
Giving people the choice to pick what they want is much better/good than forcing someone to play something that they don't want to play as.

## Testing
The radial menu appears and correctly applies the chosen model & skin.
<img width="323" height="350" alt="ninja_borg" src="https://github.com/user-attachments/assets/d41a73d1-3c7b-4a5d-b48d-e82e9c7713f9" />

## Changelog
:cl:
add Cyborgs that are hacked by a Space Ninja can now choose which robot model they want.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
