### PR TITLE
[BALANCE] Touching extremely hotwired airlocks now respects insulation + husks you instead of dusting you

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -503,7 +503,7 @@
 	var/obj/item/stock_parts/power_store/cell/cell = powernet_info["cell"]
 
 	// MONKESTATION ADDITION -- This whole proc is basically polluted because long ago we didnt care for modularization
-	if(victim.wearing_shock_proof_gloves() && (PN && PN?.netexcess < 100 MW) && !always_shock)
+	if(!victim.should_electrocute(power_source) && !always_shock)
 		SEND_SIGNAL(victim, COMSIG_LIVING_SHOCK_PREVENTED, power_source, source, siemens_coeff, dist_check)
 		return FALSE //to avoid spamming with insulated gloves on
 
@@ -527,15 +527,9 @@
 		tesla_zap(victim, 7, PN.netexcess)
 		drained_hp = PN.netexcess * 0.01
 	else
-		var/obj/item/organ/internal/brain/carbon_brain = victim.get_organ_slot(ORGAN_SLOT_BRAIN)
-		var/turf/turf = get_turf(victim)
+		drained_hp = victim.electrocute_act(600, source, siemens_coeff) //OUCH!
 		playsound(victim.loc, 'sound/magic/lightningbolt.ogg', 100, TRUE, extrarange = 30)
-		victim.death(FALSE, "electrocution")
-		carbon_brain.Remove(victim)
-		carbon_brain.forceMove(turf)
-		victim.visible_message(span_danger("[victim] turns to ash from the electrical shock!"))
-		victim.dust()
-		drained_hp = PN.netexcess * 0.1
+		victim.visible_message(span_danger("[victim]'s skin turns to ash from the electrical shock!"))
 
 	log_combat(source, victim, "electrocuted")
 


### PR DESCRIPTION


## About The Pull Request

Getting shocked by an airlock with a ludicrous amount of power going through it no longer bypasses all forms of insulation. 

If you do not have insulation, getting shocked now instantly husks you (by applying max burn damage, 600) instead of dusting you.

PR discussion thread: https://discord.com/channels/748354466335686736/1541312093066756156

## Why It's Good For The Game

With the TEG it's not super difficult for this kind of power to be reached and it is has become a very high-impact, repeated strategy used by rogue AIs. As a matter of fact just on the day I started working on this PR (august 23) it was used at least twice in a single day. 

Being instantly round-removed (dropping nothing but a brain is still effectively round-removal) by a completely silent hazard is horribly unfun gameplay. Doorshocks are infinitely spammable and once the initial setup is done can be spammed everywhere to easily round-remove a large portion of the server with minimal further effort. The punishment of getting instantly husked is still pretty severe, but leaves your body (and items) in at least a practically revivable state. The fact that insulation (of any kind, gloves or otherwise) doesn't even protect against it also makes the strategy absurdly & unfairly difficult to counter, even once you know it's happening. Given the amount this strategy has been repeated, the """"soul"""" of this feature does not outweigh the plain lameness of it.

## Testing

<img width="1920" height="1080" alt="Screenshot (19370)" src="https://github.com/user-attachments/assets/0af37751-1999-4b8c-b4ca-036b35f1d778" />

## Changelog

:cl:
balance: Insulation (of any kind) now protects against door shocks regardless of how powerful the shock is. 
balance: Getting shocked by an extremely powered door now husks you instead of dusting you.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

