### PR TITLE
knockdowns correctly temporarily turn off a cyborg's lights 

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_appearance.dm
+++ b/code/modules/mob/living/silicon/robot/robot_appearance.dm
@@ -7,7 +7,7 @@
 
 /mob/living/silicon/robot/update_overlays()
 	. = ..()
-	if(stat != DEAD && !(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || IsStun() || IsParalyzed() || low_power_mode)) // Not dead, not stunned.
+	if(stat == CONSCIOUS && !low_power_mode) // Awake and has sufficient power. Various stuns will make them unconscious.
 		if(!eye_lights)
 			eye_lights = new()
 		if(lamp_enabled || lamp_doom)


### PR DESCRIPTION

## About The Pull Request
The headlamp lights that cyborgs now temporarily turn off when they're unconscious which encompasses being knocked down (e.g. from a flash bang).

To put it simply, being conscious means the cyborg is not stunned (including the existing stuns and the now-included knockdown stun). Therefore, consciousness is all that needs to be checked.

## Why It's Good For The Game
Bugfix.

## Testing
Spawn cyborg and flashbang. `detonate` the flashbang. Cyborg has no lights until they wake up.
<img width="194" height="191" alt="flashbang" src="https://github.com/user-attachments/assets/141c862a-959c-4a65-9b6b-c8a51fa5a55f" />


## Changelog
:cl:
fix: Cyborg's lights now correctly temporarily turn off when they're unconscious caused by a knockdown.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
