### PR TITLE
adds nitrogen canisters and metal foam grenades to the DIY supermatter setup tutorial

### DIFF
--- a/_maps/virtual_domains/tutorial/engine_sm_hard.dmm
+++ b/_maps/virtual_domains/tutorial/engine_sm_hard.dmm
@@ -832,6 +832,14 @@
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron,
 /area/virtual_domain/powered_lighting)
+"Em" = (
+/obj/structure/closet/crate/engineering{
+	name = "Coolant Crate"
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
+/area/virtual_domain/powered_lighting)
 "EC" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -926,7 +934,7 @@
 /obj/item/stack/sheet/glass/fifty{
 	pixel_x = -6
 	},
-/obj/item/grenade/chem_grenade/smart_metal_foam{
+/obj/item/grenade/chem_grenade/smart_metalfoam{
 	pixel_x = 1;
 	pixel_y = -7
 	},
@@ -2460,7 +2468,7 @@ yD
 yh
 yD
 yD
-yD
+Em
 yh
 yh
 yD


### PR DESCRIPTION


## About The Pull Request

adds a crate with two nitrogen canisters next to the rest of the supermatter equipment, and smart metal foam grenades in the main area


## Why It's Good For The Game

gives the engineer a gas to use for cooling the engine down

the smart metal foam grenades were originally meant to be included in the map, but its path got changed in a different pr (so i just fixed the reference to it)


## Testing

deployed and entered the domain, both the grenades and the crate of nitrogen are there
<img width="762" height="1043" alt="nitrogen" src="https://github.com/user-attachments/assets/d3b0a4c0-a4c6-40dd-9f37-8f25ed98f45f" />
<img width="951" height="763" alt="metalfoamgrenades" src="https://github.com/user-attachments/assets/77306f22-a31b-4179-9a6d-06305776ca40" />


## Changelog

:cl:
add: adds nitrogen canisters and metal foam grenades to the DIY supermatter setup tutorial
/:cl:


## Pre-Merge Checklist


- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


