### PR TITLE
cleans up metastation piping and wiring

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1389,9 +1389,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "axU" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/closed/wall,
-/area/station/command/gateway)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "axW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -6244,12 +6246,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"cmw" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "cmB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -6408,6 +6404,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
+"coQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "cpi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green{
@@ -20924,10 +20924,6 @@
 "huG" = (
 /turf/closed/wall,
 /area/station/service/kitchen/coldroom)
-"huX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
 "huZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -39285,8 +39281,6 @@
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pathology)
 "nyk" = (
@@ -45667,6 +45661,13 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
+"pKi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "pKs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -59248,13 +59249,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"usY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "uta" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/security_space_law{
@@ -83077,7 +83071,7 @@ kjm
 daA
 eXu
 wMY
-axU
+yjd
 nSI
 qaU
 faT
@@ -108526,7 +108520,7 @@ cgL
 qXB
 wyG
 edC
-cmw
+axU
 wcu
 eBn
 qXB
@@ -108784,7 +108778,7 @@ kbo
 psZ
 psZ
 xcR
-usY
+pKi
 kbo
 eqt
 psZ
@@ -110672,8 +110666,8 @@ rhw
 wEv
 wEv
 wEv
-huX
-huX
+coQ
+coQ
 uhh
 tVv
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -784,11 +784,13 @@
 /area/station/service/kitchen/coldroom)
 "amV" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "anl" = (
@@ -1387,17 +1389,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "axU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/closed/wall,
+/area/station/command/gateway)
 "axW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -1857,7 +1851,6 @@
 	name = "Machining Room"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
@@ -2546,7 +2539,6 @@
 /area/station/science/explab)
 "aPO" = (
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aPX" = (
@@ -2558,7 +2550,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "aQi" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aQE" = (
@@ -6255,11 +6246,10 @@
 /area/station/hallway/primary/aft)
 "cmw" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/aft/greater)
+/area/station/maintenance/starboard/fore)
 "cmB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -6418,12 +6408,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
-"coQ" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/command/gateway)
 "cpi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green{
@@ -8997,7 +8981,7 @@
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "dlr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
@@ -9564,7 +9548,6 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -12871,9 +12854,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "eCn" = (
@@ -13551,6 +13533,7 @@
 "eSa" = (
 /obj/item/wrench,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eSb" = (
@@ -15188,7 +15171,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "fvb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/gary,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -15693,7 +15675,6 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fGa" = (
@@ -17498,7 +17479,6 @@
 "gmT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "gmX" = (
@@ -20243,7 +20223,6 @@
 /area/station/security/execution/transfer)
 "hjS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -20946,15 +20925,9 @@
 /turf/closed/wall,
 /area/station/service/kitchen/coldroom)
 "huX" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "huZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -27377,7 +27350,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/structure/sign/xenobio_guide/directional/west,
 /turf/open/floor/stone,
@@ -28938,6 +28910,8 @@
 /obj/item/folder/yellow,
 /obj/item/paper/pamphlet/gateway,
 /obj/item/paper/pamphlet/gateway,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "jZl" = (
@@ -31171,7 +31145,6 @@
 "kPZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "kQe" = (
@@ -31262,7 +31235,6 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/structure/cable,
 /obj/item/crowbar,
 /obj/item/wrench,
 /turf/open/floor/iron,
@@ -31762,7 +31734,6 @@
 /area/station/maintenance/starboard/greater)
 "lah" = (
 /obj/structure/rack,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
@@ -34020,7 +33991,6 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lON" = (
@@ -39744,7 +39714,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nGr" = (
@@ -45698,12 +45667,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
-"pKi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "pKs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -46027,7 +45990,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -53476,13 +53438,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"sqT" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft/greater)
 "src" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
@@ -55970,7 +55925,6 @@
 /area/station/command/heads_quarters/nt_rep)
 "tjL" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "tjN" = (
@@ -58080,7 +58034,6 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -58310,7 +58263,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "ucd" = (
@@ -58589,7 +58541,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "uhh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
@@ -59300,8 +59251,10 @@
 "usY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "uta" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/security_space_law{
@@ -63614,7 +63567,6 @@
 /area/station/hallway/primary/central)
 "vVx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/stone,
@@ -65534,7 +65486,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
 "wCT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -68936,7 +68887,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "xLv" = (
@@ -82614,7 +82564,7 @@ qWq
 scR
 aox
 yjd
-coQ
+vmQ
 aQi
 aQi
 vmQ
@@ -83127,7 +83077,7 @@ kjm
 daA
 eXu
 wMY
-yjd
+axU
 nSI
 qaU
 faT
@@ -89901,7 +89851,7 @@ rYv
 vtb
 tSw
 gOp
-sqT
+gmS
 lOf
 drm
 tSw
@@ -90158,7 +90108,7 @@ hdo
 hzG
 tSw
 lah
-cmw
+vUM
 fje
 jgW
 tSw
@@ -106541,8 +106491,8 @@ hht
 xww
 xww
 vFB
-pKi
-axU
+fRS
+tUv
 rac
 hiG
 nti
@@ -107826,8 +107776,8 @@ vph
 vQv
 cdX
 vFB
-usY
-huX
+fRS
+tUv
 obG
 ouf
 eaL
@@ -108576,7 +108526,7 @@ cgL
 qXB
 wyG
 edC
-kbo
+cmw
 wcu
 eBn
 qXB
@@ -108834,7 +108784,7 @@ kbo
 psZ
 psZ
 xcR
-kbo
+usY
 kbo
 eqt
 psZ
@@ -109599,7 +109549,7 @@ fvb
 tjL
 aGe
 mFm
-jcy
+psZ
 tCS
 rpx
 dPy
@@ -109856,7 +109806,7 @@ jCw
 lwT
 qXB
 lOK
-jcy
+psZ
 tCS
 oKx
 gLK
@@ -110722,8 +110672,8 @@ rhw
 wEv
 wEv
 wEv
-wEv
-wEv
+huX
+huX
 uhh
 tVv
 aaa


### PR DESCRIPTION


## About The Pull Request
removes stray pipes that lead nowhere

moves APC in the gateway area to no longer be inside an electrified window.
<img width="646" height="377" alt="image" src="https://github.com/user-attachments/assets/1549f480-7404-402b-8a14-e5fbacbaf121" />

## Why It's Good For The Game

## Testing
W.I.P.

## Changelog

:cl:
map: metastation's pipes have had a few loose ends trimmed off.
map: metastation's gateway APC is no longer inside an electrified grille and window.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

