### PR TITLE
Guaranteed nukie spawn now respects max_occurances

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -112,7 +112,7 @@
 	if(locate(/obj/machinery/nuclearbomb) in get_turf(src))
 		return
 	if(D.unsecured_time != 0)
-		return round(D.unsecured_time/60, 1)
+		return round(D.unsecured_time/600, 1)
 //MONKESTATION EDIT STOP
 
 /obj/effect/countdown/supermatter

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -45,7 +45,7 @@
 		//MONKESTATION EDIT START
 		unsecured_timer = new(src)
 		unsecured_timer.start()
-		junior_lone_operative_trigger_time = (20 + rand(-5, 5)) * 60 //35 minutes + -5 to 5 minutes
+		junior_lone_operative_trigger_time = (30) //35 minutes + -5 to 5 minutes
 		can_trigger_junior_operative = TRUE
 		GLOB.nuke_disk_list += src
 		//MONKESTATION EDIT STOP
@@ -69,11 +69,17 @@
 	var/turf/new_turf = get_turf(src)
 	/// How comfy is our disk?
 	var/disk_comfort_level = 0
-	//MONKESTATION EDIT START
+
 	unsecured_time += 1
 	if(unsecured_time == junior_lone_operative_trigger_time && can_trigger_junior_operative)
-		spawn_op()
-	//MONKESTATION EDIT STOP
+		var/datum/round_event_control/loneopflavor
+		if(prob(50))
+			loneopflavor = SSevents.control_by_type[/datum/round_event_control/operative]
+		else
+			loneopflavor = SSevents.control_by_type[/datum/round_event_control/junior_lone_operative]
+		if(istype(loneopflavor) && loneopflavor.get_occurrences() < loneopflavor.max_occurrences)
+			force_event(loneopflavor.type, "the nuke disk being unsecured for [round(unsecured_time/60, 1)] minutes")
+
 	//Go through and check for items that make disk comfy
 	for(var/obj/comfort_item in loc)
 		if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
@@ -147,11 +153,6 @@
 	if(src in GLOB.nuke_disk_list)
 		GLOB.nuke_disk_list -= src
 	return ..()
-/obj/item/disk/nuclear/proc/spawn_op()
-	if(prob(50))
-		force_event(/datum/round_event_control/junior_lone_operative, "the nuke disk being unsecured for [round(unsecured_time/60, 1)] minutes")
-	else
-		force_event(/datum/round_event_control/operative, "the nuke disk being unsecured for [round(unsecured_time/60, 1)] minutes")
 //MONKESTATION EDIT STOP
 
 /obj/item/disk/nuclear/fake

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -45,7 +45,7 @@
 		//MONKESTATION EDIT START
 		unsecured_timer = new(src)
 		unsecured_timer.start()
-		junior_lone_operative_trigger_time = (20 + rand(-5, 5)) * 60 //35 minutes + -5 to 5 minutes
+		junior_lone_operative_trigger_time = (20 + rand(-5, 5)) MINUTES //20 minutes + -5 to 5 minutes
 		can_trigger_junior_operative = TRUE
 		GLOB.nuke_disk_list += src
 		//MONKESTATION EDIT STOP
@@ -61,7 +61,7 @@
 		if(loneopmode.weight % 5 == 0 && SSticker.totalPlayers > 1)
 			message_admins("[src] is secured (currently in [ADMIN_VERBOSEJMP(new_turf)]). The weight of Lone Operative is now [loneopmode.get_weight()] (base [loneopmode.weight]).")
 		log_game("[src] being secured has reduced the weight of the Lone Operative event to [loneopmode.get_weight()] (base [loneopmode.weight]).")
-	junior_lone_operative_trigger_time = (20 + rand(-5, 5)) * 60
+	junior_lone_operative_trigger_time = (20 + rand(-5, 5)) MINUTES
 	unsecured_time = 0
 
 /obj/item/disk/nuclear/proc/unsecured_process(last_move)
@@ -69,7 +69,7 @@
 	/// How comfy is our disk?
 	var/disk_comfort_level = 0
 
-	unsecured_time += 1
+	unsecured_time += 2 SECONDS // Yes two.
 	if(unsecured_time == junior_lone_operative_trigger_time && can_trigger_junior_operative)
 		var/datum/round_event_control/loneopflavor
 		if(prob(50))
@@ -77,10 +77,9 @@
 		else
 			loneopflavor = SSevents.control_by_type[/datum/round_event_control/junior_lone_operative]
 		if(istype(loneopflavor) && loneopflavor.get_occurrences() < loneopflavor.max_occurrences)
-			force_event(loneopflavor.type, "the nuke disk being unsecured for [round(unsecured_time/60, 1)] minutes")
+			force_event(loneopflavor.type, "the nuke disk being unsecured for [round((unsecured_time/600), 1)] minutes")
 		else
-			junior_lone_operative_trigger_time += (5 * 60) // 5 More minutes according to the disk. It doesnt run on different scaling than MINUTES for some reason
-
+			junior_lone_operative_trigger_time += 5 MINUTES
 	//Go through and check for items that make disk comfy
 	for(var/obj/comfort_item in loc)
 		if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -45,7 +45,7 @@
 		//MONKESTATION EDIT START
 		unsecured_timer = new(src)
 		unsecured_timer.start()
-		junior_lone_operative_trigger_time = (30) //35 minutes + -5 to 5 minutes
+		junior_lone_operative_trigger_time = (20 + rand(-5, 5)) * 60 //35 minutes + -5 to 5 minutes
 		can_trigger_junior_operative = TRUE
 		GLOB.nuke_disk_list += src
 		//MONKESTATION EDIT STOP
@@ -61,9 +61,8 @@
 		if(loneopmode.weight % 5 == 0 && SSticker.totalPlayers > 1)
 			message_admins("[src] is secured (currently in [ADMIN_VERBOSEJMP(new_turf)]). The weight of Lone Operative is now [loneopmode.get_weight()] (base [loneopmode.weight]).")
 		log_game("[src] being secured has reduced the weight of the Lone Operative event to [loneopmode.get_weight()] (base [loneopmode.weight]).")
-	//MONKESTATION EDIT START
+	junior_lone_operative_trigger_time = (20 + rand(-5, 5)) * 60
 	unsecured_time = 0
-	//MONKESTATION EDIT STOP
 
 /obj/item/disk/nuclear/proc/unsecured_process(last_move)
 	var/turf/new_turf = get_turf(src)
@@ -79,6 +78,8 @@
 			loneopflavor = SSevents.control_by_type[/datum/round_event_control/junior_lone_operative]
 		if(istype(loneopflavor) && loneopflavor.get_occurrences() < loneopflavor.max_occurrences)
 			force_event(loneopflavor.type, "the nuke disk being unsecured for [round(unsecured_time/60, 1)] minutes")
+		else
+			junior_lone_operative_trigger_time += (5 * 60) // 5 More minutes according to the disk. It doesnt run on different scaling than MINUTES for some reason
 
 	//Go through and check for items that make disk comfy
 	for(var/obj/comfort_item in loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Guaranteed nukie spawn now respects max_occurances
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Primarily acts as a fix for MRP2 where they don't want nukies spawning for reasons. ask @Veth-s  about it. Without making another config change. 
The only difference for main is
A. Securing the disk sets a new randomized guaranteed nukie time which isn't observable evenways
B. If a guaranteed nukie type has already reached max occurrences prior to the timer, it'll try again in 5 minutes. Otherwise all properties remain the same
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing
<img width="761" height="467" alt="image" src="https://github.com/user-attachments/assets/ff8b2d92-0933-42c0-b215-c555cd003f2c" />
Nukie spawned and failed future checks on operative rolls
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nuke disk guaranteed nukeop spawn now respects maximum antags. And if fails will try again in 5 minutes.
fix: Nuke disk no longer tracks time at half the rate of intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
