### PR TITLE
makes unborgable ghost poll actually happen

### DIFF
--- a/monkestation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/monkestation/code/modules/mob/living/silicon/robot/robot.dm
@@ -15,7 +15,6 @@
 	unborgable_prompted_ghosts = TRUE
 	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(
 		check_jobban = JOB_CYBORG,
-		role = JOB_CYBORG,
 		poll_time = 25 SECONDS,
 		checked_target = src,
 		alert_pic = src,


### PR DESCRIPTION


## About The Pull Request
Fixes the ghost poll that is suppose to happen when someone with the Unborgable quirk somehow becomes a cyborg. It should now poll.

`role` variable is for the roles that you select via Antagonist selection in Character Preferences. Because cyborgs aren't in there, no one was eligible and thus no one got the ghost pole.
https://github.com/Monkestation/Monkestation2.0/blob/e7351e5f045a92dca63e2a26c3211e63a90a82b7/code/controllers/subsystem/polling.dm#L308-L310

## Why It's Good For The Game
Bugfix.

## Testing
Spawned a cyborg. Gave it a mind and applied the unborgable trait to it. Proc called `prompt_ghosts_if_unborgable` on it.
Got the prompt: 
<img width="150" height="100" alt="image" src="https://github.com/user-attachments/assets/3d738551-085f-47f8-be23-d680b7180cb2" />

## Changelog
:cl:
fix: People with the Unborgable quirk that somehow become cyborgs now correctly polls ghosts if they want to take over the their body.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

