### PR TITLE
AI's can now read their PDA notifications.

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -344,6 +344,12 @@
 /obj/item/modular_computer/pda/silicon/ai/get_ntnet_status()
 	return NTNET_ETHERNET_SIGNAL
 
+/obj/item/modular_computer/pda/silicon/ai/alert_call(datum/computer_file/program/origin, alerttext, sound = 'sound/machines/twobeep_high.ogg', vision_distance = DEFAULT_MESSAGE_RANGE) //doing a visible message results in AIs being unable to see their own notifications.
+	if(QDELETED(loc) || QDELETED(origin) || !origin.alert_able || origin.alert_silenced || !alerttext) //Yeah, we're checking alert_able. No, you don't get to make alerts that the user can't silence.
+		return FALSE
+	playsound(src, sound, 50, TRUE)
+	to_chat(silicon_owner, span_notice("<img class='icon' src='\ref[src]'> \The [src] displays a [origin.filedesc] notification: [html_encode(alerttext)]"))
+
 /obj/item/modular_computer/pda/silicon/Initialize(mapload)
 	. = ..()
 	vis_flags |= VIS_INHERIT_ID


### PR DESCRIPTION
## About The Pull Request
Updates the AI PDA with a copy pasted slightly edited alert to use to_chat instead of visible_message for its program notifications.

## Why It's Good For The Game
Bug fix, allows the AI to see when spess.tv goes live/the SM delaminates/they get pinged in chat client without having to listen for a ping with no chat feedback.

## Testing
<img width="264" height="72" alt="image" src="https://github.com/user-attachments/assets/c6d21b71-5cb8-44b2-bcc2-cf66413eeb72" />

## Changelog
:cl:
fix: AIs can now read program notifications from their PDA in the chat box.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
