### PR TITLE
fixes Kilostation's fore hallway disposal loop

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -28192,12 +28192,11 @@
 /area/station/hallway/primary/central/fore)
 "iFm" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	name = "library sorting disposal pipe"
-	},
 /obj/effect/mapping_helpers/mail_sorting/service/library,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "iFv" = (
@@ -48508,7 +48507,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -48649,9 +48648,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -49240,10 +49236,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	name = "library sorting disposal pipe"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pqD" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -28192,7 +28192,6 @@
 /area/station/hallway/primary/central/fore)
 "iFm" = (
 /obj/structure/cable,
-/obj/effect/mapping_helpers/mail_sorting/service/library,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49241,6 +49240,7 @@
 	dir = 4;
 	name = "library sorting disposal pipe"
 	},
+/obj/effect/mapping_helpers/mail_sorting/service/library,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "pqD" = (


### PR DESCRIPTION


## About The Pull Request
Fixes two sections of disposal pipes on Kilostation so that it connects with the rest of the disposal loop rather than ending early in the hallway.

## Why It's Good For The Game
Bugfix.

## Testing
First pipe alignment as seen ingame:
<img width="393" height="425" alt="image" src="https://github.com/user-attachments/assets/48404988-6aaf-437c-9e4f-d27d94c30a50" />

Second pipe alignment as seen ingame:
<img width="282" height="244" alt="image" src="https://github.com/user-attachments/assets/94f550a5-95ee-4440-9c31-dda2f0c2c9c7" />

## Changelog
:cl:
fix: Kilostation's North Central Primary Hallway's disposal pipes are correctly connected and no longer ends early in the hallway.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

