### PR TITLE
AIs create an announcement when they cryo.

### DIFF
--- a/monkestation/code/modules/cryopods/ai_cryo.dm
+++ b/monkestation/code/modules/cryopods/ai_cryo.dm
@@ -7,12 +7,9 @@
 		return
 	switch(alert("Would you like to enter cryo? This will ghost you. Remember to AHELP before cryoing out of important roles, even with no admins online.",,"Yes.","No."))
 		if("Yes.")
+			message_admins("[key_name_admin(src)] has entered cryogenic storage as an AI.")
 			src.ghostize(FALSE)
-			var/announce_rank = "Artificial Intelligence,"
-			if(GLOB.announcement_systems.len)
-				// Sends an announcement the AI has cryoed.
-				var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
-				announcer.announce("CRYOSTORAGE", src.real_name, announce_rank, list())
+			minor_announce("[src] has been uploaded to AI cryogenic storage.", "AI Cryogenic Oversight")
 			if(src.mind)
 				//Handle job slot/tater cleanup.
 				if(src.mind.assigned_role.title == JOB_AI)

--- a/monkestation/code/modules/cryopods/ai_cryo.dm
+++ b/monkestation/code/modules/cryopods/ai_cryo.dm
@@ -7,6 +7,8 @@
 		return
 	switch(alert("Would you like to enter cryo? This will ghost you. Remember to AHELP before cryoing out of important roles, even with no admins online.",,"Yes.","No."))
 		if("Yes.")
+			log_silicon("[key_name(src)] entered cryogenic storage.")
+			log_admin("[key_name(src)] entered AI cryogenic storage.")
 			message_admins("[key_name_admin(src)] has entered cryogenic storage as an AI.")
 			src.ghostize(FALSE)
 			minor_announce("[src] has been uploaded to AI cryogenic storage.", "AI Cryogenic Oversight")


### PR DESCRIPTION


## About The Pull Request
It was always supposed to be this way, but it pings CRYOSTORAGE on the AAS, which is not supported by it, not even by the cryogenic oversight console! that uses CRYO_LEAVE! Makes it easier to tell when an AI is leaving the round without having to tell the crew itself.

The announcement is louder than what it wouldve been if i updated the AAS to support the cryo announcements (thatd be a good idea because we can make stupid emp messages for it), but i think thats sufficient because the AI is a fair part within a round.

## Why It's Good For The Game
Bugfix, better feedback to the crew why their door machine has stopped working. 

## Testing
<img width="306" height="343" alt="image" src="https://github.com/user-attachments/assets/8d0d2aa6-a408-48ce-9da6-2c5ee2928136" />

## Changelog

:cl:
fix: AIs now create a message when they enter cryo (updated from requesting the AAS for an invalid message type to an announcement)
admin: AIs entering cryo storage now make an admin log.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

