### PR TITLE
AIs in exosuits retain mech control in event of core relocation failure

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -432,14 +432,14 @@
 
 /obj/item/modular_computer/pda/silicon/explode(mob/target, mob/bomber, from_message_menu)
 	if(from_message_menu)
-		log_bomber(null, null, target, "'s induced disruption as [target.p_they()] tried to open their tablet message menu because of a recent tablet bomb sent to a silicon.")
+		log_bomber(null, null, target, "'s induced disruption as [target.p_they()] tried to open their tablet message menu because of a recent tablet bomb sent to a silicon")
 	else
 		log_bomber(bomber, "successfully tablet-disrupted", target, "as [target.p_they()] tried to reply to a rigged tablet message sent to a silicon [bomber && !is_special_character(bomber) ? "(SENT BY NON-ANTAG)" : ""]")
 	to_chat(silicon_owner, span_danger("POWER SURGE DETECTED/"))
 	do_sparks(4, FALSE, src)
 	if(isAI(silicon_owner))
 		silicon_owner.adjustFireLoss(25)
-		if(!isturf(silicon_owner.loc)) //AI not in core? not wise to disable a random APC then.
+		if(!isvalidAIloc(silicon_owner.loc)) //AI not in core? not wise to disable a random APC then.
 			silicon_owner.Unconscious(10 SECONDS,  TRUE)
 		else
 			var/area/AIarea = get_area(silicon_owner)

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -139,7 +139,10 @@
 			if(AI.relocate(silent = TRUE, kill_otherwise = FALSE))
 				moved_already = TRUE
 			else
-				to_chat(AI, span_userdanger("No cores available. Core code corrupted."))
+				to_chat(AI, span_userdanger("No cores available. Enabling controls."))
+				AI.controlled_equipment = src
+				AI.remote_control = src
+				return FALSE
 	else
 		return ..()
 	var/mob/living/ejector = M


### PR DESCRIPTION


## About The Pull Request
closes #12417, technically.
When an AI ejects from a mech, its relocated to its last core, or, if it cant do that, the next best available core on the Z level.
in the event there are no valid cores, such as none existing on the Z level you sent your mech to, or being destroyed, ejecting will send you to purgatory. You can guess that being unable to move isnt fun.

Currently known issue is that being in a mech without any cores causes you to repeatedly create runtimes every second or so until you attempt to eject, but that is for Someone Else To Handle.

Also while im here i realized PDA bombs to AIs broke with yog AI, so i fixed that as well
## Why It's Good For The Game
Bug fix

## Testing
Assumed control of durand on runtime, destroyed all data cores, attempted to eject, retained control of the mech after failing, adminspawned new data cores, ejected safely.

Sent message to AI, APC turned off and backup battery dropped to 61%

## Changelog

:cl:
fix: AIs ejecting from exosuits without a valid core nearby will no longer get sent to container hell.
fix: AIs opening PDA bombs will disrupt their APC again.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

