### PR TITLE
Changes surplus crate to match description

### DIFF
--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -83,7 +83,7 @@
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS | UPLINK_SPY)
 	stock_key = UPLINK_SHARED_STOCK_SURPLUS
 	/// Value of items inside the crate in TC
-	var/crate_tc_value = 75
+	var/crate_tc_value = 100
 	/// crate that will be used for the surplus crate
 	var/crate_type = /obj/structure/closet/crate
 


### PR DESCRIPTION


## About The Pull Request
Changes crate value to match desc

## Why It's Good For The Game
So we dont lie to players

## Testing
none its a single number

## Changelog

:cl:
fix: Surplus crate value now matches what we said it was
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

