### PR TITLE
AI mech exit ignores z levels

### DIFF
--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -136,7 +136,7 @@
 			AI.remote_control = null
 			mob_container = AI
 			newloc = null
-			if(AI.relocate(silent = TRUE, kill_otherwise = FALSE))
+			if(AI.relocate(silent = TRUE, kill_otherwise = FALSE, ignore_z_levels = TRUE))
 				moved_already = TRUE
 			else
 				to_chat(AI, span_userdanger("No cores available. Core code corrupted."))


### PR DESCRIPTION
## About The Pull Request

I forgot to put this for non forced AI mech exits too

## Why It's Good For The Game

Lets AIs using a mech on lavaland exit to the station z level core.

## Changelog

:cl:
fix: Hopefully finally fixes AI in mechs leaving and being able to re-enter their core.
/:cl: