### PR TITLE
AI core displays have an internal camera

### DIFF
--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -18,7 +18,7 @@
 			/* Written with `0 ||` to avoid the compiler seeing call("string"), and thinking it's a deprecated DLL */ \
 			call(0 || proc_owner, proc_path)(##proc_arguments); \
 		}; \
-	} 
+	}
 
 /// like CALLBACK but specifically for verb callbacks
 #define VERB_CALLBACK new /datum/callback/verb_callback

--- a/code/datums/components/internal_cam.dm
+++ b/code/datums/components/internal_cam.dm
@@ -8,12 +8,12 @@
 	///The camera object used to gather information for the camera net
 	var/obj/machinery/camera/bodcam
 
-/datum/component/internal_cam/Initialize(list/networks = list("ss13"))
-	if(!isliving(parent))
+/datum/component/internal_cam/Initialize(list/networks = list("ss13"), custom_ctag)
+	if(!isliving(parent) && !ismachinery(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	bodcam = new(parent)
-	bodcam.c_tag = parent
+	bodcam.c_tag = custom_ctag || parent
 	bodcam.name = parent
 	var/list/lowercase_networks = list()
 	for(var/network_name in networks)

--- a/code/datums/components/internal_cam.dm
+++ b/code/datums/components/internal_cam.dm
@@ -8,7 +8,7 @@
 	///The camera object used to gather information for the camera net
 	var/obj/machinery/camera/bodcam
 
-/datum/component/internal_cam/Initialize(list/networks = list("ss13"), custom_ctag)
+/datum/component/internal_cam/Initialize(list/networks = list("ss13"), custom_ctag, emp_flags = EMP_PROTECT_SELF)
 	if(!isliving(parent) && !ismachinery(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -20,7 +20,8 @@
 		lowercase_networks += LOWER_TEXT(network_name)
 	bodcam.network = lowercase_networks
 	bodcam.setViewRange(MAX_CAMERA_RANGE) //standard camera viewrange
-	bodcam.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF)
+	if(emp_flags)
+		bodcam.AddElement(/datum/element/empprotection, emp_flags)
 
 /datum/component/internal_cam/Destroy(force, silent)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/decentralized/ai_core_display.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_core_display.dm
@@ -142,7 +142,7 @@
 	RegisterSignal(connected_ai, COMSIG_AI_ICON_CHANGE, PROC_REF(on_ai_screen_change))
 	INVOKE_ASYNC(connected_ai, TYPE_PROC_REF(/mob/living/silicon/ai, set_core_display_icon), null, connected_ai?.client)
 
-	LoadComponent(/datum/component/internal_cam, camera_networks, "[connected_ai.name] core display")
+	LoadComponent(/datum/component/internal_cam, networks = camera_networks, custom_ctag = "[connected_ai.name] core display", emp_flags = NONE)
 
 ///Called when the first AI of the round is created, as we get automatically assigned to it.
 /obj/machinery/status_display/ai_core/proc/on_ai_creation(atom/source, mob/living/silicon/ai/new_ai)

--- a/code/modules/mob/living/silicon/ai/decentralized/ai_core_display.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_core_display.dm
@@ -13,6 +13,8 @@
 	var/mutable_appearance/custom_portrait_icon
 	///The AI that controls the core display, it changes emotions as they do.
 	var/mob/living/silicon/ai/connected_ai
+	/// The networks it broadcasts to, default is CAMERANET_NETWORK_AI_CORE
+	var/list/camera_networks = list(CAMERANET_NETWORK_AI_CORE)
 
 /obj/machinery/status_display/ai_core/Initialize(mapload)
 	. = ..()
@@ -36,6 +38,7 @@
 	connected_ai = null
 	custom_emotion = null
 	custom_portrait_icon = null
+	remove_internal_camera()
 	return ..()
 
 /obj/machinery/status_display/ai_core/examine(mob/user)
@@ -131,10 +134,15 @@
 		return
 	if(connected_ai)
 		UnregisterSignal(connected_ai, list(COMSIG_QDELETING, COMSIG_AI_ICON_CHANGE))
+		remove_internal_camera()
 	connected_ai = new_ai
+	if(!connected_ai)
+		return
 	RegisterSignal(connected_ai, COMSIG_QDELETING, PROC_REF(on_ai_deleting))
 	RegisterSignal(connected_ai, COMSIG_AI_ICON_CHANGE, PROC_REF(on_ai_screen_change))
 	INVOKE_ASYNC(connected_ai, TYPE_PROC_REF(/mob/living/silicon/ai, set_core_display_icon), null, connected_ai?.client)
+
+	LoadComponent(/datum/component/internal_cam, camera_networks, "[connected_ai.name] core display")
 
 ///Called when the first AI of the round is created, as we get automatically assigned to it.
 /obj/machinery/status_display/ai_core/proc/on_ai_creation(atom/source, mob/living/silicon/ai/new_ai)
@@ -162,3 +170,7 @@
 	else
 		custom_emotion = icon_used
 	update_appearance(UPDATE_ICON)
+
+/obj/machinery/status_display/ai_core/proc/remove_internal_camera()
+	var/datum/component/internal_cam/cam = GetComponent(/datum/component/internal_cam)
+	qdel(cam)

--- a/code/modules/mob/living/silicon/ai/decentralized/ai_core_display.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_core_display.dm
@@ -43,6 +43,7 @@
 
 /obj/machinery/status_display/ai_core/examine(mob/user)
 	. = ..()
+	. += span_info("The internal AI camera is [GetComponent(/datum/component/internal_cam) ? "active" : "disabled"].")
 	if(!isobserver(user) || isnull(connected_ai))
 		return .
 	connected_ai.examine(user)


### PR DESCRIPTION


## About The Pull Request
Adds the internal_camera component to AI core displays, allowing them to act as cameras. They are added to the "Aicore" network.

## Why It's Good For The Game
Big brother AI is watching.

## Testing
<img width="1280" height="890" alt="image" src="https://github.com/user-attachments/assets/c2dda53f-d1e1-4e58-8dfc-7d16bff9bbf4" />
<img width="830" height="715" alt="image" src="https://github.com/user-attachments/assets/dcf08ce0-41a5-419e-8b9a-a5783cdf73b7" />
<img width="805" height="692" alt="image" src="https://github.com/user-attachments/assets/b09106a8-3179-42ca-8804-cede42afa0d2" />

## Changelog

:cl:
add: ai core displays have an internal camera for AIs to use
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

