### PR TITLE
Lawbringer detain mode no longer ignores armor (also cybersun disablers check for energy instead of laser armor values)

### DIFF
--- a/code/modules/projectiles/guns/energy/transforming.dm
+++ b/code/modules/projectiles/guns/energy/transforming.dm
@@ -324,6 +324,8 @@
 	icon_state = "disable_large"
 	damage = 0
 	stamina = 25
+	armor_flag = ENERGY
+	damage_type = STAMINA
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = COLOR_BRIGHT_BLUE
 
@@ -425,6 +427,8 @@
 	icon_state = "disable_bounce"
 	damage = 0
 	stamina = 25
+	armor_flag = ENERGY
+	damage_type = STAMINA
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = COLOR_BRIGHT_BLUE
 	ricochet_auto_aim_angle = 30

--- a/code/modules/projectiles/guns/energy/transforming.dm
+++ b/code/modules/projectiles/guns/energy/transforming.dm
@@ -881,7 +881,7 @@
 	damage_type = STAMINA
 	stamina = 20
 	paralyze_timer = 5 SECONDS
-	//armor_flag = ENERGY //commented out until i can figure out a way for this to not block out ricochet
+	armor_flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'
 	ricochets_max = 4
 	ricochet_chance = 140
@@ -896,6 +896,11 @@
 	light_outer_range = 1
 	light_power = 1
 	light_color = LIGHT_COLOR_BLUE
+
+/obj/projectile/lawbringer/detain/check_ricochet_flag(atom/reflecting_atom)
+	if((reflecting_atom.flags_ricochet & RICOCHET_HARD) || (reflecting_atom.flags_ricochet & RICOCHET_SHINY))
+		return TRUE
+	return FALSE
 
 /**
  * lawbringer execute mode:

--- a/code/modules/projectiles/guns/energy/transforming.dm
+++ b/code/modules/projectiles/guns/energy/transforming.dm
@@ -908,7 +908,7 @@
 
 /**
  * lawbringer execute mode:
- * It fires a 15 damage bullet
+ * It fires a 20 damage bullet
  */
 /obj/item/ammo_casing/energy/lawbringer/execute
 	projectile_type = /obj/projectile/lawbringer/execute


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

it's ABSURD, IT 2 SHOTS REGARDLESS OF ARMOR CUS OF RICOCHET AUTOAIM OR POINT BLANK SHOTS, IT SHOULDN'T also

<img width="935" height="66" alt="{C044DAAA-8833-4F96-9693-E9A493C05ACF}" src="https://github.com/user-attachments/assets/c3ebbb4a-055b-4303-bdd8-5c2754dd49a0" />


Cybersun laser changes just to make them more inline with other disablers

## Testing

launched local, spawned lawbringer, dna lock, shoot at walls (it ricochets :D)
also it 3 shots an elite suit wearer instead of 2 shotting like on live

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Lawbringer detain mode no longer ignores armor.
balance: Cybersun laser gun disabler modes now respect energy armor instead of laser armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
