### PR TITLE
Slime species regenerate limbs slight nerf

### DIFF
--- a/monkestation/code/modules/surgery/organs/internal/heart.dm
+++ b/monkestation/code/modules/surgery/organs/internal/heart.dm
@@ -158,7 +158,7 @@
 		to_chat(H, span_notice("You feel intact enough as it is."))
 		return
 	to_chat(H, span_notice("You focus intently on your missing [length(limbs_to_heal) >= 2 ? "limbs" : "limb"]..."))
-	if(!do_after(H, 15 SECONDS))
+	if(!do_after(H, 10 SECONDS))
 		return
 	if(H.blood_volume >= 40*length(limbs_to_heal)+BLOOD_VOLUME_OKAY)
 		H.regenerate_limbs()

--- a/monkestation/code/modules/surgery/organs/internal/heart.dm
+++ b/monkestation/code/modules/surgery/organs/internal/heart.dm
@@ -158,7 +158,7 @@
 		to_chat(H, span_notice("You feel intact enough as it is."))
 		return
 	to_chat(H, span_notice("You focus intently on your missing [length(limbs_to_heal) >= 2 ? "limbs" : "limb"]..."))
-	if(!do_after(H, 2 SECONDS))
+	if(!do_after(H, 15 SECONDS))
 		return
 	if(H.blood_volume >= 40*length(limbs_to_heal)+BLOOD_VOLUME_OKAY)
 		H.regenerate_limbs()


### PR DESCRIPTION


## About The Pull Request

Changes the amount of time it takes to regenerate your limbs as a slime from 2 seconds to 15 seconds

## Why It's Good For The Game

Them being easy to delimb is supposed to be their main weakness, they shouldn't negate it in 2 seconds, it should be a solid drawback

## Testing

## Changelog

:cl:
balance: Slime regen limbs now takes 15 seconds, up from 2.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

