### PR TITLE
Removes energy holsters, makes normal holsters have 2 item slots and capable of holding any normal sized gun

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_INIT(detective_vest_allowed, list(
 	/obj/item/tank/internals/plasmaman,
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
-	/obj/item/storage/belt/holster/energy,
+	/obj/item/storage/belt/holster,
 ))
 
 GLOBAL_LIST_INIT(security_vest_allowed, list(
@@ -280,7 +280,7 @@ GLOBAL_LIST_INIT(security_vest_allowed, list(
 	/obj/item/tank/internals/plasmaman,
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
-	/obj/item/storage/belt/holster/energy,
+	/obj/item/storage/belt/holster,
 	/obj/item/clothing/mask/breath/sec_bandana
 ))
 
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(security_wintercoat_allowed, list(
 	/obj/item/restraints/handcuffs,
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
-	/obj/item/storage/belt/holster/energy,
+	/obj/item/storage/belt/holster,
 ))
 
 //Allowed list for all mining suits

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -1,7 +1,7 @@
 
 /obj/item/storage/belt/holster
 	name = "shoulder holster"
-	desc = "A rather plain but still cool looking holster that can hold a handgun."
+	desc = "A rather plain but still cool looking pair of holsters that can hold 2 handguns."
 	icon_state = "holster"
 	inhand_icon_state = "holster"
 	worn_icon_state = "holster"
@@ -19,64 +19,37 @@
 
 /obj/item/storage/belt/holster/Initialize(mapload)
 	. = ..()
-	atom_storage.max_slots = 1
-	atom_storage.max_total_storage = 16
-	atom_storage.set_holdable(list(
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/gun/energy/e_gun/mini,
-		/obj/item/gun/energy/disabler,
-		/obj/item/gun/energy/taser,
-		/obj/item/gun/energy/dueling,
-		/obj/item/food/grown/banana,
-		/obj/item/gun/energy/laser/thermal,
-		/obj/item/gun/ballistic/rifle/boltaction, //fits if you make it an obrez
-		/obj/item/gun/energy/laser/captain,
-		/obj/item/gun/energy/e_gun/hos,
-	))
 
-/obj/item/storage/belt/holster/energy
-	name = "energy shoulder holsters"
-	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Designed to hold energy weaponry."
-
-/obj/item/storage/belt/holster/energy/Initialize(mapload)
-	. = ..()
 	atom_storage.max_slots = 2
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 16
 	atom_storage.set_holdable(list(
-		/obj/item/gun/energy/e_gun/mini,
-		/obj/item/gun/energy/disabler,
-		/obj/item/gun/energy/taser,
-		/obj/item/gun/energy/dueling,
+		/obj/item/gun,
 		/obj/item/food/grown/banana,
-		/obj/item/gun/energy/laser/thermal,
-		/obj/item/gun/energy/recharge/ebow,
-		/obj/item/gun/energy/laser/captain,
-		/obj/item/gun/energy/e_gun/hos,
 	))
 
-/obj/item/storage/belt/holster/energy/thermal
+/obj/item/storage/belt/holster/thermal
 	name = "thermal shoulder holsters"
 	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Meant to hold a twinned pair of thermal pistols, but can fit several kinds of energy handguns as well."
 
-/obj/item/storage/belt/holster/energy/thermal/PopulateContents()
+/obj/item/storage/belt/holster/thermal/PopulateContents()
 	generate_items_inside(list(
 		/obj/item/gun/energy/laser/thermal/inferno = 1,
 		/obj/item/gun/energy/laser/thermal/cryo = 1,
 	),src)
 
-/obj/item/storage/belt/holster/energy/disabler
-	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Designed to hold energy weaponry. A production stamp indicates that it was shipped with a disabler."
+/obj/item/storage/belt/holster/disabler
+	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. A production stamp indicates that it was shipped with a disabler."
 
-/obj/item/storage/belt/holster/energy/disabler/PopulateContents()
+/obj/item/storage/belt/holster/disabler/PopulateContents()
 	generate_items_inside(list(
 		/obj/item/gun/energy/disabler = 1,
 	),src)
 
-/obj/item/storage/belt/holster/energy/smoothbore
-	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Designed to hold energy weaponry. Seems it was meant to fit two smoothbores."
+/obj/item/storage/belt/holster/smoothbore
+	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Seems it was meant to fit two smoothbores."
 
-/obj/item/storage/belt/holster/energy/smoothbore/PopulateContents()
+/obj/item/storage/belt/holster/smoothbore/PopulateContents()
 	generate_items_inside(list(
 		/obj/item/gun/energy/disabler/smoothbore = 2,
 	),src)
@@ -91,7 +64,7 @@
 	atom_storage.max_slots = 3
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.set_holdable(list(
-		/obj/item/gun/ballistic/automatic/pistol,
+		/obj/item/gun,
 		/obj/item/ammo_box/magazine/m9mm, // Pistol magazines.
 		/obj/item/ammo_box/magazine/m9mm_aps,
 		/obj/item/ammo_box/magazine/r10mm,
@@ -102,20 +75,9 @@
 		/obj/item/ammo_box/magazine/c35sol_pistol,
 		/obj/item/ammo_box/magazine/c585trappiste_pistol,
 		/obj/item/ammo_box/magazine/whispering_jester_45_magazine,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/gun/ballistic/modular/mk_58,
 		/obj/item/ammo_box/c38, // Revolver speedloaders.
 		/obj/item/ammo_box/a357,
 		/obj/item/ammo_box/a762,
-		/obj/item/ammo_box/magazine/toy/pistol,
-		/obj/item/gun/energy/e_gun/mini,
-		/obj/item/gun/energy/disabler,
-		/obj/item/gun/energy/taser,
-		/obj/item/gun/energy/dueling,
-		/obj/item/gun/energy/laser/thermal,
-		/obj/item/gun/energy/laser/captain,
-		/obj/item/gun/energy/e_gun/hos,
-		/obj/item/gun/ballistic/rifle/boltaction, //fits if you make it an obrez
 		))
 
 /obj/item/storage/belt/holster/detective/full/PopulateContents()

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -84,7 +84,7 @@
 	desc = "Contains one disabler, the nonlethal workhorse of Nanotrasen security everywehere. Comes in a energy holster, just in case you happen to have an extra disabler."
 	cost = PAYCHECK_COMMAND * 3
 	access_view = ACCESS_WEAPONS
-	contains = list(/obj/item/storage/belt/holster/energy/disabler)
+	contains = list(/obj/item/storage/belt/holster/disabler)
 
 /datum/supply_pack/goody/energy_single
 	name = "Energy Gun Single-Pack"
@@ -112,7 +112,7 @@
 	desc = "Contains twinned thermal pistols in a holster, ready for use in the field."
 	cost = PAYCHECK_COMMAND * 15
 	access_view = ACCESS_WEAPONS
-	contains = list(/obj/item/storage/belt/holster/energy/thermal)
+	contains = list(/obj/item/storage/belt/holster/thermal)
 
 /datum/supply_pack/goody/sologamermitts
 	name = "Insulated Gloves Single-Pack"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -404,7 +404,7 @@
 	desc = "Contains a pair of holsters each with two experimental thermal pistols, \
 		using nanites as the basis for their ammo."
 	cost = CARGO_CRATE_VALUE * 7
-	contains = list(/obj/item/storage/belt/holster/energy/thermal = 2)
+	contains = list(/obj/item/storage/belt/holster/thermal = 2)
 	crate_name = "thermal pistol crate"
 
 /datum/supply_pack/security/armory/ballisticmeleeweapons

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -1060,12 +1060,14 @@
 	icon_state = "syndicate_holster"
 	inhand_icon_state = "syndicate_holster"
 	worn_icon_state = "syndicate_holster"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BELT // Missing textures for a lot of things when worn in the suit storage slot
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
 /obj/item/storage/belt/holster/chameleon/Initialize(mapload)
 	. = ..()
+
+	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY
 
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/storage/belt

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -1060,7 +1060,6 @@
 	icon_state = "syndicate_holster"
 	inhand_icon_state = "syndicate_holster"
 	worn_icon_state = "syndicate_holster"
-	slot_flags = ITEM_SLOT_BELT // Missing textures for a lot of things when worn in the suit storage slot
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
 /obj/item/storage/belt/holster/chameleon/Initialize(mapload)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -1060,14 +1060,11 @@
 	icon_state = "syndicate_holster"
 	inhand_icon_state = "syndicate_holster"
 	worn_icon_state = "syndicate_holster"
-	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BELT // Missing textures for a lot of things when worn in the suit storage slot
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
 /obj/item/storage/belt/holster/chameleon/Initialize(mapload)
 	. = ..()
-
-	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY
 
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/storage/belt

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -539,7 +539,7 @@
 	name = "Militia Man"
 
 	id = /obj/item/card/id/advanced/centcom/ert/militia
-	belt = /obj/item/storage/belt/holster/energy/smoothbore
+	belt = /obj/item/storage/belt/holster/smoothbore
 	suit = /obj/item/clothing/suit/armor/militia
 	suit_store = /obj/item/gun/energy/laser/musket
 	head = /obj/item/clothing/head/cowboy/black

--- a/code/modules/clothing/spacesuits/hardsuits/combat.dm
+++ b/code/modules/clothing/spacesuits/hardsuits/combat.dm
@@ -22,7 +22,7 @@
 		/obj/item/restraints/handcuffs,
 		/obj/item/storage/belt/holster/detective,
 		/obj/item/storage/belt/holster/nukie,
-		/obj/item/storage/belt/holster/energy,
+		/obj/item/storage/belt/holster,
 		/obj/item/clothing/mask/breath/sec_bandana,
 	)
 

--- a/code/modules/clothing/spacesuits/hardsuits/heavy.dm
+++ b/code/modules/clothing/spacesuits/hardsuits/heavy.dm
@@ -70,7 +70,7 @@
 		/obj/item/gun,
 		/obj/item/storage/belt/holster/detective,
 		/obj/item/storage/belt/holster/nukie,
-		/obj/item/storage/belt/holster/energy,
+		/obj/item/storage/belt/holster,
 	)
 	armor_type = /datum/armor/hardsuit/juggernaut
 	hardsuit_helmet = /obj/item/clothing/head/helmet/space/hardsuit/juggernaut

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -65,9 +65,7 @@ GLOBAL_LIST_INIT(syndicate_space_suits_to_helmets,list(
 		/obj/item/gun,
 		/obj/item/tank/jetpack/oxygen,
 		/obj/item/tank/jetpack/harness,
-		/obj/item/storage/belt/holster/detective,
-		/obj/item/storage/belt/holster/nukie,
-		/obj/item/storage/belt/holster/energy,
+		/obj/item/storage/belt/holster,
 	) //monkestation edit: updated list
 	armor_type = /datum/armor/space_syndicate
 	cell = /obj/item/stock_parts/power_store/cell/hyper

--- a/code/modules/mining/voucher_sets.dm
+++ b/code/modules/mining/voucher_sets.dm
@@ -196,7 +196,7 @@
 	icon = 'icons/obj/weapons/guns/energy.dmi'
 	icon_state = "disabler"
 	set_items = list(
-		/obj/item/storage/belt/holster/energy/disabler,
+		/obj/item/storage/belt/holster/disabler,
 		/obj/item/gun/energy/disabler,
 		)
 

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -38,7 +38,7 @@
 		/obj/item/clothing/gloves/tackler = 5,
 		/obj/item/grenade/stingbang = 5,
 		/obj/item/watertank/pepperspray = 2,
-		/obj/item/storage/belt/holster/energy = 4,
+		/obj/item/storage/belt/holster = 4,
 		/obj/item/holosign_creator/security = 2,
 		/obj/item/modular_computer/laptop/preset/security = 3,
 		/obj/item/storage/box/pinpointer_pairs = 2,

--- a/monkestation/code/modules/ERT/equipment/ERT_spacesuits.dm
+++ b/monkestation/code/modules/ERT/equipment/ERT_spacesuits.dm
@@ -39,7 +39,7 @@
 		/obj/item/restraints/handcuffs,
 		/obj/item/storage/belt/holster/detective,
 		/obj/item/storage/belt/holster/nukie,
-		/obj/item/storage/belt/holster/energy,
+		/obj/item/storage/belt/holster,
 	)
 
 /obj/item/clothing/suit/space/ert/equipped(mob/user, slot)

--- a/monkestation/code/modules/blueshift/armaments/microstar.dm
+++ b/monkestation/code/modules/blueshift/armaments/microstar.dm
@@ -17,7 +17,7 @@
 	cost = PAYCHECK_CREW * 5
 /*
 /datum/armament_entry/company_import/microstar/lethal_sidearm/energy_holster
-	item_type = /obj/item/storage/belt/holster/energy/thermal
+	item_type = /obj/item/storage/belt/holster/thermal
 	cost = PAYCHECK_COMMAND * 6
 
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons


### PR DESCRIPTION


## About The Pull Request

also replaces things that used energy holsters with normal holsters (the disabler holster from the sec equipment voucher, thermal pistols holsters)

they also still hold bananas so soul preserved

## Why It's Good For The Game

Making energy holsters a separate item is kind of odd and doesn't really make much sense, also having 2 pacos in your suit storage isn't that consequential when they can fit in your bag and you're sacrificing carrying a heavier weapon like a WT or shotgun in that slot

## Testing

spawned in, spawned shoulder holsters, 2 slots, put a bunch of normal sized guns in it

## Changelog

:cl:

del: Removed energy holsters
balance: Normal shoulder holsters can fit any normal sized gun and have 2 item slots

/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

