### PR TITLE
Removes auto shotgun magazine cases from the nukie uplink

### DIFF
--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -88,39 +88,46 @@
 	desc = "A case with 2 auto shotgun magazines loaded with buckshot shells. A lethal high damage spread of pellets."
 	cost = 3
 	item = /obj/item/storage/toolbox/guncase/traitor/autoshotgun/ammunition
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/ammo/autoshotgun_slugs_case
 	name = "Syndicate Auto Shotgun Slugs Magazine Case"
 	desc = "A case with 2 auto shotgun magazines loaded with slug shells. A lethal high damage accurate slug."
 	cost = 3
 	item = /obj/item/storage/toolbox/guncase/traitor/autoshotgun/ammunition/slug
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/ammo/autoshotgun_rubbershot_case
 	name = "Syndicate Auto Shotgun Rubbershot Magazine Case"
 	desc = "A case with 2 auto shotgun magazines loaded with rubber shells. A less-lethal high stamina damage spread of rubber pellets."
 	cost = 2
 	item = /obj/item/storage/toolbox/guncase/traitor/autoshotgun/ammunition/rubbershot
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/ammo/autoshotgun_beanbags_case
 	name = "Syndicate Auto Shotgun Beanbags Magazine Case"
 	desc = "A case with 2 auto shotgun magazines loaded with beanbag shells. A less-lethal high stamina damage accurate rubber slug."
 	cost = 2
 	item = /obj/item/storage/toolbox/guncase/traitor/autoshotgun/ammunition/beanbag
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/ammo/autoshotgun_trickshot_case
 	name = "Syndicate Auto Shotgun Trickshot Magazine Case"
 	desc = "A case with 2 auto shotgun magazines loaded with trickshot shells. Capable of bouncing up to five times, they are made for the most talented trickshooters around."
 	cost = 3
 	item = /obj/item/storage/toolbox/guncase/traitor/autoshotgun/ammunition/trickshot
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/ammo/autoshotgun_uraniumpen_case
 	name = "Syndicate Auto Shotgun Uranium Magazine Case"
 	desc = "A case with 2 auto shotgun magazines loaded with uranium penetrator shells. Capable to penetrating walls and objects, but not people. Works best with thermals!"
 	cost = 3
 	item = /obj/item/storage/toolbox/guncase/traitor/autoshotgun/ammunition/uraniumpen
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/ammo/beeshot
 	name = "Beeshot Auto Shotgun Magazine"
 	desc = "An auto shotgun magazine 12 beeshot shells. Creates very angry bees upon impact. Not as strong as buckshot."
 	cost = 3
 	item = /obj/item/ammo_box/magazine/autoshotgun/syndicate/beeshot
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)


### PR DESCRIPTION


## About The Pull Request

title

## Why It's Good For The Game

they can't buy autoshotguns, i forgot to exclude it

## Testing

no autoshotgun ammo on the nukie uplink

## Changelog

:cl:

fix: Removed autoshotgun ammo from the nukie uplink (they can't buy the gun for it)

/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

