### PR TITLE
operating computer tgui is more strict, aka no more patients seeing the operating computer tgui

### DIFF
--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -86,8 +86,30 @@
 				sbed.op_computer = src
 				break
 
-/obj/machinery/computer/operating/ui_state(mob/user)
-	return GLOB.not_incapacitated_state
+/obj/machinery/computer/operating/ui_status(mob/user, datum/ui_state/state)
+	. = ..()
+	if(isliving(user) && !issilicon(user))
+		. = min(., ui_check(user))
+
+/// Checks for special ui state conditions.
+/obj/machinery/computer/operating/proc/ui_check(mob/living/user)
+	// Lower states should be checked first.
+
+	// Normally machines revert to "disabled" when non-operational,
+	// but here we outright close it so people can't gleam extra info.
+	if(!is_operational)
+		return UI_CLOSE
+	// If you're knocked out, ie anesthetic... definitely a no-go.
+	if(HAS_TRAIT(user, TRAIT_KNOCKEDOUT))
+		return UI_CLOSE
+	// The patient itself should be blocked from viewing the computer.
+	if(user.body_position == LYING_DOWN)
+		return (user.loc == table?.loc) ? UI_CLOSE : UI_DISABLED
+	// We have a tight range check so people can't spy on surgeries from across the room.
+	// Likewise, it'd be pretty lame if you could see what was going on while incapacitated.
+	if(get_dist(user, src) > 2 || user.incapacitated())
+		return UI_DISABLED
+	return UI_INTERACTIVE
 
 /obj/machinery/computer/operating/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()


### PR DESCRIPTION


## About The Pull Request
Takes the ui status check from https://github.com/tgstation/tgstation/pull/93697 which limits access / information to the operating computer TGUI more strictly, e.g. closing the menu or not updating the menu with the latest information.


## Why It's Good For The Game
Arguably a bugfix, but essentially I think it is wack that people resting on an operating table can see what is happening on an operating computer when they rightfully shouldn't. This also makes trying to do certain surgeries (aka Brainwashing) while next to an operating computer not a trap.

## Testing
Opens operating computer TGUIs, then...
- Rest ontop of the connected operating table. TGUI closes.
- Rest on the floor. TGUI is disabled.
- Move away from the computer. TGUI is disabled.
- Fall asleep. TGUI closes.

## Changelog

:cl: Runian, MrMelbert
balance: Operating computer's TGUI is now more strict on who can see the information displayed on it.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

