### PR TITLE
Crafting Recipe for Tiny Fan

### DIFF
--- a/code/datums/components/crafting/atmospheric.dm
+++ b/code/datums/components/crafting/atmospheric.dm
@@ -382,3 +382,13 @@
 	crafted_pipe.pipe_color = ATMOS_COLOR_OMNI
 	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
+
+/datum/crafting_recipe/tiny_fan
+	name = "Tiny Fan"
+	tool_behaviors = list(TOOL_WRENCH) // wrench to make, wrench to dismantle
+	result = /obj/structure/fans/tiny
+	time = 4 SECONDS
+	reqs = list(
+		/obj/item/stack/sheet/iron = 5,
+		/obj/item/stock_parts/manipulator = 1,
+	)

--- a/code/game/objects/structures/fans.dm
+++ b/code/game/objects/structures/fans.dm
@@ -34,6 +34,14 @@
 	density = FALSE
 	icon_state = "fan_tiny"
 	buildstackamount = 2
+	
+/obj/structure/fans/examine(mob/user)
+    . += ..()
+    . += deconstruction_hints(user)
+
+
+/obj/structure/fans/proc/deconstruction_hints(mob/user)
+    return span_notice("It's <b>bolted</b> onto the floor.")
 
 /obj/structure/fans/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/fans.dm
+++ b/code/game/objects/structures/fans.dm
@@ -36,12 +36,12 @@
 	buildstackamount = 2
 	
 /obj/structure/fans/examine(mob/user)
-    . += ..()
-    . += deconstruction_hints(user)
+	. += ..()
+	. += deconstruction_hints(user)
 
 
 /obj/structure/fans/proc/deconstruction_hints(mob/user)
-    return span_notice("It's <b>bolted</b> onto the floor.")
+	return span_notice("It's <b>bolted</b> onto the floor.")
 
 /obj/structure/fans/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION


## About The Pull Request

Adds deconstruction hint to Tiny Fan (which is deconstructible via wrenching)
Adds the crafting recipe for Tiny Fan
Tab: Atmospherics
Cost:
     5x iron sheet 
     1x micro-manipulator
Craft time: 4 seconds
Tool requirement:
     Wrench

The Tiny Fan is placed at the feet of the crafter at the time of completion as a map object (not an item to click-and-place or drop-and-wrench)

Code taken from sample of @addust contribution to craterstation branch

Code sample from @LettuceGuardian for deconstruction hint examine text


## Why It's Good For The Game

Tiny Fans have historically been restricted to the map-editor and are only available wherever tiny fans are placed on the map at roundstart. They are a common subject of map and shuttle tweaks and provide quality of life as simple atmospherics barriers, but they are not readily accessible in-round for player-made structures.

Being able to craft Tiny Fans is intended to be a sidegrade alternative to the Atmos Holofan Projector tool:
     Crafting Tiny Fans cost materials, Holofan Projector only has initial fabrication cost
     Tiny Fans are limited by resource availability to craft (iron and stock parts), rather than the hard limit imposed by the Holofan
     Tiny Fans can be easily and quickly deconstructed with a wrench
     Tiny Fans do not depend on Holofan Projector to persist



## Testing

Compiled and Ran on private server, Spawn-Panel used to spawn items necessary for craft. 

- Crafting Menu displays recipe and requirements as expected
- Craft completes successfully, result is as expected

## Changelog

:cl:
qol: Tiny Fans now have a crafting recipe
qol: Tiny Fans examine text has a deconstruction hint
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

