### PR TITLE
Thesues Disposals fix. Again. + Telecomms mixup

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -420,6 +420,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/effect/landmark/start/network_admin,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "agM" = (
@@ -27556,11 +27557,11 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance)
 "ihS" = (
-/obj/machinery/telecomms/server/presets/supply,
-/obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 8
 	},
+/obj/machinery/telecomms/server/presets/security,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "ihW" = (
@@ -41361,11 +41362,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mbi" = (
-/obj/machinery/telecomms/server/presets/science,
-/obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "mbu" = (
@@ -41739,8 +41740,8 @@
 /turf/open/floor/carpet,
 /area/station/security/checkpoint/escape)
 "mgc" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/machinery/telecomms/server/presets/science,
+/obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "mgd" = (
@@ -52660,8 +52661,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "psI" = (
-/obj/machinery/telecomms/server/presets/security,
-/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "psV" = (
@@ -54764,11 +54764,11 @@
 	},
 /area/station/maintenance/department/medical)
 "qaj" = (
-/obj/machinery/telecomms/server/presets/command,
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "qal" = (
@@ -57328,16 +57328,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "qII" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/effect/turf_decal/tile/dark_green/fourcorners,
-/obj/effect/turf_decal/tile/dark_green/fourcorners,
-/obj/effect/turf_decal/siding/dark_green/end,
-/obj/effect/turf_decal/siding/dark_green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "qIL" = (
@@ -60889,8 +60884,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rIv" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/effect/turf_decal/siding/dark_green/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_green{
+	dir = 8
+	},
+/obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "rIF" = (
@@ -69142,8 +69144,8 @@
 /turf/closed/wall,
 /area/station/smithing)
 "tZQ" = (
-/obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/tile/gray/full,
+/obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "tZR" = (
@@ -82369,7 +82371,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "xPT" = (
-/obj/machinery/telecomms/bus/preset_two,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "xQa" = (
@@ -115669,10 +115672,10 @@ jgm
 lXw
 jGA
 jGA
+mgc
 aFa
-aFa
-xPT
-ghg
+obf
+eVY
 jGA
 uOG
 sDt
@@ -115925,9 +115928,9 @@ gTP
 jgm
 nhC
 jGA
+gMy
 aFa
-mgc
-psI
+aFa
 aFa
 iZG
 jGA
@@ -116441,7 +116444,7 @@ lXw
 jGA
 ree
 huz
-aVk
+ghg
 aFa
 qaj
 xNK
@@ -117981,9 +117984,9 @@ mZj
 jgm
 nhC
 jGA
+xPT
 aFa
-gMy
-rIv
+aFa
 aFa
 iZG
 xNK
@@ -118239,10 +118242,10 @@ jgm
 lXw
 jGA
 jGA
+rIv
 aFa
-aFa
-obf
-eVY
+psI
+aVk
 xNK
 xUs
 tWQ

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -60916,6 +60916,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rIQ" = (
@@ -61023,7 +61026,9 @@
 	pixel_x = 4;
 	pixel_y = 9
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rJI" = (
@@ -61402,13 +61407,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
-"rPr" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "rPB" = (
 /obj/structure/grandfatherclock,
 /obj/structure/disposalpipe/segment{
@@ -107455,7 +107453,7 @@ bLq
 kIN
 agN
 bGY
-jCR
+eAB
 eHC
 eHC
 eHC
@@ -107969,7 +107967,7 @@ hxo
 kIN
 ueB
 bGY
-rPr
+eAB
 ruT
 fWH
 gxR


### PR DESCRIPTION


## About The Pull Request
Fixes more Theseus disposals in science
Telecommunications has been grouped by server/processor
And servers have been pushed to the walls to prevent wasted space.

## Why It's Good For The Game
Bug fix: YIPPEE
Included is a map of how the current processors connect to the servers
<img width="944" height="554" alt="WHAT IS THIS THING" src="https://github.com/user-attachments/assets/01ebc13e-38ea-4e6b-830a-8fc0d2530d5f" />
Only 2 severs are somewhat adjacent to to their processors.
So adjust it to how they all connect together
<img width="908" height="518" alt="Screenshot 2026-08-12 132245" src="https://github.com/user-attachments/assets/3745af97-3611-4760-9af3-c4c9fdab3beb" />

## Testing

## Changelog

:cl:
map: Fixes disconnected disposal pipes in Theseus science
map: Adjusted Theseus Telecommunications to be more readable and give more space
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

