### PR TITLE
false alarm no longer can trigger Experimental Cloner Corruption

### DIFF
--- a/code/modules/antagonists/evil_clone/evil_event.dm
+++ b/code/modules/antagonists/evil_clone/evil_event.dm
@@ -8,6 +8,9 @@
 	tags = list(TAG_COMBAT, TAG_OUTSIDER_ANTAG) // Clones will likely start a fight, but will usually not cause wanton destruction.
 	earliest_start = 35 MINUTES //This requires an experimental cloner to be made, so should wait until later to fire when there's better chance one has been set up.
 
+/datum/round_event/cloner_corruption
+	fakeable = FALSE
+
 /datum/round_event/cloner_corruption/start()
 	var/found = FALSE
 	var/objective = pick(subtypesof(/datum/objective/evil_clone))


### PR DESCRIPTION


## About The Pull Request
Closes https://github.com/Monkestation/Monkestation2.0/issues/12554

Experimental Cloner Corruption no longer can be faked.

## Why It's Good For The Game
It does not have any announcement even if it was real. There is no point in faking it.

## Testing
None.

## Changelog
:cl:
fix: Experimental Cloner Corruption is no longer a valid event for False Alarm.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

