### PR TITLE
Trays for days (and minor QoL)

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedunknownsite1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedunknownsite1.dmm
@@ -1500,7 +1500,7 @@
 /area/ruin/space/has_grav/abandonedscpsite/office2)
 "fJ" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13648,7 +13648,7 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/abandonedscpsite/prisoncafe)
 "Zh" = (
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 6
 	},
 /obj/structure/table/glass,

--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -74,7 +74,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/dangerous_research/lab)
 "aZ" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/structure/table,
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/dangerous_research/medical)

--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -1116,7 +1116,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/interdyne)
 "PD" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)

--- a/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
@@ -696,7 +696,7 @@
 /area/ruin/space/has_grav/the_outlet/researchrooms)
 "rF" = (
 /obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/reagent_containers/syringe/lethal/execution,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/the_outlet/researchrooms)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -44196,7 +44196,8 @@
 /obj/item/emergency_bed{
 	pixel_y = 14
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/defibrillator_mount/directional/south,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "ojr" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12757,7 +12757,7 @@
 /obj/item/emergency_bed{
 	pixel_y = 14
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "ecI" = (
@@ -28516,7 +28516,7 @@
 /obj/item/paper_bin,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/autopsy_scanner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -44174,7 +44174,7 @@
 /obj/item/emergency_bed{
 	pixel_y = 14
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "ojr" = (
@@ -58274,7 +58274,7 @@
 	pixel_x = -1;
 	pixel_y = 6
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "sQN" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -14418,7 +14418,7 @@
 /area/station/medical/abandoned)
 "dsM" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/clothing/gloves/latex,
@@ -22542,7 +22542,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fno" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
@@ -82069,7 +82069,7 @@
 /area/station/engineering/atmos)
 "tsx" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/suit/apron/surgical,

--- a/_maps/map_files/Graveyard/Graveyard.dmm
+++ b/_maps/map_files/Graveyard/Graveyard.dmm
@@ -23558,7 +23558,7 @@
 "jig" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "jit" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -32121,7 +32121,7 @@
 /area/station/command/heads_quarters/hop)
 "flX" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/autopsy_scanner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -13416,7 +13416,7 @@
 	network = list("ss13","medbay");
 	pixel_x = 22
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -39793,7 +39793,7 @@
 	},
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/autopsy_scanner,
 /turf/open/floor/iron/dark,
@@ -58037,7 +58037,7 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "rKZ" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -32176,7 +32176,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/autopsy_scanner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -5285,7 +5285,7 @@
 /area/station/engineering/atmos)
 "cKU" = (
 /obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/effect/turf_decal/tile/dark/diagonal_centre,
 /obj/effect/turf_decal/tile/dark/diagonal_centre,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -62493,7 +62493,7 @@
 "vDM" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/autopsy_scanner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -70102,7 +70102,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "upb" = (
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 7;
 	pixel_x = -3
 	},
@@ -79577,10 +79577,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wZb" = (
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 11
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 4
 	},
 /obj/structure/table/reinforced/rglass,

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -33396,7 +33396,6 @@
 /area/station/maintenance/port/fore)
 "jPg" = (
 /obj/structure/table/optable,
-/obj/item/surgical_drapes,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/start/hangover,
 /obj/structure/drain/big,
@@ -34384,7 +34383,6 @@
 /area/station/science/ordnance/freezerchamber)
 "keL" = (
 /obj/structure/table/optable,
-/obj/item/surgical_drapes,
 /obj/effect/landmark/start/hangover,
 /obj/structure/drain/big,
 /turf/open/floor/iron/dark,
@@ -60470,6 +60468,7 @@
 /turf/closed/wall/r_wall,
 /area/station/service/janitor)
 "rDw" = (
+/obj/item/surgery_tray/deployed,
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
 "rDF" = (
@@ -79577,12 +79576,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wZb" = (
-/obj/item/surgery_tray{
-	pixel_y = 11
-	},
-/obj/item/surgery_tray{
-	pixel_y = 4
-	},
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
@@ -114410,7 +114403,7 @@ tDu
 uXh
 deo
 umj
-rDw
+agP
 miX
 tjT
 iOH
@@ -114923,7 +114916,7 @@ aYM
 aKB
 qSg
 yeK
-agP
+rDw
 rDw
 vcz
 tjT

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -14500,7 +14500,7 @@
 	dir = 5
 	},
 /obj/structure/table/reinforced/plasmarglass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = -11
 	},
 /obj/item/storage/belt/medical,
@@ -17559,7 +17559,7 @@
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "aVh" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 10;
 	pixel_x = 2
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14818,7 +14818,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "dCL" = (
@@ -24559,7 +24559,7 @@
 "gGs" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/clothing/mask/surgical,
 /obj/machinery/camera/directional/north{
 	c_tag = "Medical - Morgue";
@@ -71198,7 +71198,7 @@
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/item/radio/intercom/directional/south,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "uWn" = (
@@ -80996,7 +80996,7 @@
 /area/station/hallway/primary/tram/center)
 "xYa" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical)
 "xYc" = (

--- a/_maps/shipbreaking/gorlex_cruiser.dmm
+++ b/_maps/shipbreaking/gorlex_cruiser.dmm
@@ -394,7 +394,7 @@
 	},
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/closet/crate/medical,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark/smooth_large,
 /area/template_noop)

--- a/_maps/shipbreaking/wanglius.dmm
+++ b/_maps/shipbreaking/wanglius.dmm
@@ -698,7 +698,7 @@
 "Yx" = (
 /obj/structure/table,
 /obj/machinery/light/directional/west,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/mineral/titanium/white,
 /area/template_noop)
 "YZ" = (

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -2071,7 +2071,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Mq" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/latex/nitrile{
@@ -2714,7 +2714,7 @@
 "YA" = (
 /obj/machinery/vending/wallmed/directional/south,
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white/textured_edge,
 /area/shuttle/escape)
 "YI" = (

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -452,7 +452,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "bS" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical,
 /obj/structure/table/optable,

--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -884,7 +884,7 @@
 /area/shuttle/escape)
 "VD" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{

--- a/_maps/shuttles/emergency_haugan.dmm
+++ b/_maps/shuttles/emergency_haugan.dmm
@@ -498,7 +498,7 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/item/stack/sheet/iron,
 /obj/item/stack/sheet/mineral/silver,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/healthanalyzer,
 /obj/item/storage/medkit/toxin,
 /obj/item/storage/medkit/o2,

--- a/_maps/shuttles/emergency_hauganrefitted.dmm
+++ b/_maps/shuttles/emergency_hauganrefitted.dmm
@@ -369,7 +369,7 @@
 /area/shuttle/escape/engine)
 "zk" = (
 /obj/structure/closet/crate/medical,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/storage/medkit,
 /obj/item/healthanalyzer,
 /obj/effect/spawner/random/medical/surgery_tool,

--- a/_maps/shuttles/emergency_lance.dmm
+++ b/_maps/shuttles/emergency_lance.dmm
@@ -919,8 +919,8 @@
 /obj/item/book/manual/wiki/surgery{
 	pixel_x = -15
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray,
+/obj/item/surgery_tray{
 	pixel_x = 5
 	},
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -235,7 +235,7 @@
 "W" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron/surgical,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "X" = (

--- a/_maps/shuttles/emergency_nature.dmm
+++ b/_maps/shuttles/emergency_nature.dmm
@@ -498,7 +498,7 @@
 /area/shuttle/escape)
 "sF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 5
 	},
 /obj/structure/rack,

--- a/_maps/shuttles/emergency_northstar.dmm
+++ b/_maps/shuttles/emergency_northstar.dmm
@@ -127,7 +127,7 @@
 "nC" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/defibrillator/loaded,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 13
 	},
 /obj/effect/turf_decal/tile/blue/anticorner{

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -523,7 +523,7 @@
 "iJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/clothing/gloves/fingerless,
 /turf/open/floor/iron,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_shadow.dmm
+++ b/_maps/shuttles/emergency_shadow.dmm
@@ -956,7 +956,7 @@
 "MC" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/machinery/light/directional/north,
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical,

--- a/_maps/shuttles/emergency_tram.dmm
+++ b/_maps/shuttles/emergency_tram.dmm
@@ -265,7 +265,7 @@
 /area/shuttle/escape)
 "aX" = (
 /obj/structure/table/optable,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_tranquility.dmm
+++ b/_maps/shuttles/emergency_tranquility.dmm
@@ -2613,7 +2613,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/table,
 /obj/item/lazarus_injector,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/clothing/gloves/latex/nitrile{
 	pixel_y = 4
 	},

--- a/_maps/shuttles/ert_generic.dmm
+++ b/_maps/shuttles/ert_generic.dmm
@@ -1522,7 +1522,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table/reinforced/rglass,
 /obj/item/clothing/gloves/latex/surgical,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_x = -1;
 	pixel_y = 13
 	},

--- a/_maps/shuttles/ruin_cyborg_mothership.dmm
+++ b/_maps/shuttles/ruin_cyborg_mothership.dmm
@@ -734,7 +734,7 @@
 /area/shuttle/ruin/cyborg_mothership)
 "Oq" = (
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/effect/turf_decal/bot,
 /obj/structure/sink/directional/east,
 /obj/item/toy/figure/borg{

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -104,7 +104,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 4
 	},
 /obj/item/clothing/suit/apron/surgical,

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -1647,7 +1647,7 @@
 /area/shuttle/abandoned/medbay)
 "dO" = (
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/templates/lazy_templates/bingle_pit.dmm
+++ b/_maps/templates/lazy_templates/bingle_pit.dmm
@@ -17,7 +17,7 @@
 /turf/open/indestructible/bingle,
 /area/misc/bingle_pit)
 "T" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /turf/open/indestructible/bingle,
 /area/misc/bingle_pit)
 "U" = (

--- a/_maps/templates/lazy_templates/ninja_den.dmm
+++ b/_maps/templates/lazy_templates/ninja_den.dmm
@@ -163,7 +163,7 @@
 /area/centcom/central_command_areas/holding)
 "fb" = (
 /obj/structure/closet,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/reagent_containers/medigel/synthflesh,
 /obj/item/reagent_containers/medigel/synthflesh,
 /obj/item/reagent_containers/medigel/synthflesh,
@@ -803,7 +803,7 @@
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/holding)
 "tj" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/machinery/iv_drip,
 /obj/item/storage/medkit/regular,
 /obj/item/defibrillator,

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -750,7 +750,7 @@
 	dir = 5
 	},
 /obj/structure/table/reinforced/plasmarglass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = -11
 	},
 /obj/item/storage/belt/medical,

--- a/_maps/virtual_domains/tutorial/medbay.dmm
+++ b/_maps/virtual_domains/tutorial/medbay.dmm
@@ -3315,7 +3315,7 @@
 "Go" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/surgery_tray{
 	pixel_y = 9
 	},
 /obj/item/clothing/gloves/latex{
@@ -4154,7 +4154,7 @@
 /area/virtual_domain/powered_lighting)
 "Ok" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray,
 /obj/item/book/manual/wiki/surgery{
 	pixel_x = -4;
 	pixel_y = 3

--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -207,6 +207,7 @@
 		/obj/item/surgical_drapes,
 		/obj/item/surgicaldrill,
 		/obj/item/breathing_bag,
+		/obj/item/autopsy_scanner,
 	))
 
 /obj/item/surgery_tray/craftable

--- a/tools/UpdatePaths/Scripts/monkestation/12397_surgery_duffels_trays.txt
+++ b/tools/UpdatePaths/Scripts/monkestation/12397_surgery_duffels_trays.txt
@@ -1,0 +1,1 @@
+/obj/item/storage/backpack/duffelbag/med/surgery : /obj/item/surgery_tray{@OLD}


### PR DESCRIPTION


## About The Pull Request

Replaces all surgery duffelbags with surgery trays on all maps

i only tweaked theseus a lil to not look weird with it, haven't looked much at other maps

also surgery trays can now hold autopsy scanners as a treat

## Why It's Good For The Game

trays look nicer than duffels

## Testing

hopped on theseus and it seemed fine, i dunno how to test this tho

## Changelog

:cl:

qol: surgery trays can hold autopsy scanners now
map: replaced surgery duffel bags on all maps with surgery trays
map: tweaked theseus a little (moved trays to nicer spots and removed drapes that spawn on the surgery tables)
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

