### PR TITLE
[FIX] Matter eaters can no longer eat mobs & brains in machines.

### DIFF
--- a/code/datums/mutations/matter_eater.dm
+++ b/code/datums/mutations/matter_eater.dm
@@ -308,6 +308,11 @@
 		to_chat(hungry_boy, span_danger("You were interrupted before you could eat [src]!"))
 		return EAT_FAILED
 
+	for(var/atom/object as anything in contents)
+		if(isliving(object) || isbrain(object) || istype(object, /obj/item/mmi) || object.resistance_flags & INDESTRUCTIBLE)
+			to_chat(hungry_boy, span_danger("What was that..?"))
+			return EAT_VOMIT
+
 	hungry_boy.visible_message(span_danger("[hungry_boy] eats [src]."))
 	return EAT_SUCCESS
 
@@ -382,12 +387,35 @@
 
 	var/list/things_to_vomit = list()
 	for(var/atom/object as anything in contents)
-		if(isliving(object) || istype(object, /obj/item/organ/internal/brain) || istype(object, /obj/item/mmi) || object.resistance_flags & INDESTRUCTIBLE)
+		if(isliving(object) || isbrain(object) || istype(object, /obj/item/mmi) || object.resistance_flags & INDESTRUCTIBLE)
 			things_to_vomit += object
 
 	if(length(things_to_vomit))
 		return things_to_vomit
 
+	hungry_boy.visible_message(span_danger("[hungry_boy] consumes [src] whole!"))
+	return EAT_SUCCESS
+
+/obj/structure/filingcabinet/get_eaten(mob/living/carbon/human/hungry_boy, datum/action/cooldown/spell/pointed/consumption/ability)
+	hungry_boy.visible_message(span_danger("[hungry_boy] begins stuffing [src] into [hungry_boy.p_their()] gaping maw!"))
+	var/eat_time = 20 SECONDS
+	if(anchored)
+		eat_time *= 1.5
+
+	ability.start_biting_animation(src, eat_time)
+	if(!do_after(hungry_boy, eat_time, src))
+		to_chat(hungry_boy, span_danger("You were interrupted before you could eat [src]!"))
+		return EAT_FAILED
+
+	var/list/things_to_vomit = list()
+	for(var/atom/object as anything in contents)
+		if(ispickedupmob(object) || isbrain(object) || object.resistance_flags & INDESTRUCTIBLE) // Picked up small mobs & brains can fit
+			things_to_vomit += object
+
+	if(length(things_to_vomit))
+		return things_to_vomit
+
+	hungry_boy.visible_message(span_danger("[hungry_boy] consumes [src] whole!"))
 	return EAT_SUCCESS
 
 /obj/machinery/dna_vault/get_eaten(mob/living/carbon/human/hungry_boy, datum/action/cooldown/spell/pointed/consumption/ability)


### PR DESCRIPTION
… section, changed to isbrain() helper

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is for #12391 ; it now pukes machines (such as nanite chambers) if it has brains or living mobs... it also now checks for filing cabinets & uses helper procs
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it allows players not to be eaten which is positive
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing

https://github.com/user-attachments/assets/647b71f2-cc83-4d43-92fd-3a12e3a30086


https://github.com/user-attachments/assets/2ea28265-8cd6-4a1a-8f90-d470db8cbf10






<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: matter eaters can no longer eat machines with brains & mobs inside
fix: matter eaters can no longer eat filing cabinets with brains & mobs inside 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
