### PR TITLE
Fixes AI mechs death and domination

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -337,7 +337,7 @@
 				unlucky_ai.investigate_log("has been gibbed by having their mech destroyed.", INVESTIGATE_DEATHS)
 				unlucky_ai.gib() //No wreck, no AI to recover
 			else
-				mob_exit(unlucky_ai, silent = TRUE, forced = TRUE) // so we dont ghost the AI
+				mob_exit(ai_occupant, silent = TRUE, forced = TRUE) // so we dont ghost the AI
 			continue
 		mob_exit(occupant, forced = TRUE)
 		if(!isbrain(occupant)) // who would win.. 1 brain vs 1 sleep proc..

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -334,8 +334,9 @@
 			var/turf/ai_location_turf = get_turf(ai_occupant.last_used_data_core || ai_occupant)
 			if(!LAZYLEN(GLOB.data_cores["[ai_location_turf.z]"])) // we probably shouldnt gib AIs with a core
 				unlucky_ai = occupant
-				unlucky_ai.investigate_log("has been gibbed by having their mech destroyed.", INVESTIGATE_DEATHS)
-				unlucky_ai.gib() //No wreck, no AI to recover
+				if(!wreckage)
+					unlucky_ai.investigate_log("has been gibbed by having their mech destroyed.", INVESTIGATE_DEATHS)
+					unlucky_ai.gib() //No wreck, no AI to recover
 			else
 				mob_exit(ai_occupant, silent = TRUE, forced = TRUE) // so we dont ghost the AI
 			continue

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -122,10 +122,14 @@
 		AI.eyeobj?.forceMove(newloc) //kick the eye out as well
 		if(forced)//This should only happen if there are multiple AIs in a round, and at least one is Malf.
 			newloc = null
+			AI.controlled_equipment = null
+			AI.remote_control = null
 			//We ignore Z-levels here because AIs can control mechs from other levels.
 			if(!AI.relocate(silent = TRUE, kill_otherwise = FALSE, ignore_z_levels = TRUE))
 				AI.investigate_log("has been gibbed by being forced out of their mech by another AI.", INVESTIGATE_DEATHS)
 				AI.gib()  //If one Malf decides to steal a mech from another AI (even other Malfs!), they are destroyed, as they have nowhere to go when replaced.
+			else
+				moved_already = TRUE
 			AI = null
 			mecha_flags &= ~SILICON_PILOT
 			return


### PR DESCRIPTION


## About The Pull Request
- AI control beacons will now properly eject a AI. Rather than fully deleting the ai.
- If AI mech dies and theres nothing to return to. You will be recoverable from the mecha wreckage
- Malfunctioning ai Mech domination now wont softlock the old ai inside of the mech

## Why It's Good For The Game

## Testing
AI mecha recovery
<img width="235" height="242" alt="Screenshot 2026-08-28 035820" src="https://github.com/user-attachments/assets/fad33e6e-c747-4bf2-b993-296d3d47698f" />
Domination/death testing
<img width="1409" height="568" alt="Screenshot 2026-08-28 034406" src="https://github.com/user-attachments/assets/989dc227-668e-4334-9c38-8cdab2b0063e" />
<img width="664" height="403" alt="Screenshot 2026-08-28 034133" src="https://github.com/user-attachments/assets/45006a72-f99c-489e-af9e-371a21328721" />

## Changelog

:cl:
fix: Dying in a mech as a AI will now properly handle you returning to your mecha.
fix: AI mech wreckages now are functional
fix: AI mech domination will no longer softlock a second ai view panel if they were booted from it. 
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

