### PR TITLE
Taming a pig now plays a snorting sound & makes heart visual effect

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/pig.dm
+++ b/code/modules/mob/living/basic/farm_animals/pig.dm
@@ -56,8 +56,10 @@
 /mob/living/basic/pig/tamed(mob/living/tamer, atom/food)
 	can_buckle = TRUE
 	buckle_lying = 0
+	playsound(src, 'sound/creatures/pig1.ogg', 50)
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/pig)
 	visible_message(span_notice("[src] snorts respectfully."))
+	new /obj/effect/temp_visual/heart(loc)
 
 /datum/ai_controller/basic_controller/pig
 	blackboard = list(


### PR DESCRIPTION


## About The Pull Request
This makes it so that pigs now have a snorting sound &  heart visual popup  when they are tamed, similiar to ponies and other animals.

## Why It's Good For The Game
Pigs are lovely

## Testing

https://github.com/user-attachments/assets/e436050b-8c30-4576-8a26-c03f1507d4f3

## Changelog

:cl:
add: Added pig taming visual & SFX
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

