### PR TITLE
borg low power mode changes immediately on cell change

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -669,16 +669,19 @@
 	. = ..()
 	if(worn_hat == gone)
 		worn_hat = null
-		if(!QDELETED(src)) //Don't update icons if we are deleted.
+		if(!QDELETED(src))
 			update_icons()
 
 	if(worn_badge == gone)
 		worn_badge = null
-		if(!QDELETED(src)) //Don't update icons if we are deleted.
+		if(!QDELETED(src))
 			update_icons()
 
 	if(gone == cell)
 		cell = null
+		low_power_mode = TRUE
+		if(!QDELETED(src))
+			update_icons()
 
 	if(gone == mmi)
 		mmi = null

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -31,6 +31,8 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			if(!user.transferItemToLoc(attacking_item, src))
 				return
 			cell = attacking_item
+			if(cell.charge)
+				low_power_mode = FALSE
 			to_chat(user, span_notice("You insert the power cell."))
 		update_icons()
 		diag_hud_set_borgcell()
@@ -217,7 +219,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		cell.add_fingerprint(user)
 		user.put_in_active_hand(cell)
 		to_chat(user, span_notice("You remove \the [cell]."))
-		update_icons()
 		diag_hud_set_borgcell()
 
 /mob/living/silicon/robot/attack_hulk(mob/living/carbon/human/user)


### PR DESCRIPTION


## About The Pull Request
Taking or giving a cyborg a cell now sets their `low_power_mode` variable immediately so that their appearance correctly looks that they don't have power.

## Why It's Good For The Game
Bugfix.

## Testing
Appearance changes immediately upon add/removal of the cell.
<img width="253" height="191" alt="low_power_mode" src="https://github.com/user-attachments/assets/fb45cb69-804c-4a34-8046-8ebbbd5da89e" />

## Changelog
:cl:
fix: Changing a cyborg's now immediately changes their low power mode and their appearance rather than shortly after.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

