### PR TITLE
[MISC] [ADMIN] Allows dead crew (NOT observers) to vote in the automatic shuttle vote. 

### DIFF
--- a/code/datums/votes/transfer_vote.dm
+++ b/code/datums/votes/transfer_vote.dm
@@ -54,7 +54,7 @@
 	. = TRUE
 	if(voter.client?.holder)
 		return TRUE
-	if(isobserver(voter) || voter.stat == DEAD || !(voter.ckey in GLOB.joined_player_list)) // only living crew gets to vote
+	if(!(voter.ckey in GLOB.joined_player_list)) // only non-observers get to vote
 		return FALSE
 
 /datum/vote/shuttle_call/tiebreaker(list/winners)


### PR DESCRIPTION


## About The Pull Request

Allows dead crew (that is, anyone whose ckey is marked as having joined the round whether through readying up or latejoining) to vote in the auto-call shuttle vote. 

Does NOT allow observers (or dead ghost roles) to vote. 

PR will require admin approval. 

## Why It's Good For The Game

I totally understand why observers are banned from voting in this; observers have no rights after all. 

However, it doesn't make any sense to me why dead crew can't vote. The number of dead crew in a round is a really important factor in whether or not it's time for the round to end (in fact, arguably THE most important factor), and it doesn't really make sense to me why being killed should disqualify you from participating in this decision. It really sucks to have a whole bunch of dead players sitting out and unable to play, and that should factor in to the auto-call decision.

## Testing

Dead crewmember is able to vote:
<img width="778" height="562" alt="Screenshot 2026-09-02 015826" src="https://github.com/user-attachments/assets/247b202f-f3c1-4aba-b640-67857679ee75" />

Random observer is not able to vote:
<img width="792" height="590" alt="Screenshot 2026-09-02 015841" src="https://github.com/user-attachments/assets/953e6f95-f2ea-4c0b-bd4b-0c868f97ef69" />

Dead ghost role is not able to vote:
<img width="719" height="549" alt="Screenshot 2026-09-02 021824" src="https://github.com/user-attachments/assets/8d03b0c4-acef-4ff7-bede-63ad2c323020" />

## Changelog

:cl:
admin: Allows dead crew (NOT observers or dead ghost roles) to vote in the automatic shuttle vote. 
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

