### PR TITLE
Haloperidol nerfs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1268,7 +1268,10 @@
 /datum/reagent/medicine/haloperidol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	for(var/datum/reagent/drug/R in affected_mob.reagents.reagent_list)
 		affected_mob.reagents.remove_reagent(R.type, 5 * REM * seconds_per_tick)
-	affected_mob.adjust_drowsiness(4 SECONDS * REM * seconds_per_tick)
+	affected_mob.adjust_drowsiness_up_to(4 SECONDS * REM * seconds_per_tick, 30 SECONDS)
+
+	if(affected_mob.stamina.current <= 0)
+		affected_mob.reagents.remove_reagent(type, 5 * REAGENTS_METABOLISM * REM * seconds_per_tick)
 
 	if(affected_mob.get_timed_status_effect_duration(/datum/status_effect/jitter) >= 6 SECONDS)
 		affected_mob.adjust_jitter(-6 SECONDS * REM * seconds_per_tick)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1270,7 +1270,7 @@
 		affected_mob.reagents.remove_reagent(R.type, 5 * REM * seconds_per_tick)
 	affected_mob.adjust_drowsiness_up_to(4 SECONDS * REM * seconds_per_tick, 30 SECONDS)
 
-	if(affected_mob.stamina.current <= 0)
+	if(HAS_TRAIT_FROM(affected_mob, TRAIT_INCAPACITATED, STAMINA))
 		affected_mob.reagents.remove_reagent(type, 5 * REAGENTS_METABOLISM * REM * seconds_per_tick)
 
 	if(affected_mob.get_timed_status_effect_duration(/datum/status_effect/jitter) >= 6 SECONDS)


### PR DESCRIPTION


## About The Pull Request

Makes haloperidol self-purge at 1u per tick once you're in stamina crit, also caps how long it can extend the drowsiness status effect it gives you to 30 seconds

## Why It's Good For The Game

Being GBJ'd in stamina crit and sleep infinitely by a medical borg because they got a hypospray upgrade isn't fun gameplay

## Testing

Hopped on local, injected copious amounts of haloperidol, wasn't stunned and asleep for an eternity :)

## Changelog

:cl:
balance: Haloperidol purges itself from your bloodstream (at 1u/tick) once you're in stamina crit.
balance: Haloperidol's applied drowsiness status effect caps out at 30 seconds.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

