### PR TITLE
[BALANCE] [MINOR] Adds 2 slug ammo boxes to the ammo crate.

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -7,11 +7,12 @@
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate"
 	desc = "Contains two boxes of beanbag shotgun shells, two boxes \
-		of rubbershot shotgun shells, two boxes of buckshot, and one of each special .38 speedloaders."
+		of rubbershot shotgun shells, two boxes of buckshot, two boxes of slugs, and one of each special .38 speedloaders."
 	cost = CARGO_CRATE_VALUE * 8
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/bean = 2,
 					/obj/item/ammo_box/advanced/s12gauge/rubber = 2,
 					/obj/item/ammo_box/advanced/s12gauge/buckshot = 2,
+					/obj/item/ammo_box/advanced/s12gauge = 2,
 					/obj/item/ammo_box/c38/trac,
 					/obj/item/ammo_box/c38/hotshot,
 					/obj/item/ammo_box/c38/iceblox,


### PR DESCRIPTION


## About The Pull Request

Adds 2 slug ammo boxes to the ammo crate, consistent with it having the other types of shotgun ammo.

## Why It's Good For The Game

Doesn't really make sense why these are only in the bobr crate instead of being in the crate you would expect them to be in.

## Testing

Simple line addition. If I fucked this up somehow, that's pretty sad. 

## Changelog

:cl:
balance: Adds 2 slug ammo boxes to the ammo crate, consistent with it having the other types of shotgun ammo.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

