### PR TITLE
Allows Cyborgs To Use Assembler Interface

### DIFF
--- a/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
+++ b/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
@@ -170,18 +170,7 @@
 	empty_crafting_inventory()
 
 /obj/machinery/assembler/attack_robot(mob/user)
-	. = ..()
-	if(panel_open)
-		to_chat(user, span_warning("The assembler cannot select a recipe while its service panel is open!"))
-		user.balloon_alert(user, "panel open!")
-		return
-	var/datum/crafting_recipe/choice = tgui_input_list(user, "Choose a recipe", name, legal_crafting_recipes)
-	if(!choice)
-		return
-	chosen_recipe = choice
-	if(crafting)
-		return
-	empty_crafting_inventory()
+	return attack_hand(user)
 
 /obj/machinery/assembler/crowbar_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_BLOCKING

--- a/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
+++ b/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
@@ -170,6 +170,8 @@
 	empty_crafting_inventory()
 
 /obj/machinery/assembler/attack_robot(mob/user)
+	if(!user.Adjacent(src))
+		return
 	return attack_hand(user)
 
 /obj/machinery/assembler/crowbar_act(mob/living/user, obj/item/tool)

--- a/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
+++ b/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
@@ -169,6 +169,20 @@
 		return
 	empty_crafting_inventory()
 
+/obj/machinery/assembler/attack_robot(mob/user)
+	. = ..()
+	if(panel_open)
+		to_chat(user, span_warning("The assembler cannot select a recipe while its service panel is open!"))
+		user.balloon_alert(user, "panel open!")
+		return
+	var/datum/crafting_recipe/choice = tgui_input_list(user, "Choose a recipe", name, legal_crafting_recipes)
+	if(!choice)
+		return
+	chosen_recipe = choice
+	if(crafting)
+		return
+	empty_crafting_inventory()
+
 /obj/machinery/assembler/crowbar_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_BLOCKING
 	if(!panel_open)


### PR DESCRIPTION


## About The Pull Request

Allows cyborgs to interact with assembler and choose recipes.

## Why It's Good For The Game

It allows cyborgs to use assemblers, giving them more autonomy

## Testing

## Changelog

:cl:
add: Cyborgs can now use assembler interface
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

