### PR TITLE
Rack creator now respects t2 parts.

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
@@ -37,7 +37,7 @@
 		mat_capacity += new_matter_bin.tier * 40 * SHEET_MATERIAL_AMOUNT
 	materials.max_amount = mat_capacity
 
-	var/total_rating = 1.2
+	var/total_rating = 1.1
 	for(var/datum/stock_part/manipulator/M in component_parts)
 		total_rating = clamp(total_rating - (M.tier * 0.1), 0, 1)
 	efficiency_coeff = round(total_rating, 0.1)


### PR DESCRIPTION


## About The Pull Request
Rack creator refresh part adjusted for t2 parts.
Its set to 1.2 initally and each manipulator adjusts the value by 0.1. Meaning with a t2 manipulator you go back to the original value of 1. Since theres a saftey clamp included you dont notice it being higher at t1. This adjusts it so its cheaper. YIPPEE

## Why It's Good For The Game
Fix

## Testing

## Changelog

:cl:
fix: Rack creators numbers are tweaked to properly adjust with manipulators
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

