### PR TITLE
Twitch (the drug) can no longer make you attack infinitelly fast (and properly stacks with other mods)

### DIFF
--- a/monkestation/code/modules/blueshift/reagents/deforest.dm
+++ b/monkestation/code/modules/blueshift/reagents/deforest.dm
@@ -255,7 +255,7 @@
 		return
 
 	our_guy.add_movespeed_modifier(/datum/movespeed_modifier/reagent/twitch)
-	our_guy.next_move_modifier -= 0.3 // For the duration of this you move and attack faster
+	our_guy.next_move_modifier *= 0.7 // For the duration of this you move and attack faster
 
 	our_guy.sound_environment_override = SOUND_ENVIRONMENT_DIZZY
 
@@ -285,7 +285,7 @@
 	. = ..()
 
 	our_guy.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/twitch)
-	our_guy.next_move_modifier += (overdosed ? 0.5 : 0.3)
+	our_guy.next_move_modifier /= (overdosed ? 0.49 : 0.7)
 
 	our_guy.sound_environment_override = NONE
 
@@ -384,7 +384,7 @@
 
 	//RegisterSignal(our_guy, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(dodge_bullets)) //This is the code that enables dodging bullets, it's disabled due to bullet immunity being extremely overpowered.
 
-	our_guy.next_move_modifier -= 0.2 // Overdosing makes you a liiitle faster but you know has some really bad consequences
+	our_guy.next_move_modifier *= 0.7 // Overdosing makes you a liiitle faster but you know has some really bad consequences
 
 	if(!our_guy.hud_used)
 		return


### PR DESCRIPTION

## About The Pull Request

Ports:
- https://github.com/Bubberstation/Bubberstation/pull/2536 (only the twitch part)

Yeah, that was a thing. Bubber's PR explains it best (even if its ported from nova) so i linked em and tis be the quote from da PR

> This one needs a bit of VV to test mostly to speed up the conditions, but its doable by a miner with a bit of skill.
>
> You need the berserker armor of the chosen one, or alternatively, the Dexterous mutation and a way to remove it (I think you can do so with mutadone, but never tried, regardless!) and Twitch.
The short of it is that the next move variable is always edited with multiplicatives, but Twitch was coded with an aditive, so alternating one and another and then removing one effect and letting the other run out would net you with a lower than 1 next move variable.

## Why It's Good For The Game

Bugs bad, even if it was never exploited, Probably.

## Testing

I compiled da code, i tested if twitch gave weird numbers and it didn't, neat.

## Changelog

:cl:
fix: twitch now properly interacts with other action modifiers
/:cl:

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
