### PR TITLE
Fixes Ai Bitcoin mining not producing bitcoin

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_dashboard.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_dashboard.dm
@@ -357,7 +357,7 @@
 
 		if(crypto_mining)
 			points *= 0.5
-			var/bitcoin_mined = (points * 2) * (1 - 0.04 * sqrt(points))
+			var/bitcoin_mined = (points * 3) / (1 + 0.2 * sqrt(points))
 			bitcoin_mined = clamp(bitcoin_mined, 0, MAX_AI_BITCOIN_MINED_PER_TICK)
 			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 			if(D)


### PR DESCRIPTION


## About The Pull Request
Fixes the ai bitcoin mining not producing bitcoin. closes: #12224

TIME FOR MATH! (Mostley because I find this type of thing interesting.
`(points * 2) * (1 - 0.04 * sqrt(points))` is the orginal formula for bit mining. Which can be broken into a growth formula and a decay formula. Initially decay is fine and dandy acting as a inhibitor. Until points reaches about 277. To which decay outweighs the growth! And then you start losing value. And at 625 points. It loops back around to zero. And then after that it keeps going. Bringing the credits generated from bit mining to the negatives!
Here's a graph of it in orange.
<img width="1879" height="891" alt="image" src="https://github.com/user-attachments/assets/116b9d7f-35c8-44f7-a878-284217791126" />
Pictured in purple is the suggestion for the new formula `(points * 3) / (1 + 0.2 * sqrt(points))` Which follows a somewhat similiar formula but decay never exceeds growth. And really we only need to worry about the formula until 375 is reached. (the green line)

## Why It's Good For The Game
I like money.

## Testing
<img width="951" height="432" alt="Screenshot 2026-08-24 034623" src="https://github.com/user-attachments/assets/2db4342b-766d-4991-ba26-d6dc3f62266b" />

## Changelog

:cl:
fix: AI Crypto mining will now properly generate bitcoin at high values of CPU
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

