### PR TITLE
adds slap crafting for bags of holding

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -69,6 +69,15 @@
 	resistance_flags = FIRE_PROOF
 	item_flags = NO_MAT_REDEMPTION
 
+/obj/item/bag_of_holding_inert/attackby(obj/item/item, mob/living/user, params)
+	if(istype(item, /obj/item/assembly/signaler/anomaly/bluespace))
+		var/obj/item/storage/backpack/holding/doomsday_device = new /obj/item/storage/backpack/holding
+		qdel(item)
+		user.temporarilyRemoveItemFromInventory(src, force = TRUE)
+		user.put_in_hands(doomsday_device)
+		playsound(doomsday_device, 'sound/machines/click.ogg', 50, TRUE)
+		qdel(src)
+
 /obj/item/storage/backpack/holding
 	name = "bag of holding"
 	desc = "A backpack that opens into a localized pocket of bluespace."

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -69,13 +69,13 @@
 	resistance_flags = FIRE_PROOF
 	item_flags = NO_MAT_REDEMPTION
 
-/obj/item/bag_of_holding_inert/attackby(obj/item/item, mob/living/user, params)
-	if(istype(item, /obj/item/assembly/signaler/anomaly/bluespace))
-		if(!user.temporarilyRemoveItemFromInventory(item))
-			to_chat(user, span_warning("[item] is stuck to your hand!"))
+/obj/item/bag_of_holding_inert/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/assembly/signaler/anomaly/bluespace))
+		if(!user.temporarilyRemoveItemFromInventory(tool))
+			to_chat(user, span_warning("[tool] is stuck to your hand!"))
 			return
 		var/obj/item/storage/backpack/holding/doomsday_device = new(get_turf(src))
-		qdel(item)
+		qdel(tool)
 		user.put_in_hands(doomsday_device)
 		playsound(doomsday_device, 'sound/machines/click.ogg', 50, TRUE)
 		qdel(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -71,9 +71,12 @@
 
 /obj/item/bag_of_holding_inert/attackby(obj/item/item, mob/living/user, params)
 	if(istype(item, /obj/item/assembly/signaler/anomaly/bluespace))
+		if(!user.temporarilyRemoveItemFromInventory(item))
+			to_chat(user, span_warning("[item] is stuck to your hand!"))
+			return
+		user.temporarilyRemoveItemFromInventory(src, force = TRUE) // transmuting it into a functional one anyways
 		var/obj/item/storage/backpack/holding/doomsday_device = new /obj/item/storage/backpack/holding
 		qdel(item)
-		user.temporarilyRemoveItemFromInventory(src, force = TRUE)
 		user.put_in_hands(doomsday_device)
 		playsound(doomsday_device, 'sound/machines/click.ogg', 50, TRUE)
 		qdel(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -74,8 +74,7 @@
 		if(!user.temporarilyRemoveItemFromInventory(item))
 			to_chat(user, span_warning("[item] is stuck to your hand!"))
 			return
-		user.temporarilyRemoveItemFromInventory(src, force = TRUE) // transmuting it into a functional one anyways
-		var/obj/item/storage/backpack/holding/doomsday_device = new /obj/item/storage/backpack/holding
+		var/obj/item/storage/backpack/holding/doomsday_device = new(get_turf(src))
 		qdel(item)
 		user.put_in_hands(doomsday_device)
 		playsound(doomsday_device, 'sound/machines/click.ogg', 50, TRUE)


### PR DESCRIPTION


## About The Pull Request
closes #12536
theres been a few issues about this, and it is, frankly, a bit confusing because it doesnt follow the other anomaly items (anomaly MODs, armor, etc)

## Why It's Good For The Game
Better responsiveness to your actions, makes it so you dont have to look for a recipe that uses 2 items

## Testing
defused bluespace anomaly, inserted core into a inert boh, both items deleted and bag added to hand, paused server, spam clicked bag with core, still only made one.

## Changelog

:cl:
qol: Bags of Holding can be slap crafted now.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

