### PR TITLE
fixes janiborgs not refilling their spray bottles (again)

### DIFF
--- a/code/modules/mob/living/silicon/robot/model/janitor.dm
+++ b/code/modules/mob/living/silicon/robot/model/janitor.dm
@@ -47,16 +47,17 @@
 		QDEL_NULL(wash_toggle_ref)
 	return ..()
 
-/obj/item/robot_model/janitor/on_cyborg_recharge(coeff)
+/obj/item/robot_model/janitor/on_cyborg_recharge(datum/source, amount, repairs, sendmats)
 	. = ..()
+	var/power_coeff = amount / (200 JOULES)
 	for(var/obj/item/usable_module in usable_modules)
 		if(istype(usable_module, /obj/item/reagent_containers/spray/cyborg_drying))
 			var/obj/item/reagent_containers/spray/cyborg_drying/drying_spray
-			drying_spray.reagents.add_reagent(/datum/reagent/drying_agent, 5 * coeff)
+			drying_spray.reagents.add_reagent(/datum/reagent/drying_agent, 5 * power_coeff)
 			continue
 		if(istype(usable_module, /obj/item/reagent_containers/spray/cyborg_lube))
 			var/obj/item/reagent_containers/spray/cyborg_drying/lube_spray
-			lube_spray.reagents.add_reagent(/datum/reagent/lube, 2 * coeff)
+			lube_spray.reagents.add_reagent(/datum/reagent/lube, 2 * power_coeff)
 			continue
 
 /obj/item/reagent_containers/spray/cyborg_drying


### PR DESCRIPTION


## About The Pull Request
Janitor cyborgs' drying agent and space lube spray bottles now refill with an amount that isn't zero (aka null).

## Why It's Good For The Game
Bugfix.

## Testing
Used the spray bottles and then recharged.
<img width="523" height="568" alt="image" src="https://github.com/user-attachments/assets/efb7df92-f8aa-431f-b606-6349162afaa8" />

## Changelog
:cl:
fix: Janitor cyborgs' drying agent and space lube spray bottles now refill with an amount that isn't zero.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

