### PR TITLE
Syndicate plasmamen can purchase a tacticool plasmaman outfit.

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -552,6 +552,16 @@
 /obj/item/storage/box/syndie_kit/imp_radio/PopulateContents()
 	new /obj/item/implanter/radio/syndicate(src)
 
+/obj/item/storage/box/syndie_kit/plasmaman
+	name = "boxed badass plasmaman outfit"
+	desc = "A sleek, sturdy box used to hold a \"tactical\" plasmaman outfit."
+	illustration = "syndiesuit"
+
+/obj/item/storage/box/syndie_kit/plasmaman/PopulateContents()
+	new /obj/item/clothing/under/plasmaman/syndicate(src)
+	new /obj/item/clothing/head/helmet/space/plasmaman/syndie(src)
+	new /obj/item/clothing/gloves/combat(src)
+
 /obj/item/storage/box/syndie_kit/space
 	name = "boxed space suit and helmet"
 	desc = "A sleek, sturdy box used to hold an emergency spacesuit."

--- a/code/modules/uplink/uplink_items/species.dm
+++ b/code/modules/uplink/uplink_items/species.dm
@@ -47,3 +47,10 @@
 	item = /obj/item/book/granter/martial/tribal_claw
 	restricted_species = list(SPECIES_LIZARD)
 
+/datum/uplink_item/species_restricted/tacticool_plasmaman
+	name = "Tacticool Plasmaman Outfit"
+	desc = "A badass plasmaman outfit, for our most badass plasmamen. This blood red suit package provides no tactical advantage whatsoever."
+	cost = 1
+	item = /obj/item/storage/box/syndie_kit/plasmaman
+	restricted_species = list(SPECIES_PLASMAMAN)
+

--- a/code/modules/uplink/uplink_items/species.dm
+++ b/code/modules/uplink/uplink_items/species.dm
@@ -49,7 +49,7 @@
 
 /datum/uplink_item/species_restricted/tacticool_plasmaman
 	name = "Tacticool Plasmaman Outfit"
-	desc = "A badass plasmaman outfit, for our most badass plasmamen. This blood red suit package provides no tactical advantage whatsoever."
+	desc = "A badass plasmaman outfit, for our most badass plasmamen. This syndicate themed suit package provides no tactical advantage whatsoever."
 	cost = 1
 	item = /obj/item/storage/box/syndie_kit/plasmaman
 	restricted_species = list(SPECIES_PLASMAMAN)


### PR DESCRIPTION


## About The Pull Request
Adds the tacticool plasmaman outfit to uplinks as a role restricted plasmaman item.

## Why It's Good For The Game
Im being paid in a code bounty.
It looks cool.
If you lose your envirosuit, this can work as a failsafe option.

## Testing
loaded in as a plasmaman, traitor paneled to give myself traitor, purchased box for 1TC, replaced all my clothes with the contents and survived.

## Changelog

:cl:
add: Traitor plasmamen can purchase a Tacticool Plasmaman outfit for 1TC.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

