### PR TITLE
Fixes slab grenade launcher not cycling shells and spinning with alt click

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/grenade.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/grenade.dm
@@ -23,7 +23,7 @@
 	max_ammo = 3
 	multiload = FALSE
 
-/obj/item/ammo_box/magazine/internal/grenadelauncher/kinetic
+/obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/kinetic
 	name = "kinetic rotary grenade launcher"
 	ammo_type = /obj/item/ammo_casing/a40mm/kinetic
 	caliber = CALIBER_40MM_KINETIC

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -278,7 +278,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	icon_state = "protoklauncher"
 	inhand_icon_state = "protoklauncher"
-	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/grenadelauncher/kinetic
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/kinetic
 	fire_sound = 'sound/weapons/gun/general/grenade_launch.ogg'
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY


### PR DESCRIPTION


## About The Pull Request

title

## Why It's Good For The Game

fixes are good :)

## Testing

spawned in, var edited wasteland firing pin out and put a normal one on it, magdumped it into a wall, works

## Changelog

:cl:
fix: The PK "Slab" grenade launcher cycles ammo properly now
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

