### PR TITLE
Fixes portable chem mixers?

### DIFF
--- a/tgui/packages/tgui/interfaces/PortableChemMixer.jsx
+++ b/tgui/packages/tgui/interfaces/PortableChemMixer.jsx
@@ -54,7 +54,7 @@ export const PortableChemMixer = (props) => {
                 tooltip={`pH: ${chemical.pH}`}
                 onClick={() =>
                   act('dispense', {
-                    reagent: chemical.id,
+                    reagent: chemical.title,
                   })
                 }
               />


### PR DESCRIPTION


## About The Pull Request
Portable chemical mixers are currently broken because they cannot dispense the chemicals inserted. This is because it asks name2reagent for the ckey version of the reagent, when name2reagent just has the proper name of the reagent in its keys.
Updates the chem dispenser to request the title of the reagent to be dispensed instead of the ckey ID.
I have no idea the consequences of this, but it worked in testing.

## Why It's Good For The Game
Fixes a broken thing, bugfix good. Tech debt yet to be seen.

## Testing
Updated jsx file with tgui_dev, dispenser started working.

## Changelog

:cl:
fix: fixed the portable chem mixer not dispensing(?)
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

