### PR TITLE
fixes janiborgs not refilling their spray bottles

### DIFF
--- a/code/modules/mob/living/silicon/robot/model/janitor.dm
+++ b/code/modules/mob/living/silicon/robot/model/janitor.dm
@@ -51,11 +51,11 @@
 	. = ..()
 	for(var/obj/item/usable_module in usable_modules)
 		if(istype(usable_module, /obj/item/reagent_containers/spray/cyborg_drying))
-			var/obj/item/reagent_containers/spray/cyborg_drying/drying_spray
+			var/obj/item/reagent_containers/spray/cyborg_drying/drying_spray = usable_module
 			drying_spray.reagents.add_reagent(/datum/reagent/drying_agent, 5 * coeff)
 			continue
 		if(istype(usable_module, /obj/item/reagent_containers/spray/cyborg_lube))
-			var/obj/item/reagent_containers/spray/cyborg_drying/lube_spray
+			var/obj/item/reagent_containers/spray/cyborg_drying/lube_spray = usable_module
 			lube_spray.reagents.add_reagent(/datum/reagent/lube, 2 * coeff)
 			continue
 

--- a/code/modules/mob/living/silicon/robot/model/janitor.dm
+++ b/code/modules/mob/living/silicon/robot/model/janitor.dm
@@ -55,7 +55,7 @@
 			drying_spray.reagents.add_reagent(/datum/reagent/drying_agent, 5 * coeff)
 			continue
 		if(istype(usable_module, /obj/item/reagent_containers/spray/cyborg_lube))
-			var/obj/item/reagent_containers/spray/cyborg_drying/lube_spray = usable_module
+			var/obj/item/reagent_containers/spray/cyborg_lube/lube_spray = usable_module
 			lube_spray.reagents.add_reagent(/datum/reagent/lube, 2 * coeff)
 			continue
 


### PR DESCRIPTION


## About The Pull Request
Janitor cyborgs now correctly refills their drying agent spray and space lube spray via a recharging station.

## Why It's Good For The Game
Bugfix.

## Testing
None.

## Changelog
:cl:
fix: Janitor cyborgs now correctly refills their drying agent spray and space lube spray via a recharging station.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

