### PR TITLE
Improves some random item descriptions (bandolier, large chemical canister and CMO hypospray)

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -822,7 +822,7 @@
 
 /obj/item/storage/belt/bandolier
 	name = "bandolier"
-	desc = "A bandolier for holding rifle and shotgun ammunition."
+	desc = "A bandolier for holding rifle, shotgun and .357 revolver ammunition."
 	icon_state = "bandolier"
 	inhand_icon_state = "bandolier"
 	worn_icon_state = "bandolier"

--- a/code/modules/reagents/reagent_containers/chemcanisters.dm
+++ b/code/modules/reagents/reagent_containers/chemcanisters.dm
@@ -124,7 +124,7 @@
 /obj/item/reagent_containers/chemcanister/large
 	name = "large chemical canister"
 	base_name = "large chemical canister"
-	desc = "A large chemical for holding a sizable amounts of reagents. It's too large to fit in standard hyposprays."
+	desc = "A large chemical for holding a sizable amounts of reagents."
 	icon_state = "canister_large"
 	base_icon_state = "canister_large"
 	unique_reskin = list(

--- a/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
+++ b/code/modules/reagents/reagent_containers/hyposprays/hyposprays.dm
@@ -375,7 +375,7 @@ GLOBAL_LIST_INIT(hypospray_mode_icons, list(
 /obj/item/hypospray/cmo
 	name = "advanced hypospray"
 	icon_state = "hypo_cmo"
-	desc = "An advanced hypospray that can use larger size vials, pierce thick clothing, and deliver more reagents per injection."
+	desc = "An advanced hypospray that can pierce thick clothing and inject reagents faster than a standard hypospray."
 	allowed_containers = list(/obj/item/reagent_containers/chemcanister, /obj/item/reagent_containers/cup/tube)
 	possible_transfer_amounts = list(1, 2, 3, 5, 10, 15, 20)
 	default_vial = /obj/item/reagent_containers/chemcanister/bluespace/omnizine


### PR DESCRIPTION


## About The Pull Request

Bandolier description now says that it can hold .357 revolver bullets
Large chem canisters don't say they can't be inserted in standard hyposprays anymore
CMO hypospray doesn't say it fits larger canisters anymore and tells you it's faster than a standard hypospray now 

## Why It's Good For The Game

clearer item descriptions, reflects what they do better

## Testing

it's just item descriptions, should be fine

## Changelog

:cl:
spellcheck: Bandolier description says it hold .357 bullets
spellcheck: Large chemical canisters don't say they can't fit in standard hyposprays anymore
spellcheck: CMO Hypospray doesn't say it fits larger canisters anymore, also says that it's faster than standard hyposprays
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

