### PR TITLE
Makes the China lake capable of being held in one hand (still needs your other hand to be empty to be fired)

### DIFF
--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -228,10 +228,6 @@
 	drop_sound = 'sound/weapons/gun/china_lake_sfx/china_lake_drop.ogg'
 	pickup_sound = 'sound/weapons/gun/china_lake_sfx/china_lake_pickup.ogg'
 
-/obj/item/gun/ballistic/shotgun/china_lake/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/two_handed, require_twohands = TRUE, force_unwielded = 10, force_wielded = 10)
-
 /obj/item/gun/ballistic/shotgun/china_lake/examine(mob/user)
 	. = ..()
 	. += span_notice("The leaf sight is set for: <b>[target_range] tiles</b>.")


### PR DESCRIPTION


## About The Pull Request

China lake can be held in one hand, you still can't fire it while your other hand is holding something

you can also toggle bracing for it like any other gun with recoil now

## Why It's Good For The Game

China lake right now is pretty cumbersome to use, requiring you to do extra inventory fumbling to load it which makes it a worse choice than the smaller grenade launcher in a lot of situations also as far as i know there aren't any other weapons that force both of your hands to be busy like this, there's no reason for this weapon in particular to be awkward to use and there aren't many balance implications from making it able to be held in one hand (not fired one handed)

## Testing
<img width="249" height="559" alt="{15876A71-ADDD-4145-B81B-0AF7F561F6CA}" src="https://github.com/user-attachments/assets/4c78c31d-0f93-4a98-8440-ea0de588ec5c" />


## Changelog

:cl:

balance: you can now hold the china lake grenade launcher in one hand (still can't fire it while your other hand is holding anything tho!)

/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

