### PR TITLE
People not readied up now count as 1/3 of a readied up player

### DIFF
--- a/code/__DEFINES/storytellers.dm
+++ b/code/__DEFINES/storytellers.dm
@@ -111,3 +111,6 @@
 #define STARCOLOUR_REDSTAR "Red Star" // More agressive storytellers but not overly mean
 #define STARCOLOUR_BLACKORBIT "Black Orbit" // Events/admin exclusive storytellers
 #define STARCOLOUR_MIDNIGHTSUN "Midnight Sun" // The storyteller is taking a bat to the crew
+
+///An unreadied player counts for this much compared to a readied one
+#define UNREADIED_PLAYER_WEIGHT 0.25

--- a/code/__DEFINES/storytellers.dm
+++ b/code/__DEFINES/storytellers.dm
@@ -113,4 +113,4 @@
 #define STARCOLOUR_MIDNIGHTSUN "Midnight Sun" // The storyteller is taking a bat to the crew
 
 ///An unreadied player counts for this much compared to a readied one
-#define UNREADIED_PLAYER_WEIGHT 0.25
+#define UNREADIED_PLAYER_WEIGHT 0.33

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1391,6 +1391,10 @@ SUBSYSTEM_DEF(job)
 	for(var/job in assigned_players_by_job)
 		player_count += length(assigned_players_by_job[job])
 
+	for(var/mob/dead/new_player/unreadied_player in GLOB.new_player_list)
+		if(unreadied_player.client && unreadied_player.ready == PLAYER_NOT_READY && !unreadied_player.client.holder)
+			player_count += UNREADIED_PLAYER_WEIGHT
+
 	var/list/actual_valid_rolesets = list()
 	for(var/datum/round_event_control/antagonist/roleset in valid_rolesets)
 		if(!roleset.roundstart || !roleset.can_spawn_event(player_count))


### PR DESCRIPTION
## About The Pull Request
based on https://github.com/yogstation13/Yogstation/pull/12022
Unreadied players count as 1/3 a readied player for rolesets. Doesn't include admins.

## Why It's Good For The Game

Makes storyteller take into account roughly the amount of players that are actually going to be playing the game.

## Testing

it works

## Changelog

:cl:
add: Unreadied players now count as 1/3 a ready player for storyteller
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

