### PR TITLE
Expanded Camera network is less awful

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -156,6 +156,9 @@
 	///Did we get the death prompt?
 	var/is_dying = FALSE
 
+	///How much ai's client view_range should be adjusted by with view_size.setTo(). 0 Is default view size.
+	var/view_range_boost = 0
+
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai, shunted)
 	. = ..()
 	if(!target_ai) //If there is no player/brain inside.

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/view_range.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/view_range.dm
@@ -11,7 +11,8 @@
 	if(!.)
 		return .
 	ai.view_range_boost = 3
-	ai.client?.view_size.setTo(ai.view_range_boost)
+	if(!ai.multicam)
+		ai.client?.view_size.setTo(ai.view_range_boost)
 
 /datum/ai_project/view_range/stop()
 	ai.view_range_boost = 0

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/view_range.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/view_range.dm
@@ -5,15 +5,15 @@
 	ram_required = 6
 	research_requirements = list(/datum/ai_project/camera_speed)
 	category = AI_PROJECT_CAMERAS
-	/// How many tiles the viewing range of the ai is increased by.
-	var/boost_to = 3
 
 /datum/ai_project/view_range/run_project(force_run = FALSE)
 	. = ..()
 	if(!.)
 		return .
-	ai.client?.view_size.setTo(boost_to)
+	ai.view_range_boost = 3
+	ai.client?.view_size.setTo(ai.view_range_boost)
 
 /datum/ai_project/view_range/stop()
+	ai.view_range_boost = 0
 	ai.client?.view_size.resetToDefault()
 	return ..()

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/view_range.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/view_range.dm
@@ -11,7 +11,7 @@
 	if(!.)
 		return .
 	ai.view_range_boost = 3
-	if(!ai.multicam)
+	if(!ai.multicam_on)
 		ai.client?.view_size.setTo(ai.view_range_boost)
 
 /datum/ai_project/view_range/stop()

--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -244,6 +244,7 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 		to_chat(src, span_warning("This function is not available at this time."))
 		return
 	multicam_on = TRUE
+	client.view_size.resetToDefault()
 	refresh_multicam()
 	to_chat(src, span_notice("Multiple-camera viewing mode activated."))
 
@@ -264,6 +265,8 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 			var/atom/movable/screen/movable/pic_in_pic/P = V
 			P.unshow_to(client)
 	reset_perspective()
+	if(view_range_boost > 0)
+		client?.view_size.setTo(view_range_boost)
 	to_chat(src, span_notice("Multiple-camera viewing mode deactivated."))
 
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -830,6 +830,8 @@
 		mainframe.laws.show_laws(mainframe) //Always remind the AI when switching
 	if(mainframe.eyeobj)
 		mainframe.eyeobj.setLoc(loc)
+	if(mainframe.view_range_boost > 0)
+		mainframe.client?.view_size.setTo(mainframe.view_range_boost) // Update the viewrange if its greater than 0
 	mainframe = null
 
 /mob/living/silicon/robot/attack_ai(mob/user)

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -84,6 +84,10 @@
 	remove_occupant(M)
 	if(!isAI(M))//This is the ONE mob we dont want to be moved to the vehicle that should be handeled when used
 		M.forceMove(exit_location(M))
+	else
+		var/mob/living/silicon/ai/AiPilot = M
+		if(AiPilot.view_range_boost > 0)
+			AiPilot.client?.view_size.setTo(AiPilot.view_range_boost)
 	if(randomstep)
 		var/turf/target_turf = get_step(exit_location(M), pick(GLOB.cardinals))
 		M.throw_at(target_turf, 5, 10)


### PR DESCRIPTION


## About The Pull Request
Fixes issue with expanded camera network not persisting your view range and edge cases

## Why It's Good For The Game
Simple QOL/Fix.
Turns out simple program isnt so simple since ai aint simple
The program would continue running but not adjust since controlling a cyborg or exiting a mech would create a new client or reset your view range so womp womp. 
And then multicam you could see off the dedicated area for it. So. Great. Joy.
## Testing
Works as intended, alongside removing resources while ai is in it's shell will give a normal view range. (Aka the program is shut off)

## Changelog

:cl:
fix: Expanded view range now persist when controlling ai shells and mechs
fix: Expanded view range no longer shows more of the multicamera area
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

