### PR TITLE
borgs can turn on/off stoves

### DIFF
--- a/code/modules/food_and_drinks/machinery/stove.dm
+++ b/code/modules/food_and_drinks/machinery/stove.dm
@@ -25,6 +25,8 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
+	if(!user.Adjacent(src))
+		return
 	attack_hand_secondary(user) // Allows interaction with the stove.
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/modules/food_and_drinks/machinery/stove.dm
+++ b/code/modules/food_and_drinks/machinery/stove.dm
@@ -21,10 +21,12 @@
 	. = ..()
 	AddComponent(/datum/component/stove, container_x = -6, container_y = 16)
 
-/obj/machinery/stove/attack_robot(mob/user)
+/obj/machinery/stove/attack_robot_secondary(mob/user, list/modifiers)
 	. = ..()
-	attack_hand(user)
-	return TRUE
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	attack_hand_secondary(user) // Allows interaction with the stove.
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 // Soup pot for cooking soup
 // Future addention ideas:


### PR DESCRIPTION


## About The Pull Request
Closes https://github.com/Monkestation/Monkestation2.0/issues/7545

Cyborgs can now turn on and turn off stoves as long they are right next to it.

## Why It's Good For The Game
Bugfix.

## Testing
<img width="253" height="191" alt="borg-stove" src="https://github.com/user-attachments/assets/53df8170-503a-4dc4-a6db-12feaf4e66fb" />

## Changelog
:cl:
fix: Cyborgs can now turn on/off stoves.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

