### PR TITLE
anomalous mutations cant be saved to disk.

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -1056,6 +1056,10 @@
 			if(!mutation)
 				return
 
+			if(length(mutation.sources) && get_mutation_class(mutation) == SCANNER_MUTATION_CLASS_OTHER)
+				say("ERROR: This mutation is anomalous, and cannot be saved.")
+				return
+
 			// GUARD CHECK - Nullify should only be used on scrambled or "extra"
 			//  mutations.
 			if(!mutation.scrambled && !(MUTATION_SOURCE_MUTATOR in mutation.sources))

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -1034,6 +1034,10 @@
 			if(!original)
 				return
 
+			if(length(original.sources) && get_mutation_class(original) == SCANNER_MUTATION_CLASS_OTHER)
+				say("ERROR: This mutation is anomalous, and cannot be saved.")
+				return
+
 			diskette.mutations += original.make_copy()
 
 			to_chat(usr,span_notice("Mutation successfully stored to disk."))
@@ -1054,10 +1058,6 @@
 
 			// GUARD CHECK - This should not be possible. Unexpected result
 			if(!mutation)
-				return
-
-			if(length(mutation.sources) && get_mutation_class(mutation) == SCANNER_MUTATION_CLASS_OTHER)
-				say("ERROR: This mutation is anomalous, and cannot be saved.")
 				return
 
 			// GUARD CHECK - Nullify should only be used on scrambled or "extra"


### PR DESCRIPTION


## About The Pull Request
anomalous cant be saved to disk. IE DNA vault

## Why It's Good For The Game
Bypassing the requirements of saving it with a simple DNA Disk seems an oversight as you cant save it normally. Either they should be saveable normally, or not at all.

## Testing
<img width="360" height="290" alt="Screenshot 2026-08-26 145134" src="https://github.com/user-attachments/assets/1bd3db57-50f4-4026-82ba-69eeac89eaa7" />

## Changelog

:cl:
balance: Anomalous mutations can't be saved via DNA disk
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

