### PR TITLE
Multi AI resource issues fixes.

### DIFF
--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -38,8 +38,8 @@
 	var/obj/machinery/ai/data_core/relocated_into = get_turf(ai_spawn)
 	var/datum/ai_os/os_using = GLOB.ai_os["[relocated_into.z]"]
 
-	os_using.set_cpu(ai_spawn, os_using.total_cpu)
-	os_using.set_ram(ai_spawn, os_using.total_ram)
+	os_using.set_cpu(ai_spawn, os_using.total_cpu, TRUE)
+	os_using.set_ram(ai_spawn, os_using.total_ram, TRUE)
 	ai_spawn.log_current_laws()
 
 /datum/job/ai/get_roundstart_spawn_point()

--- a/code/modules/mob/living/silicon/ai/decentralized/decentralized_os.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/decentralized_os.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_EMPTY(ai_os)
 
 	//Find out how much is actually assigned. We can have more total_cpu than the sum of cpu_assigned. Same with RAM
 	var/total_assigned_ram = total_ram_assigned()
-	//If we have less assigned  ram than we have cpu and ram, just return, everything is fine.
+	//If we have less assigned ram than we have cpu and ram, just return, everything is fine.
 	if(total_assigned_ram < total_ram)
 		return
 
@@ -118,22 +118,26 @@ GLOBAL_LIST_EMPTY(ai_os)
 
 	to_chat(affected_AIs, span_warning("You have been deducted processing capabilities. Please contact your network administrator if you believe this to be an error."))
 
-/datum/ai_os/proc/set_cpu(mob/living/silicon/ai/AI, amount, update = TRUE)
+/datum/ai_os/proc/set_cpu(mob/living/silicon/ai/AI, amount, adjust_overflow = FALSE, update = TRUE)
 	if(!istype(AI) || amount < 0)
 		return
-	//total cpu - (current AIs CPU + CPU we're giving) > total_cpu
-	if(total_cpu_assigned() - (cpu_assigned[AI] + amount) > total_cpu)
-		return
+	//total cpu - current AIs CPU + new CPU we're giving > total_cpu
+	if(total_cpu_assigned() - cpu_assigned[AI] + amount > total_cpu)
+		if(!adjust_overflow)
+			return
+		amount = total_cpu - total_cpu_assigned() + cpu_assigned[AI]
 	cpu_assigned[AI] = amount
 	if(update)
 		update_allocations()
 
-/datum/ai_os/proc/set_ram(mob/living/silicon/ai/AI, amount, update = TRUE)
+/datum/ai_os/proc/set_ram(mob/living/silicon/ai/AI, amount, adjust_overflow = FALSE, update = TRUE)
 	if(!istype(AI) || amount < 0)
 		return
-	//total ram - (current AIs ram + ram we're giving) > total_ram
-	if(total_ram_assigned() - (ram_assigned[AI] + amount) > total_ram)
-		return
+	//total ram - current AIs ram + new ram we're giving > total_ram
+	if(total_ram_assigned() - ram_assigned[AI] + amount > total_ram)
+		if(!adjust_overflow)
+			return
+		amount = total_ram - total_ram_assigned() + ram_assigned[AI]
 	ram_assigned[AI] = amount
 	if(update)
 		update_allocations()

--- a/code/modules/mob/living/silicon/ai/decentralized/management/resource_distribution.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/resource_distribution.dm
@@ -158,7 +158,7 @@
 			var/amount = params["amount_cpu"]
 			if(!isnum(amount) || amount < 0)
 				return
-			os_using.set_cpu(target_ai, amount)
+			os_using.set_cpu(target_ai, amount, TRUE)
 			. = TRUE
 
 		if("set_ram")
@@ -176,7 +176,7 @@
 			var/amount = params["amount_ram"]
 			if(!isnum(amount) || amount < 0)
 				return
-			os_using.set_ram(target_ai, amount)
+			os_using.set_ram(target_ai, amount, TRUE)
 
 		if("toggle_human_status")
 			if(!authenticated)

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/research_booster.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/research_booster.dm
@@ -17,7 +17,7 @@
 	var/obj/machinery/rnd/server/selected_server = pick(SSresearch.get_available_servers(ai_turf))
 	if(isnull(selected_server))
 		return FALSE
-	if(selected_server.stored_research.ai_boosted == TRUE)
+	if(selected_server.stored_research.ai_boosted)
 		to_chat(ai, span_warning("Found research network is already being boosted by another artifical intelligence; preventing redundant processing."))
 		return FALSE
 	techweb_boosting = selected_server.stored_research

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/research_booster.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/research_booster.dm
@@ -17,6 +17,9 @@
 	var/obj/machinery/rnd/server/selected_server = pick(SSresearch.get_available_servers(ai_turf))
 	if(isnull(selected_server))
 		return FALSE
+	if(selected_server.stored_research.ai_boosted == TRUE)
+		to_chat(ai, span_warning("Found research network is already being boosted by another artifical intelligence; preventing redundant processing."))
+		return FALSE
 	techweb_boosting = selected_server.stored_research
 	return ..()
 


### PR DESCRIPTION


## About The Pull Request
- Research booster can no longer be used if another AI is already using research booster.
- You can no longer set RAM/CPU values greater than the total networks CPU/RAM Value.  closes: #12400
- If you set a value greater than whats possible, it'll default to the next highest possible value, rather than failing

## Why It's Good For The Game
- If two ai's run research booster. Then one cancels it, it cancels it for both alongside it not having additional benefits to having multiple ai's running it on the same server.
- Illegal values are bad. Ew
- Pure QOL to not have to try to set the value 24325 times and get errored by this fix.

## Testing
<img width="630" height="82" alt="image" src="https://github.com/user-attachments/assets/10a6e4f3-006f-4845-a486-9dabd16baf59" />

The rest I dont know how to show saying it. Requires something NOT HAPPENING
rather than showing it is happening
## Changelog

:cl:
qol: AI Research Acceleration will not run if it is already being ran by another AI
qol: Setting a RAM/CPU value higher than whats possible via the distribution console will now default to the highest possible value.
fix: You no longer can generate fake RAM/CPU with multiple AI's 
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

