### PR TITLE
refactors borg low_power_mode

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -132,9 +132,6 @@
 /// from base of atom/eminence_act() : (mob/living/eminence/user)
 #define COMSIG_ATOM_EMINENCE_ACT "atom_eminence_act"
 
-///Called by either cell/proc/give or cell/proc/use
-#define COMSIG_CELL_CHANGE_POWER "cell_change_power"
-
 /// generic turf checker signal
 #define COMSIG_CHECK_TURF_GENERIC "check_turf_generic"
 

--- a/code/__DEFINES/dcs/signals/signals_power.dm
+++ b/code/__DEFINES/dcs/signals/signals_power.dm
@@ -1,0 +1,10 @@
+// Signals sent by power storage.
+
+/// From base of /item/stock_parts/power_store/use(): (power_used)
+#define COMSIG_CELL_POWER_USED "cell_power_used"
+
+/// From base of /item/stock_parts/power_store/proc/give(): (power_given)
+#define COMSIG_CELL_POWER_GIVEN "cell_power_given"
+
+/// From base of /item/stock_parts/power_store/proc/change(): (power_difference)
+#define COMSIG_CELL_POWER_CHANGED "cell_power_changed"

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -126,8 +126,7 @@
 		victim.heal_damage_type(max(0, 80 - victim.getBruteLoss()), BRUTE)
 	else
 		var/mob/living/silicon/robot/new_borg = victim.Robotize()
-		var/obj/item/stock_parts/power_store/cell/upgraded/plus/replacement_cell = new(new_borg, robot_cell_charge)
-		new_borg.set_cell(replacement_cell)
+		new_borg.set_cell(new /obj/item/stock_parts/power_store/cell/upgraded/plus(new_borg, robot_cell_charge))
 
 		// So he can't jump out the gate right away.
 		new_borg.SetLockdown()

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -126,7 +126,8 @@
 		victim.heal_damage_type(max(0, 80 - victim.getBruteLoss()), BRUTE)
 	else
 		var/mob/living/silicon/robot/new_borg = victim.Robotize()
-		new_borg.cell = new /obj/item/stock_parts/power_store/cell/upgraded/plus(new_borg, robot_cell_charge)
+		var/obj/item/stock_parts/power_store/cell/upgraded/plus/replacement_cell = new(new_borg, robot_cell_charge)
+		new_borg.set_cell(replacement_cell)
 
 		// So he can't jump out the gate right away.
 		new_borg.SetLockdown()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -670,7 +670,7 @@
 /obj/item/attack_robot(mob/living/silicon/robot/user)
 	if(loc != user.model)
 		return
-	if(user.low_power_mode) //can't equip modules with an empty cell.
+	if(user.low_power_mode) // Can't equip modules with an empty cell.
 		return
 	user.activate_module(src)
 

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -210,9 +210,7 @@
 /obj/item/melee/energy/sword/cyborg/attack(mob/target, mob/living/silicon/robot/user)
 	if(!user.cell)
 		return
-
-	var/obj/item/stock_parts/power_store/cell/our_cell = user.cell
-	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE) && !(our_cell.use(hitcost)))
+	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE) && !(user.cell.use(hitcost)))
 		attack_self(user)
 		to_chat(user, span_notice("It's out of charge!"))
 		return

--- a/code/game/objects/items/robot/items/food.dm
+++ b/code/game/objects/items/robot/items/food.dm
@@ -121,7 +121,7 @@
 	check_amount()
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/robot_user = user
-		if(!robot_user.cell?.use(12))
+		if(!robot_user.cell?.use(0.0012 * STANDARD_CELL_VALUE))
 			to_chat(user, span_warning("Not enough power."))
 			return ITEM_INTERACT_BLOCKING
 
@@ -140,7 +140,7 @@
 	check_amount()
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/robot_user = user
-		if(!robot_user.cell?.use(12))
+		if(!robot_user.cell?.use(0.0012 * STANDARD_CELL_VALUE))
 			to_chat(user, span_warning("Not enough power."))
 			return ITEM_INTERACT_BLOCKING
 

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -143,7 +143,7 @@
 						span_warning("You bop [attacked_mob] on the head!"))
 			playsound(loc, 'sound/weapons/tap.ogg', 50, TRUE, -1)
 		if(HUG_MODE_SHOCK)
-			if (!COOLDOWN_FINISHED(src, shock_cooldown))
+			if(!COOLDOWN_FINISHED(src, shock_cooldown))
 				return
 			if(ishuman(attacked_mob))
 				attacked_mob.electrocute_act(5, "[user]", flags = SHOCK_NOGLOVES)
@@ -157,11 +157,11 @@
 				else
 					user.visible_message(span_userdanger("[user] shocks [attacked_mob]. It does not seem to have an effect"), \
 						span_danger("You shock [attacked_mob] to no effect."))
+			user.cell?.use(0.05 * STANDARD_CELL_VALUE)
 			playsound(loc, 'sound/effects/sparks2.ogg', 50, TRUE, -1)
-			user.cell.charge -= 500
 			COOLDOWN_START(src, shock_cooldown, HUG_SHOCK_COOLDOWN)
 		if(HUG_MODE_CRUSH)
-			if (!COOLDOWN_FINISHED(src, crush_cooldown))
+			if(!COOLDOWN_FINISHED(src, crush_cooldown))
 				return
 			if(ishuman(attacked_mob))
 				user.visible_message(span_userdanger("[user] crushes [attacked_mob] in [user.p_their()] grip!"), \
@@ -171,7 +171,7 @@
 						span_danger("You crush [attacked_mob]!"))
 			playsound(loc, 'sound/weapons/smash.ogg', 50, TRUE, -1)
 			attacked_mob.adjustBruteLoss(15)
-			user.cell.charge -= 300
+			user.cell?.use(0.03 * STANDARD_CELL_VALUE)
 			COOLDOWN_START(src, crush_cooldown, HUG_CRUSH_COOLDOWN)
 
 /obj/item/borg/cyborghug/peacekeeper
@@ -415,7 +415,7 @@
 		if(!robot_user.cell || robot_user.cell.charge < 1200)
 			to_chat(user, span_warning("You don't have enough charge to do this!"))
 			return
-		robot_user.cell.charge -= 1000
+		robot_user.cell.use(0.1 * STANDARD_CELL_VALUE)
 		if(robot_user.emagged)
 			safety = FALSE
 

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -110,8 +110,6 @@
 		removed_cell.update_appearance()
 		removed_cell.add_fingerprint(user)
 		user.put_in_hands(removed_cell)
-		touched_cyborg.update_icons()
-		touched_cyborg.diag_hud_set_borgcell()
 		return ITEM_INTERACT_SUCCESS
 	return NONE
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -340,7 +340,7 @@
 		brainmob.mind?.remove_antags_for_borging()
 		new_borg.job = JOB_CYBORG
 
-		new_borg.cell = chest.cell
+		new_borg.set_cell(chest.cell)
 		chest.cell.forceMove(new_borg)
 
 		tool.forceMove(new_borg)//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -111,7 +111,7 @@ ADMIN_VERB(borg_panel, R_ADMIN, FALSE, "Show Borg Panel", ADMIN_VERB_NO_DESCRIPT
 				if (borg.cell)
 					QDEL_NULL(borg.cell)
 				var/new_cell = new chosen(borg)
-				borg.cell = new_cell
+				borg.set_cell(new_cell)
 				borg.cell.charge = borg.cell.maxcharge
 				borg.diag_hud_set_borgcell()
 				message_admins("[key_name_admin(user)] changed the cell of [ADMIN_LOOKUPFLW(borg)] to [new_cell].")

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -54,7 +54,7 @@
 /// Helper for cyborgs unequipping things.
 /mob/living/silicon/robot/proc/deactivate_module(obj/item/item_module)
 	REMOVE_TRAIT(item_module, TRAIT_NODROP, CYBORG_ITEM_TRAIT)
-	transferItemToLoc(item_module, newloc = model)
+	return transferItemToLoc(item_module, newloc = model)
 
 /mob/living/silicon/robot/doUnEquip(obj/item/dropping_item, force, atom/newloc, no_move, invdrop, silent)
 	// If it is not a module, it is free to drop.
@@ -219,10 +219,11 @@
 
 // Technically none of the items are dropped, only unequipped
 /mob/living/silicon/robot/drop_all_held_items()
+	. = FALSE
 	for(var/cyborg_slot in 1 to length(held_items))
 		if(!held_items[cyborg_slot])
 			continue
-		deactivate_module(held_items[cyborg_slot])
+		. |= deactivate_module(held_items[cyborg_slot])
 
 /**
  * Checks if the item is currently in a slot.

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -17,7 +17,7 @@
 	if(!cell)
 		throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/nocell)
 		return
-	switch(cell.percent())
+	switch(ROUND_UP(cell.percent()))
 		if(75 to INFINITY)
 			clear_alert(ALERT_CHARGE)
 		if(50 to 75)
@@ -56,18 +56,17 @@
 /mob/living/silicon/robot/proc/handle_robot_cell(seconds_per_tick, times_fired)
 	if(stat == DEAD)
 		return
+	// It is unexpected (but possible) that cyborgs that change their low power status here.
+	// This is caused by someone directly setting the cyborg's cell or their cell's charge value. Since we can't stacktrace how it happened, we leave it be.
 	if(!cell?.charge)
 		if(!low_power_mode)
 			set_low_power_mode(TRUE)
-			// Cyborg somehow regained power.
-			// This is caused by someone directly setting the cyborg's cell or their cell's charge value. They shouldn't be doing that.
-			CRASH("Cyborg left low power mode unexpectedly!")
 		return
 	if(low_power_mode)
 		set_low_power_mode(FALSE)
-		CRASH("Cyborg entered low power mode unexpectedly!") // Ditto above, but for losing power.
+		return
 	if(stat == CONSCIOUS)
-		if(cell.charge <= 0.01 * STANDARD_CELL_CHARGE) // An obvious warning for busy cyborgs to go charge.
-			drop_all_held_items()
+		if(cell.charge <= 0.01 * STANDARD_CELL_CHARGE && drop_all_held_items()) // An obvious warning for busy cyborgs to go charge.
+			to_chat(src, span_warning("Automatic power conservation engaged! Deactivating active modules...")) // It doesn't really conserve power, but you get the gist.
 		var/energy_consumption = max(lamp_power_consumption * lamp_enabled * lamp_intensity * seconds_per_tick, BORG_MINIMUM_POWER_CONSUMPTION * seconds_per_tick) // Lamp will use a max of 5 * [BORG_LAMP_POWER_CONSUMPTION], depending on brightness of lamp. If lamp is off, borg systems consume [BORG_MINIMUM_POWER_CONSUMPTION], or the rest of the cell if it's lower than that.
 		cell.use(energy_consumption, TRUE)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -59,11 +59,13 @@
 	if(!cell?.charge)
 		if(!low_power_mode)
 			set_low_power_mode(TRUE)
-			CRASH("Cyborg left low power mode through unexpected means.") // Cyborg gained power somehow. This usually means that something directly set their cell/charge.
+			// Cyborg somehow regained power.
+			// This is caused by someone directly setting the cyborg's cell or their cell's charge value. They shouldn't be doing that.
+			CRASH("Cyborg left low power mode unexpectedly!")
 		return
 	if(low_power_mode)
 		set_low_power_mode(FALSE)
-		CRASH("Cyborg entered low power mode through unexpected means.") // Ditto above, but for lost power.
+		CRASH("Cyborg entered low power mode unexpectedly!") // Ditto above, but for losing power.
 	if(stat == CONSCIOUS)
 		if(cell.charge <= 0.01 * STANDARD_CELL_CHARGE) // An obvious warning for busy cyborgs to go charge.
 			drop_all_held_items()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -6,67 +6,66 @@
 	handle_robot_hud_updates()
 	handle_robot_cell(seconds_per_tick, times_fired)
 
-/mob/living/silicon/robot/proc/handle_robot_cell(seconds_per_tick, times_fired)
-	if(stat == DEAD)
-		return
-
-	if(low_power_mode)
-		if(cell?.charge)
-			low_power_mode = FALSE
-	else if(stat == CONSCIOUS)
-		use_energy(seconds_per_tick, times_fired)
-
-/mob/living/silicon/robot/proc/use_energy(seconds_per_tick, times_fired)
-	if(cell?.charge)
-		if(cell.charge <= 0.01 * STANDARD_CELL_CHARGE)
-			drop_all_held_items()
-		var/energy_consumption = max(lamp_power_consumption * lamp_enabled * lamp_intensity * seconds_per_tick, BORG_MINIMUM_POWER_CONSUMPTION * seconds_per_tick) //Lamp will use a max of 5 * [BORG_LAMP_POWER_CONSUMPTION], depending on brightness of lamp. If lamp is off, borg systems consume [BORG_MINIMUM_POWER_CONSUMPTION], or the rest of the cell if it's lower than that.
-		cell.use(energy_consumption, force = TRUE)
-	else
-		drop_all_held_items()
-		low_power_mode = TRUE
-		toggle_headlamp(TRUE)
-	diag_hud_set_borgcell()
-
+/// Handles all additional cyborg-specific hud updates.
 /mob/living/silicon/robot/proc/handle_robot_hud_updates()
 	if(!client)
 		return
-
 	update_cell_hud_icon()
 
-/mob/living/silicon/robot/update_health_hud()
-	if(!client || !hud_used)
-		return
-	if(hud_used.healths)
-		if(stat != DEAD)
-			if(health >= maxHealth)
-				hud_used.healths.icon_state = "health0"
-			else if(health > maxHealth*0.6)
-				hud_used.healths.icon_state = "health2"
-			else if(health > maxHealth*0.2)
-				hud_used.healths.icon_state = "health3"
-			else if(health > -maxHealth*0.2)
-				hud_used.healths.icon_state = "health4"
-			else if(health > -maxHealth*0.6)
-				hud_used.healths.icon_state = "health5"
-			else
-				hud_used.healths.icon_state = "health6"
-		else
-			hud_used.healths.icon_state = "health7"
-
+/// Deals with the alert associated with the cyborg's cell and its percentage of remaining power.
 /mob/living/silicon/robot/proc/update_cell_hud_icon()
-	if(cell)
-		var/cellcharge = cell.charge/cell.maxcharge
-		switch(cellcharge)
-			if(0.75 to INFINITY)
-				clear_alert(ALERT_CHARGE)
-			if(0.5 to 0.75)
-				throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell, 1)
-			if(0.25 to 0.5)
-				throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell, 2)
-			if(0.01 to 0.25)
-				throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell, 3)
-			else
-				throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/emptycell)
-	else
+	if(!cell)
 		throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/nocell)
+		return
+	switch(cell.percent())
+		if(75 to INFINITY)
+			clear_alert(ALERT_CHARGE)
+		if(50 to 75)
+			throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell, 1)
+		if(25 to 50)
+			throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell, 2)
+		if(1 to 25)
+			throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell, 3)
+		else
+			throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/emptycell)
+
+/mob/living/silicon/robot/update_health_hud()
+	if(!client || !hud_used?.healths)
+		return
+	if(stat != DEAD)
+		if(health >= maxHealth)
+			hud_used.healths.icon_state = "health0"
+			return
+		if(health > maxHealth * 0.6)
+			hud_used.healths.icon_state = "health2"
+			return
+		if(health > maxHealth * 0.2)
+			hud_used.healths.icon_state = "health3"
+			return
+		if(health > -maxHealth * 0.2)
+			hud_used.healths.icon_state = "health4"
+			return
+		if(health > -maxHealth * 0.6)
+			hud_used.healths.icon_state = "health5"
+			return
+		hud_used.healths.icon_state = "health6"
+		return
+	hud_used.healths.icon_state = "health7"
+
+/// Performs power upkeep for the cyborg.
+/mob/living/silicon/robot/proc/handle_robot_cell(seconds_per_tick, times_fired)
+	if(stat == DEAD)
+		return
+	if(!cell?.charge)
+		if(!low_power_mode)
+			set_low_power_mode(TRUE)
+			CRASH("Cyborg left low power mode through unexpected means.") // Cyborg gained power somehow. This usually means that something directly set their cell/charge.
+		return
+	if(low_power_mode)
+		set_low_power_mode(FALSE)
+		CRASH("Cyborg entered low power mode through unexpected means.") // Ditto above, but for lost power.
+	if(stat == CONSCIOUS)
+		if(cell.charge <= 0.01 * STANDARD_CELL_CHARGE) // An obvious warning for busy cyborgs to go charge.
+			drop_all_held_items()
+		var/energy_consumption = max(lamp_power_consumption * lamp_enabled * lamp_intensity * seconds_per_tick, BORG_MINIMUM_POWER_CONSUMPTION * seconds_per_tick) // Lamp will use a max of 5 * [BORG_LAMP_POWER_CONSUMPTION], depending on brightness of lamp. If lamp is off, borg systems consume [BORG_MINIMUM_POWER_CONSUMPTION], or the rest of the cell if it's lower than that.
+		cell.use(energy_consumption, TRUE)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -152,9 +152,6 @@
 	if(href_list["showalerts"])
 		alert_control.ui_interact(src)
 
-/mob/living/silicon/robot/get_cell()
-	return cell
-
 /mob/living/silicon/robot/proc/pick_model()
 	if(has_model())
 		return
@@ -941,6 +938,9 @@
 //
 // Power
 //
+
+/mob/living/silicon/robot/get_cell()
+	return cell
 
 /// Replaces the cyborg's current cell with a new cell. Will not automatically move the new cell.
 /mob/living/silicon/robot/proc/set_cell(obj/item/stock_parts/power_store/cell/new_cell)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -30,7 +30,8 @@
 
 	previous_health = health
 
-	set_cell(cell)
+	if(cell)
+		set_cell(cell)
 
 	create_modularInterface()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -30,8 +30,7 @@
 
 	previous_health = health
 
-	if(ispath(cell))
-		cell = new cell(src)
+	set_cell(cell)
 
 	create_modularInterface()
 
@@ -678,10 +677,7 @@
 			update_icons()
 
 	if(gone == cell)
-		cell = null
-		low_power_mode = TRUE
-		if(!QDELETED(src))
-			update_icons()
+		set_cell(null)
 
 	if(gone == mmi)
 		mmi = null
@@ -890,13 +886,6 @@
 		for(var/i in connected_ai.aicamera.stored)
 			aicamera.stored[i] = TRUE
 
-/mob/living/silicon/robot/proc/charge(datum/source, amount, repairs, sendmats)
-	SIGNAL_HANDLER
-	if(cell)
-		cell.charge = min(cell.charge + amount, cell.maxcharge)
-	if(repairs)
-		heal_bodypart_damage(repairs, repairs)
-
 /mob/living/silicon/robot/proc/set_connected_ai(new_ai)
 	if((connected_ai == new_ai) || centcom)
 		return
@@ -935,15 +924,6 @@
 
 	return GLOB.fire_appearances[fire_icon]
 
-/// Draw power from the robot
-/mob/living/silicon/robot/proc/draw_power(power_to_draw)
-	cell?.use(power_to_draw)
-
-
-/mob/living/silicon/robot/set_stat(new_stat)
-	. = ..()
-	//update_stat() // This is probably not needed, but hopefully should be a little sanity check for the spaghetti that borgs are built from
-
 /mob/living/silicon/robot/proc/on_dampen()
 	SIGNAL_HANDLER
 	eject_riders()
@@ -956,6 +936,95 @@
 		unbuckle_mob(buckled_mob) // In case the paralyze doesn't automatically unbuckle them.
 		buckled_mob.Paralyze(1 SECONDS)
 	do_sparks(5, 0, src)
+
+//
+// Power
+//
+
+/// Replaces the cyborg's current cell with a new cell. Will not automatically move the new cell.
+/mob/living/silicon/robot/proc/set_cell(obj/item/stock_parts/power_store/cell/new_cell)
+	if(cell)
+		UnregisterSignal(cell, list(COMSIG_QDELETING, COMSIG_CELL_POWER_USED, COMSIG_CELL_POWER_GIVEN, COMSIG_CELL_POWER_CHANGED))
+		cell = null
+	if(!new_cell)
+		if(!low_power_mode && !cell)
+			set_low_power_mode(TRUE)
+			return
+		update_icons()
+		return
+	cell = ispath(new_cell) ? new new_cell(src) : new_cell
+	RegisterSignal(cell, COMSIG_QDELETING, PROC_REF(on_cell_deleted))
+	RegisterSignal(cell, COMSIG_CELL_POWER_USED, PROC_REF(on_cell_power_used))
+	RegisterSignal(cell, COMSIG_CELL_POWER_GIVEN, PROC_REF(on_cell_power_given))
+	RegisterSignal(cell, COMSIG_CELL_POWER_CHANGED, PROC_REF(on_cell_power_changed))
+	if(low_power_mode && cell.charge())
+		set_low_power_mode(FALSE)
+		return
+	if(!low_power_mode && !cell.charge())
+		set_low_power_mode(TRUE)
+		return
+	update_icons()
+
+/// Charges the cyborg with power. Repairs are optional.
+/mob/living/silicon/robot/proc/charge(datum/source, amount, repairs)
+	SIGNAL_HANDLER
+	cell?.give(amount)
+	if(repairs)
+		heal_bodypart_damage(repairs, repairs)
+
+/// Uses a certain amount of power from the cyborg.
+/mob/living/silicon/robot/proc/draw_power(power_to_draw)
+	cell?.use(power_to_draw)
+
+/// Occurs when our current cell gets deleted.
+/mob/living/silicon/robot/proc/on_cell_deleted(datum/source)
+	SIGNAL_HANDLER
+	cell = null
+	if(!low_power_mode)
+		set_low_power_mode(TRUE)
+
+/// Occurs when our current cell's power is used.
+/mob/living/silicon/robot/proc/on_cell_power_used(datum/source, power_used)
+	SIGNAL_HANDLER
+	if(QDELETED(cell) || !power_used)
+		return
+	if(!low_power_mode && !cell.charge())
+		set_low_power_mode(TRUE)
+		return
+	diag_hud_set_borgcell()
+
+/// Occurs when our current cell's power is recharged.
+/mob/living/silicon/robot/proc/on_cell_power_given(datum/source, power_gained)
+	SIGNAL_HANDLER
+	if(QDELETED(cell) || !power_gained)
+		return
+	if(low_power_mode && cell.charge())
+		set_low_power_mode(FALSE)
+		return
+	diag_hud_set_borgcell()
+
+/// Occurs when our current cell's power is directly set to a value.
+/mob/living/silicon/robot/proc/on_cell_power_changed(datum/source, power_difference)
+	SIGNAL_HANDLER
+	if(power_difference >= 0)
+		on_cell_power_given(source, power_difference)
+		return
+	on_cell_power_used(source, -power_difference)
+
+/// Sets the cyborg's low power mode status.
+/mob/living/silicon/robot/proc/set_low_power_mode(new_mode)
+	if(low_power_mode == new_mode)
+		return
+	low_power_mode = new_mode
+	if(low_power_mode)
+		drop_all_held_items()
+		toggle_headlamp(TRUE)
+	update_icons()
+	diag_hud_set_borgcell()
+
+//
+// Models & Skins
+//
 
 /// Resets the model to default.
 /mob/living/silicon/robot/proc/reset_model()

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -30,12 +30,8 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		else
 			if(!user.transferItemToLoc(attacking_item, src))
 				return
-			cell = attacking_item
-			if(cell.charge)
-				low_power_mode = FALSE
-			to_chat(user, span_notice("You insert the power cell."))
-		update_icons()
-		diag_hud_set_borgcell()
+			set_cell(attacking_item)
+			to_chat(user, span_notice("You insert \the [attacking_item]."))
 		return
 
 	if(is_wire_tool(attacking_item))
@@ -215,11 +211,11 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	if(!wiresexposed && !issilicon(user))
 		if(!cell)
 			return
-		cell.update_appearance()
-		cell.add_fingerprint(user)
-		user.put_in_active_hand(cell)
-		to_chat(user, span_notice("You remove \the [cell]."))
-		diag_hud_set_borgcell()
+		var/obj/item/stock_parts/power_store/cell/removed_cell = cell
+		user.put_in_active_hand(removed_cell) // Cell becomes null here.
+		removed_cell.add_fingerprint(user)
+		removed_cell.update_appearance()
+		to_chat(user, span_notice("You remove \the [removed_cell]."))
 
 /mob/living/silicon/robot/attack_hulk(mob/living/carbon/human/user)
 	. = ..()

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -359,20 +359,19 @@
 	return FALSE
 
 /obj/item/modular_computer/pda/silicon/get_ntnet_status()
-	//No borg found
+	// No owner found.
 	if(!silicon_owner)
 		return FALSE
-	// no AIs/pAIs
+	// Non-cyborgs can continue as usual.
 	var/mob/living/silicon/robot/cyborg_check = silicon_owner
 	if(!istype(cyborg_check))
 		return ..()
-	//lockdown restricts borg networking
+	// Lockdown restricts cyborg networking.
 	if(cyborg_check.lockcharge)
 		return FALSE
-	//borg cell dying restricts borg networking
-	if(!cyborg_check.cell || cyborg_check.cell.charge == 0)
+	// Lack of power restricts cyborg networking.
+	if(cyborg_check.low_power_mode)
 		return FALSE
-
 	return ..()
 
 /**

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -34,41 +34,6 @@
 	UnregisterSignal(reagents, list(COMSIG_REAGENTS_NEW_REAGENT, COMSIG_REAGENTS_ADD_REAGENT, COMSIG_REAGENTS_DEL_REAGENT, COMSIG_REAGENTS_REM_REAGENT, COMSIG_QDELETING))
 	return NONE
 
-/obj/item/stock_parts/power_store/cell/update_overlays()
-	. = ..()
-	if(grown_battery)
-		. += mutable_appearance('icons/obj/power.dmi', "grown_wires")
-	if((charge < 0.01) || !charge_light_type)
-		return
-	. += mutable_appearance('icons/obj/power.dmi', "cell-[charge_light_type]-o[(percent() >= 99.5) ? 2 : 1]")
-
-/obj/item/stock_parts/power_store/cell/vv_edit_var(vname, vval)
-	if(vname == NAMEOF(src, charge))
-		charge = clamp(vval, 0, maxcharge)
-		return TRUE
-	if(vname == NAMEOF(src, maxcharge))
-		if(charge > vval)
-			charge = vval
-	if(vname == NAMEOF(src, corrupted) && vval && !corrupted)
-		corrupt(TRUE)
-		return TRUE
-	return ..()
-
-// use power from a cell
-/obj/item/stock_parts/power_store/cell/use(used, force)
-	SHOULD_CALL_PARENT(FALSE) // MONKE EDIT: For some reason there's a parent call, but im going to ignore it
-	var/power_used = min(used, charge)
-	if(rigged && power_used > 0)
-		explode()
-		return 0 // The cell decided to explode so we won't be able to use it.
-	if(!force && charge < used)
-		return 0
-	charge -= power_used
-	if(!istype(loc, /obj/machinery/power/apc))
-		SSblackbox.record_feedback("tally", "cell_used", 1, type)
-	SEND_SIGNAL(src, COMSIG_CELL_CHANGE_POWER) // MONKE EDIT: Signal being sent
-	return power_used
-
 /obj/item/stock_parts/power_store/cell/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is licking the electrodes of [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return FIRELOSS

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -162,28 +162,29 @@
 /// - force: If true, uses the remaining power from the cell if there isn't enough power to supply the demand.
 /// Returns: The power used from the cell in joules.
 /obj/item/stock_parts/power_store/use(used, force = FALSE)
-	SHOULD_CALL_PARENT(FALSE) // MONKE EDIT: Ignoring the parent call
-	var/power_used = min(used, charge)
-	if(rigged && power_used > 0)
+	SHOULD_CALL_PARENT(FALSE)
+	. = min(used, charge)
+	if(rigged && . > 0)
 		explode()
-		return 0 // The cell decided to explode so we won't be able to use it.
-	if(!force && charge < used)
-		return 0
-	charge -= power_used
-	if(!istype(loc, /obj/machinery/power/apc))
-		SSblackbox.record_feedback("tally", "cell_used", 1, type)
-	return power_used
+		. = 0 // The cell decided to explode so we won't be able to use it.
+	else if(!force && charge < used)
+		. = 0 // Nothing to use.
+	else
+		charge -= .
+		if(!istype(loc, /obj/machinery/power/apc))
+			SSblackbox.record_feedback("tally", "cell_used", 1, type)
+	SEND_SIGNAL(src, COMSIG_CELL_POWER_USED, .)
 
 /// Recharge the cell.
 /// Args:
 /// - amount: The amount of energy to give to the cell in joules.
 /// Returns: The power given to the cell in joules.
 /obj/item/stock_parts/power_store/proc/give(amount)
-	var/power_used = min(maxcharge-charge,amount)
+	var/power_used = min(maxcharge - charge, amount)
 	charge += power_used
 	if(rigged && amount > 0)
 		explode()
-	SEND_SIGNAL(src,COMSIG_CELL_CHANGE_POWER) // MONKE EDIT: Signal
+	SEND_SIGNAL(src, COMSIG_CELL_POWER_GIVEN, power_used)
 	return power_used
 
 /**
@@ -197,6 +198,7 @@
 	charge += energy_used
 	if(rigged && energy_used)
 		explode()
+	SEND_SIGNAL(src, COMSIG_CELL_POWER_CHANGED, energy_used)
 	return energy_used
 
 /obj/item/stock_parts/power_store/examine(mob/user)

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/unsorted.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/unsorted.dm
@@ -237,7 +237,7 @@
 	if(istype(maybegun,/obj/item/gun/energy))
 		var/obj/item/gun/energy/egun = maybegun
 		our_gun = egun
-		RegisterSignal(egun.cell,COMSIG_CELL_CHANGE_POWER, PROC_REF(update_hud_elements))
+		RegisterSignals(egun.cell, list(COMSIG_CELL_POWER_USED, COMSIG_CELL_POWER_GIVEN, COMSIG_CELL_POWER_CHANGED), PROC_REF(update_hud_elements))
 
 	update_hud_elements()
 
@@ -252,8 +252,7 @@
 
 	if(istype(maybegun,/obj/item/gun/energy))
 		var/obj/item/gun/energy/egun = maybegun
-		UnregisterSignal(egun.cell,COMSIG_CELL_CHANGE_POWER)
-
+		UnregisterSignal(egun.cell, list(COMSIG_CELL_POWER_USED, COMSIG_CELL_POWER_GIVEN, COMSIG_CELL_POWER_CHANGED))
 
 	our_gun = null
 	update_hud_elements()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -424,6 +424,7 @@
 #include "code\__DEFINES\dcs\signals\signals_operating_computer.dm"
 #include "code\__DEFINES\dcs\signals\signals_painting.dm"
 #include "code\__DEFINES\dcs\signals\signals_plane_master_group.dm"
+#include "code\__DEFINES\dcs\signals\signals_power.dm"
 #include "code\__DEFINES\dcs\signals\signals_proxmonitor.dm"
 #include "code\__DEFINES\dcs\signals\signals_radiation.dm"
 #include "code\__DEFINES\dcs\signals\signals_reagent.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Signals involving the power storage/cells have been moved to their own file and are unique for using, giving, and directly setting power.

Many, if not all, cyborg cell power usage now uses the cell's `use` proc and are now relative to `STANDARD_CELL_VALUE`.

Everything that directly sets or changes a cyborg's cell now uses the cyborg's `set_cell` proc.
Cyborg's low power mode is now immediately set upon the insertion/removal of a cyborg's cell and/or any change in their cell's charge.

Fixes an issue where removing a cyborg's cell by hand would put them into low power mode, but not take any of their equipped modules.

Removing a cyborg's cell by hand now tells you the removed cell's name.

Deletes `/obj/item/stock_parts/power_store/cell`'s `update_overlays`, `vv_edit_var`, and `use` because it was (now) all duplicate code.

Organizes, autodocs and updates some other procs to early return when possible (`robot_life.dm`) or corrects them to use the new signals or low_power_mode.

Cyborgs that automatically deactivate their modules as the result of very low power (below 100 charge) now get a chat message why it happened.

The no-power alert no longer happens when a cyborg has less than 1% of their cell charge left over. It now only happens at 0%.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier to deal with a cyborg's cell and their low power mode & stops inconsistency involving it. General cleanup and fixes.

## Testing
Inserting/removing cell and cyborg module getting deselected.
<img width="344" height="312" alt="image" src="https://github.com/user-attachments/assets/f44640bf-6e57-400e-ad2b-8f97c521aa1a" />

Entering and leaving low power mode.
<img width="160" height="95" alt="low_power_mode" src="https://github.com/user-attachments/assets/9861cca6-d59d-4819-9154-b1d37483e896" />

Feedback regarding deactivated modules when having very low power (below 100 charge):
<img width="484" height="114" alt="image" src="https://github.com/user-attachments/assets/7987d1aa-b95d-4b13-b471-958d1bf32229" />

## Changelog
:cl:
qol: Removing a cyborg's cell now tells you the removed cell's name.
qol: Cyborgs that have their modules deactivated as the result of low power are now told why.
fix: It is no longer possible to have negative power by using a cyborg's shock/crush hug.
fix: Cyborgs now correctly deselect all of their modules upon entering low power mode caused by their cell's removal.
fix: Cyborgs now only get their no-power alert when they're actually out of power.
code: Updates some old cyborg power usage to use power based on the standardized cell value.
refactor: Cyborg's low power mode has been refactored to be more consistent and immediate when it comes to a cyborg's power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
