### PR TITLE
allows uranium to be used as an item material once more

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -143,7 +143,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 		MAT_CATEGORY_SILO = TRUE,
 		MAT_CATEGORY_RIGID = TRUE,
 		MAT_CATEGORY_BASE_RECIPES = TRUE,
-		AT_CATEGORY_ITEM_MATERIAL = TRUE,
+		MAT_CATEGORY_ITEM_MATERIAL = TRUE,
 	)
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
 	value_per_unit = 100 / SHEET_MATERIAL_AMOUNT


### PR DESCRIPTION


## About The Pull Request
Fixes an typo from AT_CATEGORY_ITEM_MATERIAL -> MAT_CATEGORY_ITEM_MATERIAL which stopped it from being used for item materials.

## Why It's Good For The Game
Bugfix.

## Testing
None.

## Changelog
:cl:
fix: Uranium can now be used once more as an item material.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

