### PR TITLE
fixes Theseus server room's freezer

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -48872,6 +48872,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"oml" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/engine,
+/area/station/science/server)
 "omo" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -68347,9 +68351,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/engine,
 /area/station/science/server)
 "tPo" = (
@@ -106626,7 +106628,7 @@ oAh
 vdw
 xLC
 tPl
-jrK
+oml
 fqx
 gBx
 cOR


### PR DESCRIPTION


## About The Pull Request
Adds a pipe and rotates the freezer (from facing north to south) inside of Theseus's Research Division Server Room.

## Why It's Good For The Game
Bugfix. The freezer was facing north for some reason and there was no pipe south of it so it wouldn't connect even if it was facing south.

## Testing
As seen in StrongDMM:
<img width="218" height="280" alt="image" src="https://github.com/user-attachments/assets/fa92c512-1570-4685-b515-fce5d6d0eb7a" />

As seen in the game:
<img width="504" height="312" alt="image" src="https://github.com/user-attachments/assets/f3cecd57-8545-43fa-b2f9-49018dd16e7d" />

## Changelog

:cl:
fix: The freezer within Theseus's research server room now properly cools down the research server.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

